### PR TITLE
Attempt rustdoc for mdbook tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script:
 - cargo test && (cd bytes; cargo test)
 - cargo bench
 - cargo doc
+- for file in $(find mdbook -name '*.md'); do rustdoc --test $file  -L ./target/debug/deps; done
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ repository = "https://github.com/TimelyDataflow/timely-dataflow.git"
 keywords = ["timely", "dataflow"]
 license = "MIT"
 
-#build = "booktests.rs"
-
 [features]
 bincode= ["timely_communication/bincode"]
 
@@ -31,10 +29,6 @@ timely_communication = { path = "./communication", version = "0.8" }
 [dev-dependencies]
 timely_sort="0.1.6"
 rand="0.4"
-#skeptic = "0.12"
-
-#[build-dependencies]
-#skeptic = "0.12"
 
 [profile.release]
 opt-level = 3

--- a/booktests.rs
+++ b/booktests.rs
@@ -1,9 +1,0 @@
-extern crate skeptic;
-
-use skeptic::*;
-
-fn main() {
-    println!("building tests");
-    let mdbook_files = markdown_files_of_directory("mdbook/src");
-    generate_doc_tests(&mdbook_files);
-}

--- a/mdbook/src/chapter_0/chapter_0_0.md
+++ b/mdbook/src/chapter_0/chapter_0_0.md
@@ -19,6 +19,7 @@ This program gives us a bit of a flavor for what a timely dataflow program might
 
 If we run the program up above, we see it print out the numbers zero through nine.
 
+```ignore
     Echidnatron% cargo run --example simple
         Finished dev [unoptimized + debuginfo] target(s) in 0.05s
          Running `target/debug/examples/simple`
@@ -33,6 +34,7 @@ If we run the program up above, we see it print out the numbers zero through nin
     seen: 8
     seen: 9
     Echidnatron%
+```
 
 This isn't very different from a Rust program that would do this much more simply, namely the program
 

--- a/mdbook/src/chapter_0/chapter_0_0.md
+++ b/mdbook/src/chapter_0/chapter_0_0.md
@@ -2,7 +2,7 @@
 
 Let's start with what may be the simplest non-trivial timely dataflow program.
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::operators::{ToStream, Inspect};
@@ -38,7 +38,7 @@ If we run the program up above, we see it print out the numbers zero through nin
 
 This isn't very different from a Rust program that would do this much more simply, namely the program
 
-```rust,no_run
+```rust
 fn main() {
     (0..10).for_each(|x| println!("seen: {:?}", x));
 }

--- a/mdbook/src/chapter_0/chapter_0_1.md
+++ b/mdbook/src/chapter_0/chapter_0_1.md
@@ -43,6 +43,7 @@ We can run this program in a variety of configurations: with just a single worke
 
 To try this out yourself, first clone the timely dataflow repository using `git`
 
+```ignore
     Echidnatron% git clone https://github.com/frankmcsherry/timely-dataflow
     Cloning into 'timely-dataflow'...
     remote: Counting objects: 14254, done.
@@ -50,9 +51,11 @@ To try this out yourself, first clone the timely dataflow repository using `git`
     remote: Total 14254 (delta 2625), reused 3824 (delta 2123), pack-reused 9856
     Receiving objects: 100% (14254/14254), 9.01 MiB | 1.04 MiB/s, done.
     Resolving deltas: 100% (10686/10686), done.
+```
 
 Now `cd` into the directory and build timely dataflow by typing
 
+```ignore
     Echidnatron% cd timely-dataflow
     Echidnatron% cargo build
         Updating registry `https://github.com/rust-lang/crates.io-index`
