### PR TITLE
Feedback relaxation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The `Worker` and the `Subgraph` operator no longer schedules all of their child 
 
 The `dataflow_using` method has been generalized to support arbitrary dataflow names, loggers, and additional resources the dataflow should keep alive. Its name has been chaged to `dataflow_core`.
 
+You can now construct `feedback` operators with a `Default::default()` path summary, which has the ability to not increment timestamps. Instead of panicking, Timely's reachability module will inform you if a non-incrementing cycle is detected, at which point you should probably double check your code. It is not 100% known what the system will do in this case (e.g., the progress tracker may enter a non-terminating loop; this is on you, not us ;)).
+
 ## 0.8.0
 
 This release made several breaking modifications to the types associated with scopes, and in particular the generic parameters for the `Child<'a, G: ScopeParent, T: Timestamp>` type. Where previously the `T` parameter would be the *new coordinate* to add to `G`'s timestamp, it is now the *new timestamp* including `G`'s timestamp as well. This was done to support a broader class of timestamps to be used, beyond always requiring product combinations with new timestamps.

--- a/src/dataflow/operators/feedback.rs
+++ b/src/dataflow/operators/feedback.rs
@@ -70,10 +70,6 @@ pub trait LoopVariable<'a, G: Scope, T: Timestamp> {
 impl<G: Scope> Feedback<G> for G {
     fn feedback<D: Data>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (Handle<G, D>, Stream<G, D>) {
 
-        if summary == Default::default() {
-            panic!("Cannot use default summary for a loop variable");
-        }
-
         let mut builder = OperatorBuilder::new("Feedback".to_owned(), self.clone());
         let (output, stream) = builder.new_output();
 

--- a/src/progress/nested/reachability_neu.rs
+++ b/src/progress/nested/reachability_neu.rs
@@ -199,7 +199,6 @@ impl<T: Timestamp> Builder<T> {
         if !self.is_acyclic() {
             println!("Cycle detected without timestamp increment");
             println!("{:?}", self);
-            panic!();
         }
 
         Tracker::allocate_from(self)

--- a/src/progress/nested/reachability_neu.rs
+++ b/src/progress/nested/reachability_neu.rs
@@ -237,6 +237,30 @@ impl<T: Timestamp> Builder<T> {
     ///
     /// assert!(!builder.is_acyclic());
     /// ```
+    ///
+    /// This test exists because it is possible to describe dataflow graphs
+    /// that do
+    ///
+    /// ```rust
+    /// use timely::progress::frontier::Antichain;
+    /// use timely::progress::{Source, Target};
+    /// use timely::progress::nested::reachability_neu::Builder;
+    ///
+    /// // allocate a new empty topology builder.
+    /// let mut builder = Builder::<usize>::new();
+    ///
+    /// // Two inputs and outputs, only one of which advances.
+    /// builder.add_node(0, 2, 2, vec![
+    ///     vec![Antichain::from_elem(0),Antichain::new(),],
+    ///     vec![Antichain::new(),Antichain::from_elem(1),],
+    /// ]);
+    ///
+    /// // Connect each output to the opposite input.
+    /// builder.add_edge(Source { index: 0, port: 0}, Target { index: 0, port: 1} );
+    /// builder.add_edge(Source { index: 0, port: 1}, Target { index: 0, port: 0} );
+    ///
+    /// assert!(builder.is_acyclic());
+    /// ```
     pub fn is_acyclic(&self) -> bool {
 
         let mut in_degree = HashMap::new();

--- a/src/progress/nested/reachability_neu.rs
+++ b/src/progress/nested/reachability_neu.rs
@@ -238,8 +238,9 @@ impl<T: Timestamp> Builder<T> {
     /// assert!(!builder.is_acyclic());
     /// ```
     ///
-    /// This test exists because it is possible to describe dataflow graphs
-    /// that do
+    /// This test exists because it is possible to describe dataflow graphs that
+    /// do not contain non-incrementing cycles, but without feedback nodes that
+    /// strictly increment timestamps. For example,
     ///
     /// ```rust
     /// use timely::progress::frontier::Antichain;


### PR DESCRIPTION
This PR 

1. Removes the requirement that `feedback` operators have non-trivial path summaries. You can now use a feedback edge without adjusting the timestamp.

2. Adds a cycle detector to the progress tracker builder. At the moment, the logic is rigged to print an alert, rather than to panic. This is because there are reasonable use cases for non-incrementing cycles, where you want unbounded asynchronous iteration and do not plan to use progress information to block or unblock computation.

cc @antiguru 