### PR TITLE
Speculatively schedule operator sequences

### DIFF
--- a/src/progress/nested/subgraph.rs
+++ b/src/progress/nested/subgraph.rs
@@ -441,7 +441,12 @@ where
         for ((location, time), diff) in self.pointstamp_tracker.pushed().drain() {
             // Targets are actionable, sources are not.
             if let ::progress::Port::Target(port) = location.port {
-                self.temp_active.push(Reverse(location.node));
+                if self.children[location.node].notify {
+                    self.temp_active.push(Reverse(location.node));
+                }
+                // TODO: This logic could also be guarded by `.notify`, but
+                // we want to be a bit careful to make sure all related logic
+                // agrees with this (e.g. initialization, operator logic, etc.)
                 self.children[location.node]
                     .shared_progress
                     .borrow_mut()


### PR DESCRIPTION
This PR causes a subgraph to schedule operators whose inputs are attached to operator outputs that have produced data, without awaiting positive confirmation from the channel that data exist. The intent is that there is a fair chance that there will be data, and awaiting the next `worker.step()` to discover this can substantially increase the critical path.

With the fix in place, the `examples/event_driven.rs` example, which sets up X dataflows each a sequence of Y map operators, has its times significantly reduced:

    cargo run --release --example event_driven -- 100 100 record

Pre-fix:

    3.376066625s    round 9997 complete in 102 steps
    3.376272991s    round 9998 complete in 102 steps
    3.376481583s    round 9999 complete in 102 steps
    3.376684118s    round 10000 complete in 102 steps
    3.376884082s    round 10001 complete in 102 steps
    3.377099496s    round 10002 complete in 102 steps
    3.377305554s    round 10003 complete in 102 steps

Post-fix:

    2.490122678s    round 9997 complete in 2 steps
    2.490269231s    round 9998 complete in 2 steps
    2.490410658s    round 9999 complete in 2 steps
    2.490558343s    round 10000 complete in 2 steps
    2.490703365s    round 10001 complete in 2 steps
    2.490847676s    round 10002 complete in 2 steps
    2.490988816s    round 10003 complete in 2 steps

The potential downside is false positive scheduling, which is not harmful from a correctness point of view, but could be an efficiency hit in some cases (e.g. perhaps the `examples/pingpong.rs` example, which intentionally avoids sending data to the same worker). There is also more logging burden with additional scheduling events.