### PR TITLE
Restrain progress messages

### DIFF
--- a/src/progress/nested/reachability_neu.rs
+++ b/src/progress/nested/reachability_neu.rs
@@ -292,10 +292,19 @@ impl<T: Timestamp> PortInformation<T> {
             output_summaries: Vec::new(),
         }
     }
+    /// True if updates at this pointstamp uniquely block progress.
+    ///
+    /// This method returns true if the currently maintained pointstamp
+    /// counts are such that zeroing out outstanding updates at *this*
+    /// pointstamp would change the frontiers at this operator. When the
+    /// method returns false it means that, temporarily at least, there
+    /// are outstanding pointstamp updates that are strictly less than
+    /// this pointstamp.
     #[inline(always)]
     fn is_global(&self, time: &T) -> bool {
-        self.pointstamps.count_for(time) > 0 &&
-        self.implications.count_for(time) == 1
+        let dominated = self.implications.frontier().iter().any(|t| t.less_than(time));
+        let redundant = self.implications.count_for(time) > 1;
+        !dominated && !redundant
     }
 }
 
@@ -521,11 +530,6 @@ impl<T:Timestamp> Tracker<T> {
     }
 
     /// Indicates if pointstamp is in the scope-wide frontier.
-    ///
-    /// A pointstamp (location, timestamp) is in the global frontier exactly when:
-    ///
-    ///  1. `self.pointstamps[location]` has count[timestamp] > 0.
-    ///  2. `self.implications[location]` has count[timestamp] == 1.
     ///
     /// Such a pointstamp would, if removed from `self.pointstamps`, cause a change
     /// to `self.implications`, which is what we track for per operator input frontiers.

--- a/src/progress/nested/subgraph.rs
+++ b/src/progress/nested/subgraph.rs
@@ -195,7 +195,7 @@ where
             shared_progress: Rc::new(RefCell::new(SharedProgress::new(inputs, outputs))),
             scope_summary,
 
-            eager_progress_send: ::std::env::var("DEFAULT_PROGRESS_MODE") == Ok("EAGER".to_owned()),
+            eager_progress_send: ::std::env::var("DEFAULT_PROGRESS_MODE") != Ok("DEMAND".to_owned()),
         }
     }
 }


### PR DESCRIPTION
This PR ports the logic from #205 to the new event-driven scheduler logic. Most of the logic is unchanged or simplified, due to the state maintained by the new reachability tracker.

One important change is that the default behavior is now with the progress accumulation optimization *enabled*, rather than disabled as it is in #205. To return to the old behavior, where progress messages are eagerly exchanged rather than exchanged only when justified, set the environment variable

    DEFAULT_PROGRESS_MODE = EAGER

This should cause all progress messages to be exchanged as soon as they are available, even if they cannot obviously improve the progress of the computation.

The down side for non-eager progress message exchange is the potential increase of the critical path for latency sensitive, progress bound computations. Where one `worker.step()` could have circulated all outstanding progress messages, we may need multiple rounds in order to inform participants that they should now send their updates. 

It remains an open question how painful this is, but the alternative (eager progress messages) has a known downside of many orders of magnitude increase in the volume of progress traffic. Ideally, some experimentation will begin to surface any problems, and we can look at ways to fix things further.