### PR TITLE
Progress hack

### DIFF
--- a/examples/realtime.rs
+++ b/examples/realtime.rs
@@ -1,7 +1,7 @@
 extern crate timely;
 
 use timely::dataflow::{InputHandle, ProbeHandle};
-use timely::dataflow::operators::{Input, Filter, Probe};
+use timely::dataflow::operators::{Input, Exchange, Probe};
 
 fn main() {
 
@@ -24,7 +24,7 @@ fn main() {
         worker.dataflow(|scope| {
             scope
                 .input_from(&mut input)     // read input.
-                .filter(|_| false)          // do nothing.
+                .exchange(|&x| x as u64)     // exchange data.
                 .probe_with(&mut probe);    // observe output.
         });
 
@@ -81,7 +81,7 @@ fn main() {
             if inserted_ns < target_ns {
 
                 while ((insert_counter * ns_per_request) as u64) < target_ns {
-                    input.send(insert_counter);
+                    input.send(insert_counter / peers);
                     insert_counter += peers;
                 }
                 input.advance_to(target_ns);

--- a/examples/realtime.rs
+++ b/examples/realtime.rs
@@ -76,6 +76,7 @@ fn main() {
 
             // Technique 3:
             let scale = (inserted_ns - acknowledged_ns).next_power_of_two();
+            let scale = ::std::cmp::max(scale, 1024) / 4;
             let target_ns = elapsed_ns & !(scale - 1);
 
             if inserted_ns < target_ns {

--- a/src/progress/nested/reachability_neu.rs
+++ b/src/progress/nested/reachability_neu.rs
@@ -250,7 +250,7 @@ pub struct Tracker<T:Timestamp> {
     // output_summaries: HashMap<Location, Vec<Antichain<T::Summary>>>,
     output_changes: Vec<ChangeBatch<T>>,
 
-    global_frontier: HashSet<(Location, T)>,
+    // global_frontier: HashSet<(Location, T)>,
 }
 
 struct PerOperator<T: Timestamp> {
@@ -294,8 +294,9 @@ struct PortInformation<T: Timestamp> {
 impl<T: Timestamp> PortInformation<T> {
     #[inline(always)]
     fn is_global(&self, time: &T) -> bool {
-        self.pointstamps.count_for(time) > 0 &&
-        self.implications.count_for(time) == 1
+        let dominated = self.implications.frontier().iter().any(|t| t.less_than(time));
+        let redundant = self.implications.count_for(time) > 1;
+        !dominated && !redundant
     }
     #[inline(always)]
     fn update_into<I: IntoIterator<Item=(T, i64)>>(
@@ -378,7 +379,7 @@ impl<T:Timestamp> Tracker<T> {
             worklist: BinaryHeap::new(),
             pushed_changes: ChangeBatch::new(),
             output_changes,
-            global_frontier: HashSet::new(),
+            // global_frontier: HashSet::new(),
         }
     }
 

--- a/src/progress/nested/subgraph.rs
+++ b/src/progress/nested/subgraph.rs
@@ -188,7 +188,7 @@ where
             pointstamp_builder: builder,
             pointstamp_tracker: tracker,
 
-            reachability_hack: ::std::env::var("REACHABILITY_HACK") != Ok("ZOMG".to_owned()),
+            reachability_hack: ::std::env::var("REACHABILITY_HACK") == Ok("ZOMG".to_owned()),
         }
     }
 }


### PR DESCRIPTION
This introduces a bit of a hack with respect to progress tracking, strictly optional and enabled by environment variable, that suppresses some volume of progress traffic. It is not meant to be a durable change to the code, but rather to slot into place to help test out to what extent high volumes of progress traffic can be reigned in.

The change is enabled by specifying the environment variable `REACHABILITY_HACK` with value `ZOMG`, which .. should make it clear that this isn't going to stick around (famous last words).

The hack enables logic which will hold back from exchange batches of progress updates for which all changes are demonstrably dominated by other pointstamps, either strictly less pointstamps at the same location, or in the case of messages the existence of an upstream pointstamp with the same timestamp (e.g. a capability held by the source of messages).

This should be generalized and clarified and better tested in the future, but at the moment we only maintain partial information about the state of progress tracking, and these are the only optimizations I could figure that we should be doing.