### PR TITLE
WIP: Total order notificator

### DIFF
--- a/src/dataflow/operators/generic/mod.rs
+++ b/src/dataflow/operators/generic/mod.rs
@@ -11,7 +11,7 @@ mod notificator;
 mod operator_info;
 
 pub use self::handles::{InputHandle, FrontieredInputHandle, OutputHandle};
-pub use self::notificator::{Notificator, FrontierNotificator};
+pub use self::notificator::{Notificator, FrontierNotificator, TotalOrderFrontierNotificator};
 
 pub use self::unary::Unary;
 pub use self::binary::Binary;

--- a/src/dataflow/operators/generic/notificator.rs
+++ b/src/dataflow/operators/generic/notificator.rs
@@ -102,10 +102,10 @@ impl<'a, T: Timestamp, D, I: Notify<T, D>> Notificator<'a, T, D, I> {
     /// representing how many capabilities were requested for that specific timestamp.
     #[inline]
     pub fn for_each<F: FnMut(Capability<T>, Vec<D>, &mut Self)>(&mut self, mut logic: F) {
-        while let Some((cap, count)) = self.next() {
+        while let Some((cap, data)) = self.next() {
             self.logging.when_enabled(|l| l.log(::logging::TimelyEvent::GuardedProgress(
                     ::logging::GuardedProgressEvent { is_start: true })));
-            logic(cap, count, self);
+            logic(cap, data, self);
             self.logging.when_enabled(|l| l.log(::logging::TimelyEvent::GuardedProgress(
                     ::logging::GuardedProgressEvent { is_start: false })));
         }
@@ -141,7 +141,7 @@ impl<'a, T: Timestamp, I: Notify<T, ()>> Notificator<'a, T, (), I> {
 /// ```
     #[inline]
     pub fn notify_at(&mut self, cap: Capability<T>) {
-        self.inner.notify_at_frontiered(cap, Some(()), self.frontiers);
+        self.notify_at_data(cap, Some(()));
     }
 
 }

--- a/src/dataflow/operators/generic/notificator.rs
+++ b/src/dataflow/operators/generic/notificator.rs
@@ -526,20 +526,15 @@ impl<T: Timestamp, D> Notify<T, D> for FrontierNotificator<T, D> {
 ///         let (in2_handle, in2) = scope.new_input();
 ///         in1.binary_frontier(&in2, Pipeline, Pipeline, "example", |mut _default_cap, _info| {
 ///             let mut notificator = TotalOrderFrontierNotificator::new();
-///             let mut stash = HashMap::new();
 ///             move |input1, input2, output| {
 ///                 while let Some((time, data)) = input1.next() {
-///                     stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.drain(..));
-///                     notificator.notify_at(time.retain());
+///                     notificator.notify_at_data(time.retain(), data.drain(..));
 ///                 }
 ///                 while let Some((time, data)) = input2.next() {
-///                     stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.drain(..));
-///                     notificator.notify_at(time.retain());
+///                     notificator.notify_at_data(time.retain(), data.drain(..));
 ///                 }
-///                 notificator.for_each(&[input1.frontier(), input2.frontier()], |time, _| {
-///                     if let Some(mut vec) = stash.remove(time.time()) {
-///                         output.session(&time).give_iterator(vec.drain(..));
-///                     }
+///                 notificator.for_each_data(&[input1.frontier(), input2.frontier()], |time, mut vec, _| {
+///                     output.session(&time).give_iterator(vec.drain(..));
 ///                 });
 ///             }
 ///         }).inspect_batch(|t, x| println!("{:?} -> {:?}", t, x));

--- a/src/dataflow/operators/mod.rs
+++ b/src/dataflow/operators/mod.rs
@@ -27,7 +27,7 @@ pub use self::capture::Capture;
 pub use self::branch::{Branch, BranchWhen};
 
 pub use self::generic::{Unary, Binary, Operator};
-pub use self::generic::{Notificator, FrontierNotificator};
+pub use self::generic::{Notificator, FrontierNotificator, TotalOrderFrontierNotificator};
 
 pub use self::reclock::Reclock;
 pub use self::count::Accumulate;


### PR DESCRIPTION
This PR adds a specialized notificator for totally-ordered time domains. It also changes the notificator implementations to carry data associated with notifications if required.