@@ -65,16 +68,20 @@ Now `cd` into the directory and build timely dataflow by typing
     Compiling timely_communication v0.1.7
     Compiling timely v0.2.0 (file:///Users/mcsherry/Projects/temporary/timely-dataflow)
         Finished dev [unoptimized + debuginfo] target(s) in 6.37 secs
+```
 
 Now we build the `hello` example
 
+```ignore
     Echidnatron% cargo build --example hello
     Compiling rand v0.3.16
     Compiling timely v0.2.0 (file:///Users/mcsherry/Projects/temporary/timely-dataflow)
         Finished dev [unoptimized + debuginfo] target(s) in 6.35 secs
+```
 
 And finally we run the `hello` example
 
+```ignore
     Echidnatron% cargo run --example hello
         Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
         Running `target/debug/examples/hello`
@@ -89,11 +96,13 @@ And finally we run the `hello` example
     worker 0:	hello 8
     worker 0:	hello 9
     Echidnatron%
+```
 
 Rust is relatively clever, and we could have skipped the `cargo build` and `cargo build --example hello` commands; just invoking `cargo run --example hello` will build (or rebuild) anything necessary.
 
 Of course, we can run this with multiple workers using the `-w` or `--workers` flag, followed by the number of workers we want in the process. Notice that you'll need an `--` before the arguments to our program; any arguments before that are treated as arguments to the `cargo` command.
 
+```ignore
     Echidnatron% cargo run --example hello -- -w2
         Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
         Running `target/debug/examples/hello -w2`
@@ -108,6 +117,7 @@ Of course, we can run this with multiple workers using the `-w` or `--workers` f
     worker 0:	hello 8
     worker 1:	hello 9
     Echidnatron%
+```
 
 Although you can't easily see this happening, timely dataflow has spun up *two* worker threads and together they have exchanged some data and printed the results as before. However, notice that the worker index is now varied; this is our only clue that different workers exist, and processed different pieces of data. Worker zero introduces all of the data (notice the guard in the code; without this *each* worker would introduce `0 .. 10`), and then it is shuffled between the workers. The only *guarantee* is that records that evaluate to the same integer in the exchange closure go to the same worker. In practice, we (currently) route records based on the remainder of the number when divided by the number of workers.
 
@@ -115,12 +125,15 @@ Finally, let's run with multiple processes. To do this, you use the `-n` and `-p
 
 In one shell, I'm going to start a computation that expects multiple processes. It will hang out waiting for the other processes to start up.
 
+```ignore
     Echidnatron% cargo run --example hello -- -n2 -p0
         Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
         Running `target/debug/examples/hello -n2 -p0`
+```
 
 Now if we head over to another shell, we can type the same thing but with a different `-p` identifier.
 
+```ignore
     Echidnatron% cargo run --example hello -- -n2 -p1
         Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
         Running `target/debug/examples/hello -n2 -p1`
@@ -130,9 +143,11 @@ Now if we head over to another shell, we can type the same thing but with a diff
     worker 1:	hello 7
     worker 1:	hello 9
     Echidnatron%
+```
 
 Wow, fast! And, we get to see some output too. Only the output for this worker, though. If we head back to the other shell we see the process got moving and produced the other half of the output.
 
+```ignore
     Echidnatron% cargo run --example hello -- -n2 -p0
         Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
         Running `target/debug/examples/hello -n2 -p0`
@@ -142,5 +157,6 @@ Wow, fast! And, we get to see some output too. Only the output for this worker, 
     worker 0:	hello 6
     worker 0:	hello 8
     Echidnatron%
+```
 
 This may seem only slightly interesting so far, but we will progressively build up more interesting tools and more interesting computations, and see how timely dataflow can efficiently execute them for us.

--- a/mdbook/src/chapter_0/chapter_0_1.md
+++ b/mdbook/src/chapter_0/chapter_0_1.md
@@ -4,7 +4,7 @@ Timely dataflow means to capture a large number of idioms, so it is a bit tricky
 
 The following complete program initializes a timely dataflow computation, in which participants can supply a stream of numbers which are exchanged between the workers based on their value. Workers print to the screen when they see numbers. You can also find this as [`examples/hello.rs`](https://github.com/frankmcsherry/timely-dataflow/blob/master/examples/hello.rs) in the [timely dataflow repository](https://github.com/frankmcsherry/timely-dataflow/tree/master/examples).
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::InputHandle;

--- a/mdbook/src/chapter_1/chapter_1_1.md
+++ b/mdbook/src/chapter_1/chapter_1_1.md
@@ -8,7 +8,7 @@ Let's write an overly simple dataflow program. Remember our `examples/hello.rs` 
 
 Here is a reduced version of `examples/hello.rs` that just feeds data in to our dataflow, without paying any attention to progress made. In particular, we have removed the `probe()` operation, the resulting `probe` variable, and the use of `probe` to determine how long we should step the worker before introducing more data.
 
-```rust,no_run
+```rust
 #![allow(unused_variables)]
 extern crate timely;
 
@@ -46,6 +46,7 @@ This program is a *dataflow program*. There are two dataflow operators here, `ex
 
 Importantly, we haven't imposed any constraints on how these operators need to run. We removed the code that caused the input to be delayed until a certain amount of progress had been made, and it shows in the results when we run with more than one worker:
 
+```ignore
     Echidnatron% cargo run --example hello -- -w2
         Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
         Running `target/debug/examples/hello -w2`
@@ -60,6 +61,7 @@ Importantly, we haven't imposed any constraints on how these operators need to r
     worker 0:	hello 6
     worker 0:	hello 8
     Echidnatron%
+```
 
 What a mess. Nothing in our dataflow program requires that workers zero and one alternate printing to the screen, and you can even see that worker one is *done* before worker zero even gets to printing `hello 4`.
 
@@ -81,26 +83,32 @@ However, this is only a mess if we are concerned about the order, and in many ca
 
  Let's check out the time to print out the prime numbers up to 10,000 using one worker:
 
+```ignore
     Echidnatron% time cargo run --example hello -- -w1 > output1.txt
         Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
         Running `target/debug/examples/hello -w1`
     cargo run --example hello -- -w1 > output1.txt  59.84s user 0.10s system 99% cpu 1:00.01 total
     Echidnatron%
+```
 
 And now again with two workers:
 
+```ignore
     Echidnatron% time cargo run --example hello -- -w2 > output2.txt
         Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
         Running `target/debug/examples/hello -w2`
     cargo run --example hello -- -w2 > output2.txt  60.74s user 0.12s system 196% cpu 30.943 total
     Echidnatron%
+```
 
 The time is basically halved, from one minute to thirty seconds, which is a great result for those of us who like factoring small numbers. Furthermore, although the 1,262 lines of results of `output1.txt` and `output2.txt` are not in the same order, it takes a fraction of a second to make them so, and verify that they are identical:
 
+```ignore
     Echidnatron% sort output1.txt > sorted1.txt
     Echidnatron% sort output2.txt > sorted2.txt
     Echidnatron% diff sorted1.txt sorted2.txt
     Echidnatron%
+```
 
 ---
 

--- a/mdbook/src/chapter_1/chapter_1_2.md
+++ b/mdbook/src/chapter_1/chapter_1_2.md
@@ -30,6 +30,7 @@ The `inspect_batch` operator gets lower-level access to data in timely dataflow,
 
 The output we get with two workers is now:
 
+```ignore
     Echidnatron% cargo run --example hello -- -w2
         Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
         Running `target/debug/examples/hello -w2`
@@ -44,6 +45,7 @@ The output we get with two workers is now:
     worker 1:	hello 7 @ (Root, 7)
     worker 1:	hello 9 @ (Root, 9)
     Echidnatron%
+```
 
 The timestamps are the `(Root, i)` things for various values of `i`. These happen to correspond to the data themselves, but had we provided random input data rather than `i` itself we would still be able to make sense of the output and put it back "in order".
 

--- a/mdbook/src/chapter_1/chapter_1_3.md
+++ b/mdbook/src/chapter_1/chapter_1_3.md
@@ -4,7 +4,7 @@ Both dataflow and timestamps are valuable in their own right, but when we bring 
 
 Let's recall that bit of code we commented out from `examples/hello.rs`, which had to do with consulting something named `probe`.
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::InputHandle;

--- a/mdbook/src/chapter_2/chapter_2.md
+++ b/mdbook/src/chapter_2/chapter_2.md
@@ -6,7 +6,7 @@ This section will be a bit of a tour through the dataflow construction process, 
 
 Here is a relatively simple example, taken from `examples/simple.rs`, that turns the numbers zero through nine into a stream, and then feeds them through an `inspect` operator printing them to the screen.
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::operators::{ToStream, Inspect};

--- a/mdbook/src/chapter_2/chapter_2_1.md
+++ b/mdbook/src/chapter_2/chapter_2_1.md
@@ -6,7 +6,7 @@ Almost all operators in timely can only be defined from a source of data, with a
 
 For example, we can create a new dataflow with one interactive input and one static input:
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::InputHandle;

--- a/mdbook/src/chapter_2/chapter_2_2.md
+++ b/mdbook/src/chapter_2/chapter_2_2.md
@@ -4,7 +4,7 @@ Having constructed a minimal streaming computation, we might like to take a peek
 
 The `inspect` operator is called with a closure, and it ensures that the closure is run on each record that passes through the operator. This closure can do just about anything, from printing to the screen or writing to a file.
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::operators::{ToStream, Inspect};
@@ -26,7 +26,7 @@ This simple example turns the sequence zero through nine into a stream and then 
 
 The `inspect` operator has a big sibling, `inspect_batch`, whose closure gets access to whole batches of records at a time, just like the underlying operator. More precisely, `inspect_batch` takes a closure of two parameters: first, the timestamp of a batch, and second a reference to the batch itself. The `inspect_batch` operator can be especially helpful if you want to process the outputs more efficiently.
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::operators::{ToStream, Inspect};
@@ -50,7 +50,7 @@ The simplest form of capture is the `capture()` method, which turns the stream i
 
 Consider the documentation test for the `ToStream` trait:
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::operators::{ToStream, Capture};

--- a/mdbook/src/chapter_2/chapter_2_3.md
+++ b/mdbook/src/chapter_2/chapter_2_3.md
@@ -10,7 +10,7 @@ The `map` operator takes as argument a closure from the input data type to an ou
 
 The following program should print out the numbers one through ten.
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::operators::{ToStream, Inspect, Map};
@@ -29,7 +29,7 @@ fn main() {
 
 The closure `map` takes *owned* data as input, which means you are able to mutate it as you like without cloning or copying the data. For example, if you have a stream of `String` data, then you could upper-case the string contents without having to make a second copy; your closure owns the data that comes in, with all the benefits that entails.
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::operators::{ToStream, Inspect, Map};
@@ -53,7 +53,7 @@ There are a few variants of `map` with different functionality.
 
 For example, the `map_in_place` method takes a closure which receives a mutable reference and produces no output; instead, this method allows you to change the data *in-place*, which can be a valuable way to avoid duplication of resources.
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::operators::{ToStream, Inspect, Map};
@@ -73,7 +73,7 @@ fn main() {
 
 Alternately, the `flat_map` method takes input data and allows your closure to transform each element to an iterator, which it then enumerates into the output stream. The following fragment takes each number from zero through eight and has each produce all numbers less than it. The result should be 8 zeros, 7 ones, and so on up to 1 seven.
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::operators::{ToStream, Inspect, Map};
@@ -94,7 +94,7 @@ fn main() {
 
 Another fundamental operation is *filtering*, in which a predicate dictates a subset of the stream to retain.
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::operators::{ToStream, Inspect, Filter};
@@ -119,7 +119,7 @@ There are two operators for spliting and combining streams, `partition` and `con
 
 The `partition` operator takes two arguments, a number of resulting streams to produce, and a closure which takes each record to a pair of the target partition identifier and the output record. The output of `partition` is a list of streams, where each stream contains those elements mapped to the stream under the closure.
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::operators::{ToStream, Partition, Inspect};
@@ -140,7 +140,7 @@ This example breaks the input stream apart into three logical streams, which are
 
 In the other direction, `concat` takes two streams and produces one output stream containing elements sent along either. The following example merges the partitioned streams back together.
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::operators::{ToStream, Partition, Concat, Inspect};
@@ -159,7 +159,7 @@ fn main() {
 
 There is also a `concatenate` method defined for scopes which collects all streams from a supplied vector, effectively undoing the work of `partition` in one operator.
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::operators::{ToStream, Partition, Concatenate, Inspect};

--- a/mdbook/src/chapter_2/chapter_2_5.md
+++ b/mdbook/src/chapter_2/chapter_2_5.md
@@ -8,12 +8,12 @@ Let's model a changing corpus of text as a list of pairs of *times* which will b
 
 We are going to write a program that is the moral equivalent of the following sequential Rust program:
 
-```rust,ignore
+```rust
 /// From a sequence of changes to the occurrences of text,
 /// produce the changing counts of words in that text.
-fn word_count(history: Vec<(u64, Vec<(String, i64)>)>) {
-    let mut counts = HashMap::new();
-    for (time, changes) in history.drain(..) {
+fn word_count(mut history: Vec<(u64, Vec<(String, i64)>)>) {
+    let mut counts = ::std::collections::HashMap::new();
+    for (time, mut changes) in history.drain(..) {
         for (text, diff) in changes.drain(..) {
             for word in text.split_whitespace() {
                 let mut entry = counts.entry(word.to_owned())
@@ -34,7 +34,7 @@ Our program will be a bit larger, but it will be more flexible. By specifying mo
 
 Let's first build a timely computation into which we can send text and which will show us the text back. Our next steps will be to put more clever logic in place, but let's start here to get some boiler-plate out of the way.
 
-```rust,no_run
+```rust
 extern crate timely;
 
 use timely::dataflow::{InputHandle, ProbeHandle};
@@ -262,6 +262,7 @@ Remember that `time` we capture as the key, and how it acts as our ability to se
 
 You can check out the result in [`examples/wordcount.rs`](https://github.com/frankmcsherry/timely-dataflow/blob/master/examples/wordcount.rs). If you run it as written, you'll see output that looks like:
 
+```ignore
     Echidnatron% cargo run --example wordcount
         Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
         Running `target/debug/examples/wordcount`
@@ -276,9 +277,11 @@ You can check out the result in [`examples/wordcount.rs`](https://github.com/fra
     seen: ("round", 9)
     seen: ("round", 10)
     Echidnatron%
+```
 
 We kept sending the same word over and over, so its count goes up. Neat. If you'd like to run it with two workers, you just need to put `-- -w2` at the end of the command, like so:
 
+```ignore
     Echidnatron% cargo run --example wordcount -- -w2
         Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
         Running `target/debug/examples/wordcount -w2`
@@ -288,5 +291,6 @@ We kept sending the same word over and over, so its count goes up. Neat. If you'
     seen: ("round", 19)
     seen: ("round", 20)
     Echidnatron%
+```
 
 Because there are two workers, each inputting `"round"` repeatedly, we count up to twenty. By the end of this text you should be able to produce more interesting examples, for example reading the contents of directories and divvying up responsibility for the files between the workers.

--- a/mdbook/src/chapter_4/chapter_4_1.md
+++ b/mdbook/src/chapter_4/chapter_4_1.md
@@ -4,16 +4,16 @@ The first bit of complexity we will introduce is the timely dataflow *scope*.
 
 You can create a new scope in any scope, just by invoking the `scoped` method:
 
-```rust,ignore
+```rust
 extern crate timely;
 
-use timely::dataflow::operators::*;
+use timely::dataflow::Scope;
 
 fn main() {
     timely::example(|scope| {
 
-        // create a new nested scope
-        scope.scoped(|subscope| {
+        // Create a new scope with the same (u64) timestamp.
+        scope.scoped::<u64,_,_>("SubScope", |subscope| {
             // probably want something here
         })
 
@@ -34,9 +34,10 @@ In addition to *creating* scopes, we will also need to get streams of data into 
 There are two simple methods, `enter` and `leave`, that allow streams of data into and out of scopes. It is important that you use them! If you try to use a stream in a nested scope, Rust will be confused because it can't get the timestamps of your streams to typecheck.
 
 
-```rust,ignore
+```rust
 extern crate timely;
 
+use timely::dataflow::Scope;
 use timely::dataflow::operators::*;
 
 fn main() {
@@ -44,7 +45,8 @@ fn main() {
 
         let stream = (0 .. 10).to_stream(scope);
 
-        let result = scope.scoped(|subscope| {
+        // Create a new scope with the same (u64) timestamp.
+        let result = scope.scoped::<u64,_,_>("SubScope", |subscope| {
             stream.enter(subscope)
                   .inspect_batch(|t, xs| println!("{:?}, {:?}", t, xs))
                   .leave()

--- a/mdbook/src/chapter_4/chapter_4_1.md
+++ b/mdbook/src/chapter_4/chapter_4_1.md
@@ -1,8 +1,18 @@
 # Scopes
 
-The first bit of complexity we will introduce is the timely dataflow *scope*.
+The first bit of complexity we will introduce is the timely dataflow *scope*. A scope is a region of dataflow, much like how curly braces provide scopes in imperative languages:
 
-You can create a new scope in any scope, just by invoking the `scoped` method:
+```rust
+{
+    // this is an outer scope
+
+    {
+        // this is an inner scope
+    }
+}
+```
+
+You can create a new scope in any other scope by invoking the `scoped` method:
 
 ```rust
 extern crate timely;
@@ -21,18 +31,15 @@ fn main() {
 }
 ```
 
-The main thing that a scope does for you is to add an additional timestamp to all streams that are brought into it. For example, perhaps the timestamp type in your base dataflow scope is `usize`, your nested scope could augment this to `(usize, u32)`, or whatever additional timestamp type you might want.
+The main thing that a scope does for you is allow you to enrich the timestamp of all streams that are brought into it. For example, perhaps the timestamp type in your base dataflow scope is `usize`, your nested scope could augment this to `(usize, u32)`, or whatever additional timestamp type you might want. In the example above, we choose to keep the same timestamp, `u64`.
 
-Why are additional timestamps useful? They allow operators in the nested scope to change their behavior based on the enriched timestamp, without worrying the streams and operators outside the scope about the detail.
-
-For example, the first use of scopes we will see is for *iterative* dataflow. Our nested scopes will introduce a new timestamp corresponding to the round of iteration. This timestamp will allow us to take data in a stream and return it to the beginning of the dataflow, as long as we increment the new timestamp coordinate (the round of iteration). Iterative dataflow is really neat, and in the context of an iterative scope our operators will know that they can observe a round of iteration; outside of the iterative scope the operators have no idea one even exists.
+Why are additional timestamps useful? They allow operators in the nested scope to change their behavior based on the enriched timestamp, without worrying the streams and operators outside the scope about this detail. We will soon see the example of *iterative* dataflow, where a scope allows cycles within it, but does not bother operators outside the scope with that detail.
 
 ## Entering and exiting scopes
 
 In addition to *creating* scopes, we will also need to get streams of data into and out of scopes.
 
 There are two simple methods, `enter` and `leave`, that allow streams of data into and out of scopes. It is important that you use them! If you try to use a stream in a nested scope, Rust will be confused because it can't get the timestamps of your streams to typecheck.
-
 
 ```rust
 extern crate timely;
@@ -58,4 +65,62 @@ fn main() {
 
 Notice how we can both `enter` a stream and `leave` in a single sequence of operations.
 
-The `enter` operator introduces each batch of records as a batch with the same timestamp, extended with a new copy of the default value for the new timestamp. The `leave` just strips off the new timestamp from each batch, resulting in a stream fit for consumption in the containing scope.
+The `enter` operator introduces each batch of records as a batch with an enriched timestamp, which usually means "the same" or "with a new zero coordinate". The `leave` just de-enriches the timestamp, correspondingly "the same" or "without that new coordinate". The `leave` operator results in a stream fit for consumption in the containing scope.
+
+## Regions
+
+There is a handy shortcut for scopes that do not change the timestamp type, a `region`.
+
+```rust
+extern crate timely;
+
+use timely::dataflow::Scope;
+use timely::dataflow::operators::*;
+
+fn main() {
+    timely::example(|scope| {
+
+        let stream = (0 .. 10).to_stream(scope);
+
+        // Create a new scope with the same (u64) timestamp.
+        let result = scope.region(|subscope| {
+            stream.enter(subscope)
+                  .inspect_batch(|t, xs| println!("{:?}, {:?}", t, xs))
+                  .leave()
+        });
+
+    });
+}
+```
+
+Regions are mostly here to help you organize your dataflow. A region presents itself to its surrounding dataflow as a single operator, and that can make it easier for you or others to reason about the logical structure of your dataflow.
+
+**IMPORTANT** Although you can probably write a program that uses `region()` but then skips the calls to `enter` and `leave`, because the timestamp types are the same, this is very naughty and please do not do this.
+
+## Iteration
+
+Iteration is a particularly neat form of nested scope in which all timestamps are enriched with an iteration counter. This counter starts at zero for streams that `enter` the scope, may increment in the context of the loop (next section gives examples of this), and is removed when the `leave` method is called.
+
+The enriched timestamp type is `timely::order::Product<TOuter, TInner>`, for an outer timestamp type `TOuter` and an iteration counter type `TInner`. However, there is a convenience method that can allow you to skip thinking too hard about this.
+
+```rust
+extern crate timely;
+
+use timely::dataflow::Scope;
+use timely::dataflow::operators::*;
+
+fn main() {
+    timely::example(|scope| {
+
+        let stream = (0 .. 10).to_stream(scope);
+
+        // Create a new scope with a (u64, u32) timestamp.
+        let result = scope.iterative::<u32,_,_>(|subscope| {
+            stream.enter(subscope)
+                  .inspect_batch(|t, xs| println!("{:?}, {:?}", t, xs))
+                  .leave()
+        });
+
+    });
+}
+```

--- a/mdbook/src/chapter_4/chapter_4_2.md
+++ b/mdbook/src/chapter_4/chapter_4_2.md
@@ -18,8 +18,8 @@ use timely::dataflow::operators::*;
 fn main() {
     timely::example(|scope| {
 
-        // create a loop that cycles at most 100 times.
-        let (handle, stream) = scope.loop_variable(100, 1);
+        // create a loop that cycles unboundedly.
+        let (handle, stream) = scope.feedback(1);
 
         // circulate numbers, Collatz stepping each time.
         (1 .. 10)
@@ -29,7 +29,6 @@ fn main() {
             .inspect(|x| println!("{:?}", x))
             .filter(|x| *x != 1)
             .connect_loop(handle);
-
     });
 }
 ```
@@ -54,9 +53,9 @@ use timely::dataflow::operators::*;
 fn main() {
     timely::example(|scope| {
 
-        // create a loop that cycles at most 100 times.
-        let (handle0, stream0) = scope.loop_variable(100, 1);
-        let (handle1, stream1) = scope.loop_variable(100, 1);
+        // create a loop that cycles unboundedly.
+        let (handle0, stream0) = scope.feedback(1);
+        let (handle1, stream1) = scope.feedback(1);
 
         // do the right steps for even and odd numbers, respectively.
         let results0 = stream0.map(|x| x / 2).filter(|x| *x != 1);
@@ -95,9 +94,11 @@ fn main() {
 
         let input = (1 .. 10).to_stream(scope);
 
-        scope.scoped(|subscope| {
+        // Create a nested iterative scope.
+        // Rust needs help understanding the iteration counter type.
+        scope.iterative::<u64,_,_>(|subscope| {
 
-            let (handle, stream) = subscope.loop_variable(100, 1);
+            let (handle, stream) = subscope.loop_variable(1);
 
             input
                 .enter(subscope)

--- a/mdbook/src/chapter_4/chapter_4_4.md
+++ b/mdbook/src/chapter_4/chapter_4_4.md
@@ -176,14 +176,19 @@ Finally, each worker just uses the list of `EventReader`s as the argument to `re
 
 If you want to try it out, make sure to start up the `capture_recv` example first (otherwise the connections will be refused for `capture_send`) and specify the expected number of source workers, modifying the number of received workers if you like. Here we are expecting five source workers, and distributing them among three receive workers (to make life complicated):
 
+```ignore
     shell1% cargo run --example capture_recv -- 5 -w3
+```
 
 Nothing happens yet, so head over to another shell and run `capture_send` with the specified number of workers (five, in this case):
 
+```ignore
     shell2% cargo run --example capture_send -- -w5
+```
 
 Now, back in your other shell you should see something like
 
+```ignore
     shell1% cargo run --example capture_recv -- 5 -w3
     replayed: 0
     replayed: 1
@@ -195,6 +200,7 @@ Now, back in your other shell you should see something like
     replayed: 6
     replayed: 1
     ...
+```
 
 which just goes on and on, but which should produce 50 lines of text, with five copies of `0 .. 10` interleaved variously.
 


### PR DESCRIPTION
This PR attempts to use `rustdoc` to test the `./mdbook/` documentation, which has gone untested for a while (previously: skeptic, whose use of `build.rs` files made everything painful).