### PR TITLE
Upgrade to the Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ name = "timely"
 version = "0.8.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 readme = "README.md"
+edition = "2018"
 
 description = "A low-latency data-parallel dataflow system in Rust"
 

--- a/communication/examples/hello.rs
+++ b/communication/examples/hello.rs
@@ -1,5 +1,3 @@
-extern crate timely_communication;
-
 use std::ops::Deref;
 use timely_communication::{Message, Allocate};
 

--- a/src/dataflow/channels/mod.rs
+++ b/src/dataflow/channels/mod.rs
@@ -1,6 +1,6 @@
 //! Structured communication between timely dataflow operators.
 
-use communication::Push;
+use crate::communication::Push;
 
 /// A collection of types that may be pushed at.
 pub mod pushers;
@@ -10,7 +10,7 @@ pub mod pullers;
 pub mod pact;
 
 /// The input to and output from timely dataflow communication channels.
-pub type Bundle<T, D> = ::communication::Message<Message<T, D>>;
+pub type Bundle<T, D> = crate::communication::Message<Message<T, D>>;
 
 /// A serializable representation of timestamped data.
 #[derive(Clone, Abomonation, Serialize, Deserialize)]

--- a/src/dataflow/channels/pact.rs
+++ b/src/dataflow/channels/pact.rs
@@ -9,14 +9,14 @@
 
 use std::marker::PhantomData;
 
-use communication::{Push, Pull, Data};
-use communication::allocator::thread::{ThreadPusher, ThreadPuller};
+use crate::communication::{Push, Pull, Data};
+use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
 
-use worker::AsWorker;
-use dataflow::channels::pushers::Exchange as ExchangePusher;
+use crate::worker::AsWorker;
+use crate::dataflow::channels::pushers::Exchange as ExchangePusher;
 use super::{Bundle, Message};
 
-use logging::TimelyLogger as Logger;
+use crate::logging::TimelyLogger as Logger;
 
 /// A `ParallelizationContract` allocates paired `Push` and `Pull` implementors.
 pub trait ParallelizationContract<T: 'static, D: 'static> {
@@ -127,7 +127,7 @@ impl<T, D, P: Push<Bundle<T, D>>> Push<Bundle<T, D>> for LogPusher<T, D, P> {
                 message.from = self.source;
             }
 
-            self.logging.as_ref().map(|l| l.log(::logging::MessagesEvent {
+            self.logging.as_ref().map(|l| l.log(crate::logging::MessagesEvent {
                 is_send: true,
                 channel: self.channel,
                 source: self.source,
@@ -168,7 +168,7 @@ impl<T, D, P: Pull<Bundle<T, D>>> Pull<Bundle<T, D>> for LogPuller<T, D, P> {
         if let Some(bundle) = result {
             let channel = self.channel;
             let target = self.index;
-            self.logging.as_ref().map(|l| l.log(::logging::MessagesEvent {
+            self.logging.as_ref().map(|l| l.log(crate::logging::MessagesEvent {
                 is_send: false,
                 channel,
                 source: bundle.from,

--- a/src/dataflow/channels/pullers/counter.rs
+++ b/src/dataflow/channels/pullers/counter.rs
@@ -3,9 +3,9 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use dataflow::channels::Bundle;
-use progress::ChangeBatch;
-use communication::Pull;
+use crate::dataflow::channels::Bundle;
+use crate::progress::ChangeBatch;
+use crate::communication::Pull;
 
 /// A wrapper which accounts records pulled past in a shared count map.
 pub struct Counter<T: Ord+Clone+'static, D, P: Pull<Bundle<T, D>>> {

--- a/src/dataflow/channels/pushers/buffer.rs
+++ b/src/dataflow/channels/pushers/buffer.rs
@@ -1,10 +1,10 @@
 //! Buffering and session mechanisms to provide the appearance of record-at-a-time sending,
 //! with the performance of batched sends.
 
-use dataflow::channels::{Bundle, Message};
-use progress::Timestamp;
-use dataflow::operators::Capability;
-use communication::Push;
+use crate::dataflow::channels::{Bundle, Message};
+use crate::progress::Timestamp;
+use crate::dataflow::operators::Capability;
+use crate::communication::Push;
 
 /// Buffers data sent at the same time, for efficient communication.
 ///

--- a/src/dataflow/channels/pushers/counter.rs
+++ b/src/dataflow/channels/pushers/counter.rs
@@ -3,9 +3,9 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use progress::ChangeBatch;
-use dataflow::channels::Bundle;
-use communication::Push;
+use crate::progress::ChangeBatch;
+use crate::dataflow::channels::Bundle;
+use crate::communication::Push;
 
 /// A wrapper which updates shared `produced` based on the number of records pushed.
 pub struct Counter<T: Ord, D, P: Push<Bundle<T, D>>> {

--- a/src/dataflow/channels/pushers/exchange.rs
+++ b/src/dataflow/channels/pushers/exchange.rs
@@ -1,8 +1,8 @@
 //! The exchange pattern distributes pushed data between many target pushees.
 
-use Data;
-use communication::Push;
-use dataflow::channels::{Bundle, Message};
+use crate::Data;
+use crate::communication::Push;
+use crate::dataflow::channels::{Bundle, Message};
 
 // TODO : Software write combining
 /// Distributes records among target pushees according to a distribution function.

--- a/src/dataflow/channels/pushers/tee.rs
+++ b/src/dataflow/channels/pushers/tee.rs
@@ -3,10 +3,10 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use Data;
-use dataflow::channels::{Bundle, Message};
+use crate::Data;
+use crate::dataflow::channels::{Bundle, Message};
 
-use communication::Push;
+use crate::communication::Push;
 
 /// Wraps a shared list of `Box<Push>` to forward pushes to. Owned by `Stream`.
 pub struct Tee<T: 'static, D: 'static> {

--- a/src/dataflow/operators/aggregation/aggregate.rs
+++ b/src/dataflow/operators/aggregation/aggregate.rs
@@ -2,10 +2,10 @@
 use std::hash::Hash;
 use std::collections::HashMap;
 
-use ::{Data, ExchangeData};
-use dataflow::{Stream, Scope};
-use dataflow::operators::generic::operator::Operator;
-use dataflow::channels::pact::Exchange;
+use crate::{Data, ExchangeData};
+use crate::dataflow::{Stream, Scope};
+use crate::dataflow::operators::generic::operator::Operator;
+use crate::dataflow::channels::pact::Exchange;
 
 /// Generic intra-timestamp aggregation
 ///

--- a/src/dataflow/operators/aggregation/state_machine.rs
+++ b/src/dataflow/operators/aggregation/state_machine.rs
@@ -2,10 +2,10 @@
 use std::hash::Hash;
 use std::collections::HashMap;
 
-use ::{Data, ExchangeData};
-use dataflow::{Stream, Scope};
-use dataflow::operators::generic::operator::Operator;
-use dataflow::channels::pact::Exchange;
+use crate::{Data, ExchangeData};
+use crate::dataflow::{Stream, Scope};
+use crate::dataflow::operators::generic::operator::Operator;
+use crate::dataflow::channels::pact::Exchange;
 
 /// Generic state-transition machinery: each key has a state, and receives a sequence of events.
 /// Events are applied in time-order, but no other promises are made. Each state transition can

--- a/src/dataflow/operators/branch.rs
+++ b/src/dataflow/operators/branch.rs
@@ -1,9 +1,9 @@
 //! Operators that separate one stream into two streams based on some condition
 
-use dataflow::channels::pact::Pipeline;
-use dataflow::operators::generic::builder_rc::OperatorBuilder;
-use dataflow::{Scope, Stream};
-use Data;
+use crate::dataflow::channels::pact::Pipeline;
+use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
+use crate::dataflow::{Scope, Stream};
+use crate::Data;
 
 /// Extension trait for `Stream`.
 pub trait Branch<S: Scope, D: Data> {

--- a/src/dataflow/operators/broadcast.rs
+++ b/src/dataflow/operators/broadcast.rs
@@ -5,11 +5,11 @@
 
 // use communication::Pull;
 
-use ::ExchangeData;
+use crate::ExchangeData;
 // use progress::{Source, Target};
 // use progress::{Timestamp, Operate, operate::{Schedule, SharedProgress}, Antichain};
-use dataflow::{Stream, Scope};
-use dataflow::operators::{Map, Exchange};
+use crate::dataflow::{Stream, Scope};
+use crate::dataflow::operators::{Map, Exchange};
 
 // use dataflow::channels::{Message, Bundle};
 // use dataflow::channels::pushers::Counter as PushCounter;

--- a/src/dataflow/operators/capability.rs
+++ b/src/dataflow/operators/capability.rs
@@ -26,9 +26,9 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use std::fmt::{self, Debug};
 
-use order::PartialOrder;
-use progress::Timestamp;
-use progress::ChangeBatch;
+use crate::order::PartialOrder;
+use crate::progress::Timestamp;
+use crate::progress::ChangeBatch;
 
 /// An internal trait expressing the capability to send messages with a given timestamp.
 pub trait CapabilityTrait<T: Timestamp> {

--- a/src/dataflow/operators/capture/capture.rs
+++ b/src/dataflow/operators/capture/capture.rs
@@ -8,14 +8,14 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use ::Data;
-use dataflow::{Scope, Stream};
-use dataflow::channels::pact::Pipeline;
-use dataflow::channels::pullers::Counter as PullCounter;
-use dataflow::operators::generic::builder_raw::OperatorBuilder;
+use crate::Data;
+use crate::dataflow::{Scope, Stream};
+use crate::dataflow::channels::pact::Pipeline;
+use crate::dataflow::channels::pullers::Counter as PullCounter;
+use crate::dataflow::operators::generic::builder_raw::OperatorBuilder;
 
-use progress::ChangeBatch;
-use progress::Timestamp;
+use crate::progress::ChangeBatch;
+use crate::progress::Timestamp;
 
 use super::{Event, EventPusher};
 
@@ -140,7 +140,7 @@ impl<S: Scope, D: Data> Capture<S::Timestamp, D> for Stream<S, D> {
             },
             move |consumed, _internal, _external| {
 
-                use communication::message::RefOrMut;
+                use crate::communication::message::RefOrMut;
 
                 // turn each received message into an event.
                 let mut borrow = event_pusher2.borrow_mut();

--- a/src/dataflow/operators/capture/replay.rs
+++ b/src/dataflow/operators/capture/replay.rs
@@ -38,12 +38,12 @@
 //! allowing the replay to occur in a timely dataflow computation with more or fewer workers
 //! than that in which the stream was captured.
 
-use ::Data;
-use dataflow::{Scope, Stream};
-use dataflow::channels::pushers::Counter as PushCounter;
-use dataflow::channels::pushers::buffer::Buffer as PushBuffer;
-use dataflow::operators::generic::builder_raw::OperatorBuilder;
-use progress::Timestamp;
+use crate::Data;
+use crate::dataflow::{Scope, Stream};
+use crate::dataflow::channels::pushers::Counter as PushCounter;
+use crate::dataflow::channels::pushers::buffer::Buffer as PushBuffer;
+use crate::dataflow::operators::generic::builder_raw::OperatorBuilder;
+use crate::progress::Timestamp;
 
 use super::Event;
 use super::event::EventIterator;

--- a/src/dataflow/operators/concat.rs
+++ b/src/dataflow/operators/concat.rs
@@ -1,9 +1,9 @@
 //! Merges the contents of multiple streams.
 
 
-use Data;
-use dataflow::channels::pact::Pipeline;
-use dataflow::{Stream, Scope};
+use crate::Data;
+use crate::dataflow::channels::pact::Pipeline;
+use crate::dataflow::{Stream, Scope};
 
 /// Merge the contents of two streams.
 pub trait Concat<G: Scope, D: Data> {
@@ -20,7 +20,7 @@ pub trait Concat<G: Scope, D: Data> {
     ///           .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn concat(&self, &Stream<G, D>) -> Stream<G, D>;
+    fn concat(&self, _: &Stream<G, D>) -> Stream<G, D>;
 }
 
 impl<G: Scope, D: Data> Concat<G, D> for Stream<G, D> {
@@ -47,14 +47,14 @@ pub trait Concatenate<G: Scope, D: Data> {
     ///          .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn concatenate(&self, impl IntoIterator<Item=Stream<G, D>>) -> Stream<G, D>;
+    fn concatenate(&self, _: impl IntoIterator<Item=Stream<G, D>>) -> Stream<G, D>;
 }
 
 impl<G: Scope, D: Data> Concatenate<G, D> for G {
     fn concatenate(&self, sources: impl IntoIterator<Item=Stream<G, D>>) -> Stream<G, D> {
 
         // create an operator builder.
-        use dataflow::operators::generic::builder_rc::OperatorBuilder;
+        use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
         let mut builder = OperatorBuilder::new("Concatenate".to_string(), self.clone());
 
         // create new input handles for each input stream.

--- a/src/dataflow/operators/count.rs
+++ b/src/dataflow/operators/count.rs
@@ -1,12 +1,12 @@
 //! Counts the number of records at each time.
 use std::collections::HashMap;
 
-use communication::message::RefOrMut;
+use crate::communication::message::RefOrMut;
 
-use Data;
-use dataflow::channels::pact::Pipeline;
-use dataflow::{Stream, Scope};
-use dataflow::operators::generic::operator::Operator;
+use crate::Data;
+use crate::dataflow::channels::pact::Pipeline;
+use crate::dataflow::{Stream, Scope};
+use crate::dataflow::operators::generic::operator::Operator;
 
 /// Accumulates records within a timestamp.
 pub trait Accumulate<G: Scope, D: Data> {

--- a/src/dataflow/operators/delay.rs
+++ b/src/dataflow/operators/delay.rs
@@ -2,11 +2,11 @@
 
 use std::collections::HashMap;
 
-use Data;
-use order::{PartialOrder, TotalOrder};
-use dataflow::channels::pact::Pipeline;
-use dataflow::{Stream, Scope};
-use dataflow::operators::generic::operator::Operator;
+use crate::Data;
+use crate::order::{PartialOrder, TotalOrder};
+use crate::dataflow::channels::pact::Pipeline;
+use crate::dataflow::{Stream, Scope};
+use crate::dataflow::operators::generic::operator::Operator;
 
 /// Methods to advance the timestamps of records or batches of records.
 pub trait Delay<G: Scope, D: Data> {

--- a/src/dataflow/operators/enterleave.rs
+++ b/src/dataflow/operators/enterleave.rs
@@ -23,19 +23,19 @@
 
 use std::marker::PhantomData;
 
-use progress::Timestamp;
-use progress::timestamp::Refines;
-use progress::{Source, Target};
-use order::Product;
-use Data;
-use communication::Push;
-use dataflow::channels::pushers::{Counter, Tee};
-use dataflow::channels::{Bundle, Message};
+use crate::progress::Timestamp;
+use crate::progress::timestamp::Refines;
+use crate::progress::{Source, Target};
+use crate::order::Product;
+use crate::Data;
+use crate::communication::Push;
+use crate::dataflow::channels::pushers::{Counter, Tee};
+use crate::dataflow::channels::{Bundle, Message};
 
-use worker::AsWorker;
-use dataflow::{Stream, Scope};
-use dataflow::scopes::{Child, ScopeParent};
-use dataflow::operators::delay::Delay;
+use crate::worker::AsWorker;
+use crate::dataflow::{Stream, Scope};
+use crate::dataflow::scopes::{Child, ScopeParent};
+use crate::dataflow::operators::delay::Delay;
 
 /// Extension trait to move a `Stream` into a child of its current `Scope`.
 pub trait Enter<G: Scope, T: Timestamp+Refines<G::Timestamp>, D: Data> {
@@ -53,10 +53,10 @@ pub trait Enter<G: Scope, T: Timestamp+Refines<G::Timestamp>, D: Data> {
     ///     });
     /// });
     /// ```
-    fn enter<'a>(&self, &Child<'a, G, T>) -> Stream<Child<'a, G, T>, D>;
+    fn enter<'a>(&self, _: &Child<'a, G, T>) -> Stream<Child<'a, G, T>, D>;
 }
 
-use dataflow::scopes::child::Iterative;
+use crate::dataflow::scopes::child::Iterative;
 
 /// Extension trait to move a `Stream` into a child of its current `Scope` setting the timestamp for each element.
 pub trait EnterAt<G: Scope, T: Timestamp, D: Data> {

--- a/src/dataflow/operators/exchange.rs
+++ b/src/dataflow/operators/exchange.rs
@@ -1,11 +1,11 @@
 //! Exchange records between workers.
 
-use ::ExchangeData;
-use dataflow::channels::pact::Exchange as ExchangePact;
+use crate::ExchangeData;
+use crate::dataflow::channels::pact::Exchange as ExchangePact;
 // use dataflow::channels::pact::TimeExchange as TimeExchangePact;
-use dataflow::{Stream, Scope};
-use dataflow::operators::generic::operator::Operator;
-use progress::timestamp::Timestamp;
+use crate::dataflow::{Stream, Scope};
+use crate::dataflow::operators::generic::operator::Operator;
+use crate::progress::timestamp::Timestamp;
 
 /// Exchange records between workers.
 pub trait Exchange<T, D: ExchangeData> {

--- a/src/dataflow/operators/feedback.rs
+++ b/src/dataflow/operators/feedback.rs
@@ -1,17 +1,17 @@
 //! Create cycles in a timely dataflow graph.
 
-use Data;
+use crate::Data;
 
-use progress::{Timestamp, PathSummary};
-use progress::frontier::Antichain;
-use order::Product;
+use crate::progress::{Timestamp, PathSummary};
+use crate::progress::frontier::Antichain;
+use crate::order::Product;
 
-use dataflow::channels::pushers::Tee;
-use dataflow::channels::pact::Pipeline;
-use dataflow::{Stream, Scope};
-use dataflow::scopes::child::Iterative;
-use dataflow::operators::generic::builder_rc::OperatorBuilder;
-use dataflow::operators::generic::OutputWrapper;
+use crate::dataflow::channels::pushers::Tee;
+use crate::dataflow::channels::pact::Pipeline;
+use crate::dataflow::{Stream, Scope};
+use crate::dataflow::scopes::child::Iterative;
+use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
+use crate::dataflow::operators::generic::OutputWrapper;
 
 /// Creates a `Stream` and a `Handle` to later bind the source of that `Stream`.
 pub trait Feedback<G: Scope> {
@@ -102,7 +102,7 @@ pub trait ConnectLoop<G: Scope, D: Data> {
     ///            .connect_loop(handle);
     /// });
     /// ```
-    fn connect_loop(&self, Handle<G, D>);
+    fn connect_loop(&self, _: Handle<G, D>);
 }
 
 impl<G: Scope, D: Data> ConnectLoop<G, D> for Stream<G, D> {

--- a/src/dataflow/operators/filter.rs
+++ b/src/dataflow/operators/filter.rs
@@ -1,9 +1,9 @@
 //! Filters a stream by a predicate.
 
-use Data;
-use dataflow::channels::pact::Pipeline;
-use dataflow::{Stream, Scope};
-use dataflow::operators::generic::operator::Operator;
+use crate::Data;
+use crate::dataflow::channels::pact::Pipeline;
+use crate::dataflow::{Stream, Scope};
+use crate::dataflow::operators::generic::operator::Operator;
 
 /// Extension trait for filtering.
 pub trait Filter<D: Data> {

--- a/src/dataflow/operators/flow_controlled.rs
+++ b/src/dataflow/operators/flow_controlled.rs
@@ -1,10 +1,10 @@
 //! Methods to construct flow-controlled sources.
 
-use ::Data;
-use order::{PartialOrder, TotalOrder};
-use dataflow::operators::generic::operator::source;
-use dataflow::operators::probe::Handle;
-use dataflow::{Stream, Scope};
+use crate::Data;
+use crate::order::{PartialOrder, TotalOrder};
+use crate::dataflow::operators::generic::operator::source;
+use crate::dataflow::operators::probe::Handle;
+use crate::dataflow::{Stream, Scope};
 
 /// Output of the input reading function for iterator_source.
 pub struct IteratorSourceInput<T: Clone, D: Data, DI: IntoIterator<Item=D>, I: IntoIterator<Item=(T, DI)>> {

--- a/src/dataflow/operators/generic/builder_raw.rs
+++ b/src/dataflow/operators/generic/builder_raw.rs
@@ -8,18 +8,18 @@ use std::default::Default;
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use ::Data;
+use crate::Data;
 
-use scheduling::{Schedule, Activations};
+use crate::scheduling::{Schedule, Activations};
 
-use progress::{Source, Target};
-use progress::ChangeBatch;
-use progress::{Timestamp, Operate, operate::SharedProgress, Antichain};
+use crate::progress::{Source, Target};
+use crate::progress::ChangeBatch;
+use crate::progress::{Timestamp, Operate, operate::SharedProgress, Antichain};
 
-use dataflow::{Stream, Scope};
-use dataflow::channels::pushers::Tee;
-use dataflow::channels::pact::ParallelizationContract;
-use dataflow::operators::generic::operator_info::OperatorInfo;
+use crate::dataflow::{Stream, Scope};
+use crate::dataflow::channels::pushers::Tee;
+use crate::dataflow::channels::pact::ParallelizationContract;
+use crate::dataflow::operators::generic::operator_info::OperatorInfo;
 
 /// Contains type-free information about the operator properties.
 pub struct OperatorShape {

--- a/src/dataflow/operators/generic/builder_rc.rs
+++ b/src/dataflow/operators/generic/builder_rc.rs
@@ -4,23 +4,23 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use std::default::Default;
 
-use ::Data;
+use crate::Data;
 
-use progress::{ChangeBatch, Timestamp};
-use progress::frontier::{Antichain, MutableAntichain};
+use crate::progress::{ChangeBatch, Timestamp};
+use crate::progress::frontier::{Antichain, MutableAntichain};
 
-use dataflow::{Stream, Scope};
-use dataflow::channels::pushers::Tee;
-use dataflow::channels::pushers::Counter as PushCounter;
-use dataflow::channels::pushers::buffer::Buffer as PushBuffer;
-use dataflow::channels::pact::ParallelizationContract;
-use dataflow::channels::pullers::Counter as PullCounter;
-use dataflow::operators::capability::Capability;
-use dataflow::operators::capability::mint as mint_capability;
-use dataflow::operators::generic::handles::{InputHandle, new_input_handle, OutputWrapper};
-use dataflow::operators::generic::operator_info::OperatorInfo;
+use crate::dataflow::{Stream, Scope};
+use crate::dataflow::channels::pushers::Tee;
+use crate::dataflow::channels::pushers::Counter as PushCounter;
+use crate::dataflow::channels::pushers::buffer::Buffer as PushBuffer;
+use crate::dataflow::channels::pact::ParallelizationContract;
+use crate::dataflow::channels::pullers::Counter as PullCounter;
+use crate::dataflow::operators::capability::Capability;
+use crate::dataflow::operators::capability::mint as mint_capability;
+use crate::dataflow::operators::generic::handles::{InputHandle, new_input_handle, OutputWrapper};
+use crate::dataflow::operators::generic::operator_info::OperatorInfo;
 
-use logging::TimelyLogger as Logger;
+use crate::logging::TimelyLogger as Logger;
 
 use super::builder_raw::OperatorBuilder as OperatorBuilderRaw;
 
@@ -185,9 +185,9 @@ mod tests {
         // This tests that if we attempt to use a capability associated with the
         // wrong output, there is a run-time assertion.
 
-        use ::dataflow::operators::generic::builder_rc::OperatorBuilder;
+        use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
 
-        ::example(|scope| {
+        crate::example(|scope| {
 
             let mut builder = OperatorBuilder::new("Failure".to_owned(), scope.clone());
 
@@ -215,9 +215,9 @@ mod tests {
         // This tests that if we attempt to use capabilities with the correct outputs
         // there is no runtime assertion
 
-        use ::dataflow::operators::generic::builder_rc::OperatorBuilder;
+        use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
 
-        ::example(|scope| {
+        crate::example(|scope| {
 
             let mut builder = OperatorBuilder::new("Failure".to_owned(), scope.clone());
 

--- a/src/dataflow/operators/generic/handles.rs
+++ b/src/dataflow/operators/generic/handles.rs
@@ -6,20 +6,20 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use ::Data;
-use progress::Timestamp;
-use progress::ChangeBatch;
-use progress::frontier::MutableAntichain;
-use dataflow::channels::pullers::Counter as PullCounter;
-use dataflow::channels::pushers::Counter as PushCounter;
-use dataflow::channels::pushers::buffer::{Buffer, Session};
-use dataflow::channels::Bundle;
-use communication::{Push, Pull, message::RefOrMut};
-use logging::TimelyLogger as Logger;
+use crate::Data;
+use crate::progress::Timestamp;
+use crate::progress::ChangeBatch;
+use crate::progress::frontier::MutableAntichain;
+use crate::dataflow::channels::pullers::Counter as PullCounter;
+use crate::dataflow::channels::pushers::Counter as PushCounter;
+use crate::dataflow::channels::pushers::buffer::{Buffer, Session};
+use crate::dataflow::channels::Bundle;
+use crate::communication::{Push, Pull, message::RefOrMut};
+use crate::logging::TimelyLogger as Logger;
 
-use dataflow::operators::CapabilityRef;
-use dataflow::operators::capability::mint_ref as mint_capability_ref;
-use dataflow::operators::capability::CapabilityTrait;
+use crate::dataflow::operators::CapabilityRef;
+use crate::dataflow::operators::capability::mint_ref as mint_capability_ref;
+use crate::dataflow::operators::capability::CapabilityTrait;
 
 /// Handle to an operator's input stream.
 pub struct InputHandle<T: Timestamp, D, P: Pull<Bundle<T, D>>> {
@@ -78,9 +78,9 @@ impl<'a, T: Timestamp, D: Data, P: Pull<Bundle<T, D>>> InputHandle<T, D, P> {
     pub fn for_each<F: FnMut(CapabilityRef<T>, RefOrMut<Vec<D>>)>(&mut self, mut logic: F) {
         let mut logging = self.logging.clone();
         while let Some((cap, data)) = self.next() {
-            logging.as_mut().map(|l| l.log(::logging::GuardedMessageEvent { is_start: true }));
+            logging.as_mut().map(|l| l.log(crate::logging::GuardedMessageEvent { is_start: true }));
             logic(cap, data);
-            logging.as_mut().map(|l| l.log(::logging::GuardedMessageEvent { is_start: false }));
+            logging.as_mut().map(|l| l.log(crate::logging::GuardedMessageEvent { is_start: false }));
         }
     }
 

--- a/src/dataflow/operators/generic/notificator.rs
+++ b/src/dataflow/operators/generic/notificator.rs
@@ -1,7 +1,7 @@
-use progress::frontier::{AntichainRef, MutableAntichain};
-use progress::Timestamp;
-use dataflow::operators::Capability;
-use logging::TimelyLogger as Logger;
+use crate::progress::frontier::{AntichainRef, MutableAntichain};
+use crate::progress::Timestamp;
+use crate::dataflow::operators::Capability;
+use crate::logging::TimelyLogger as Logger;
 
 /// Tracks requests for notification and delivers available notifications.
 ///
@@ -80,9 +80,9 @@ impl<'a, T: Timestamp> Notificator<'a, T> {
     #[inline]
     pub fn for_each<F: FnMut(Capability<T>, u64, &mut Notificator<T>)>(&mut self, mut logic: F) {
         while let Some((cap, count)) = self.next() {
-            self.logging.as_ref().map(|l| l.log(::logging::GuardedProgressEvent { is_start: true }));
+            self.logging.as_ref().map(|l| l.log(crate::logging::GuardedProgressEvent { is_start: true }));
             logic(cap, count, self);
-            self.logging.as_ref().map(|l| l.log(::logging::GuardedProgressEvent { is_start: false }));
+            self.logging.as_ref().map(|l| l.log(crate::logging::GuardedProgressEvent { is_start: false }));
         }
     }
 }
@@ -106,10 +106,10 @@ impl<'a, T: Timestamp> Iterator for Notificator<'a, T> {
 fn notificator_delivers_notifications_in_topo_order() {
     use std::rc::Rc;
     use std::cell::RefCell;
-    use progress::ChangeBatch;
-    use progress::frontier::MutableAntichain;
-    use order::Product;
-    use dataflow::operators::capability::mint as mint_capability;
+    use crate::progress::ChangeBatch;
+    use crate::progress::frontier::MutableAntichain;
+    use crate::order::Product;
+    use crate::dataflow::operators::capability::mint as mint_capability;
 
     let mut frontier = MutableAntichain::new_bottom(Product::new(0, 0));
 

--- a/src/dataflow/operators/generic/operator.rs
+++ b/src/dataflow/operators/generic/operator.rs
@@ -1,19 +1,19 @@
 
 //! Methods to construct generic streaming and blocking unary operators.
 
-use dataflow::channels::pushers::Tee;
-use dataflow::channels::pact::ParallelizationContract;
+use crate::dataflow::channels::pushers::Tee;
+use crate::dataflow::channels::pact::ParallelizationContract;
 
-use dataflow::operators::generic::handles::{InputHandle, FrontieredInputHandle, OutputHandle};
-use dataflow::operators::capability::Capability;
+use crate::dataflow::operators::generic::handles::{InputHandle, FrontieredInputHandle, OutputHandle};
+use crate::dataflow::operators::capability::Capability;
 
-use ::Data;
+use crate::Data;
 
-use dataflow::{Stream, Scope};
+use crate::dataflow::{Stream, Scope};
 
 use super::builder_rc::OperatorBuilder;
-use dataflow::operators::generic::OperatorInfo;
-use dataflow::operators::generic::notificator::{Notificator, FrontierNotificator};
+use crate::dataflow::operators::generic::OperatorInfo;
+use crate::dataflow::operators::generic::notificator::{Notificator, FrontierNotificator};
 
 /// Methods to construct generic streaming and blocking operators.
 pub trait Operator<G: Scope, D1: Data> {

--- a/src/dataflow/operators/generic/unary.rs
+++ b/src/dataflow/operators/generic/unary.rs
@@ -1,15 +1,15 @@
 //! Methods to construct generic streaming and blocking unary operators.
 
-use dataflow::operators::generic::{Notificator, FrontierNotificator};
-use dataflow::channels::pushers::Tee;
-use dataflow::channels::pact::ParallelizationContract;
+use crate::dataflow::operators::generic::{Notificator, FrontierNotificator};
+use crate::dataflow::channels::pushers::Tee;
+use crate::dataflow::channels::pact::ParallelizationContract;
 
-use dataflow::operators::generic::Operator as GenericOperator;
-use dataflow::operators::generic::handles::{InputHandle, OutputHandle};
+use crate::dataflow::operators::generic::Operator as GenericOperator;
+use crate::dataflow::operators::generic::handles::{InputHandle, OutputHandle};
 
-use ::Data;
+use crate::Data;
 
-use dataflow::{Stream, Scope};
+use crate::dataflow::{Stream, Scope};
 
 /// Methods to construct generic streaming and blocking unary operators.
 pub trait Unary<G: Scope, D1: Data> {

--- a/src/dataflow/operators/input.rs
+++ b/src/dataflow/operators/input.rs
@@ -4,16 +4,16 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use std::default::Default;
 
-use scheduling::{Schedule, Activator};
+use crate::scheduling::{Schedule, Activator};
 
-use progress::frontier::Antichain;
-use progress::{Operate, operate::SharedProgress, Timestamp, ChangeBatch};
-use progress::Source;
+use crate::progress::frontier::Antichain;
+use crate::progress::{Operate, operate::SharedProgress, Timestamp, ChangeBatch};
+use crate::progress::Source;
 
-use Data;
-use communication::Push;
-use dataflow::{Stream, ScopeParent, Scope};
-use dataflow::channels::{Message, pushers::{Tee, Counter}};
+use crate::Data;
+use crate::communication::Push;
+use crate::dataflow::{Stream, ScopeParent, Scope};
+use crate::dataflow::channels::{Message, pushers::{Tee, Counter}};
 
 // TODO : This is an exogenous input, but it would be nice to wrap a Subgraph in something
 // TODO : more like a harness, with direct access to its inputs.
@@ -92,7 +92,7 @@ pub trait Input : Scope {
     fn input_from<D: Data>(&mut self, handle: &mut Handle<<Self as ScopeParent>::Timestamp, D>) -> Stream<Self, D>;
 }
 
-use order::TotalOrder;
+use crate::order::TotalOrder;
 impl<G: Scope> Input for G where <G as ScopeParent>::Timestamp: TotalOrder {
     fn new_input<D: Data>(&mut self) -> (Handle<<G as ScopeParent>::Timestamp, D>, Stream<G, D>) {
         let mut handle = Handle::new();

--- a/src/dataflow/operators/inspect.rs
+++ b/src/dataflow/operators/inspect.rs
@@ -1,9 +1,9 @@
 //! Extension trait and implementation for observing and action on streamed data.
 
-use Data;
-use dataflow::channels::pact::Pipeline;
-use dataflow::{Stream, Scope};
-use dataflow::operators::generic::Operator;
+use crate::Data;
+use crate::dataflow::channels::pact::Pipeline;
+use crate::dataflow::{Stream, Scope};
+use crate::dataflow::operators::generic::Operator;
 
 /// Methods to inspect records and batches of records on a stream.
 pub trait Inspect<G: Scope, D: Data> {

--- a/src/dataflow/operators/map.rs
+++ b/src/dataflow/operators/map.rs
@@ -1,9 +1,9 @@
 //! Extension methods for `Stream` based on record-by-record transformation.
 
-use Data;
-use dataflow::{Stream, Scope};
-use dataflow::channels::pact::Pipeline;
-use dataflow::operators::generic::operator::Operator;
+use crate::Data;
+use crate::dataflow::{Stream, Scope};
+use crate::dataflow::channels::pact::Pipeline;
+use crate::dataflow::operators::generic::operator::Operator;
 
 /// Extension trait for `Stream`.
 pub trait Map<S: Scope, D: Data> {

--- a/src/dataflow/operators/partition.rs
+++ b/src/dataflow/operators/partition.rs
@@ -1,9 +1,9 @@
 //! Partition a stream of records into multiple streams.
 
-use dataflow::channels::pact::Pipeline;
-use dataflow::operators::generic::builder_rc::OperatorBuilder;
-use dataflow::{Scope, Stream};
-use Data;
+use crate::dataflow::channels::pact::Pipeline;
+use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
+use crate::dataflow::{Scope, Stream};
+use crate::Data;
 
 /// Partition a stream of records into multiple streams.
 pub trait Partition<G: Scope, D: Data, D2: Data, F: Fn(D)->(u64, D2)> {

--- a/src/dataflow/operators/probe.rs
+++ b/src/dataflow/operators/probe.rs
@@ -3,17 +3,17 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use progress::Timestamp;
-use progress::frontier::{AntichainRef, MutableAntichain};
-use dataflow::channels::pushers::Counter as PushCounter;
-use dataflow::channels::pushers::buffer::Buffer as PushBuffer;
-use dataflow::channels::pact::Pipeline;
-use dataflow::channels::pullers::Counter as PullCounter;
-use dataflow::operators::generic::builder_raw::OperatorBuilder;
+use crate::progress::Timestamp;
+use crate::progress::frontier::{AntichainRef, MutableAntichain};
+use crate::dataflow::channels::pushers::Counter as PushCounter;
+use crate::dataflow::channels::pushers::buffer::Buffer as PushBuffer;
+use crate::dataflow::channels::pact::Pipeline;
+use crate::dataflow::channels::pullers::Counter as PullCounter;
+use crate::dataflow::operators::generic::builder_raw::OperatorBuilder;
 
 
-use Data;
-use dataflow::{Stream, Scope};
+use crate::Data;
+use crate::dataflow::{Stream, Scope};
 
 /// Monitors progress at a `Stream`.
 pub trait Probe<G: Scope, D: Data> {
@@ -111,7 +111,7 @@ impl<G: Scope, D: Data> Probe<G, D> for Stream<G, D> {
                     started = true;
                 }
 
-                use communication::message::RefOrMut;
+                use crate::communication::message::RefOrMut;
 
                 while let Some(message) = input.next() {
                     let (time, data) = match message.as_ref_or_mut() {
@@ -180,14 +180,14 @@ impl<T: Timestamp> Clone for Handle<T> {
 #[cfg(test)]
 mod tests {
 
-    use ::communication::Configuration;
-    use dataflow::operators::{Input, Probe};
+    use crate::communication::Configuration;
+    use crate::dataflow::operators::{Input, Probe};
 
     #[test]
     fn probe() {
 
         // initializes and runs a timely dataflow computation
-        ::execute(Configuration::Thread, |worker| {
+        crate::execute(Configuration::Thread, |worker| {
 
             // create a new input, and inspect its output
             let (mut input, probe) = worker.dataflow(move |scope| {

--- a/src/dataflow/operators/reclock.rs
+++ b/src/dataflow/operators/reclock.rs
@@ -1,10 +1,10 @@
 //! Extension methods for `Stream` based on record-by-record transformation.
 
-use Data;
-use order::PartialOrder;
-use dataflow::{Stream, Scope};
-use dataflow::channels::pact::Pipeline;
-use dataflow::operators::generic::operator::Operator;
+use crate::Data;
+use crate::order::PartialOrder;
+use crate::dataflow::{Stream, Scope};
+use crate::dataflow::channels::pact::Pipeline;
+use crate::dataflow::operators::generic::operator::Operator;
 
 /// Extension trait for reclocking a stream.
 pub trait Reclock<S: Scope, D: Data> {

--- a/src/dataflow/operators/to_stream.rs
+++ b/src/dataflow/operators/to_stream.rs
@@ -1,11 +1,11 @@
 //! Conversion to the `Stream` type from iterators.
 
-use progress::Timestamp;
+use crate::progress::Timestamp;
 
-use Data;
-use dataflow::channels::Message;
-use dataflow::operators::generic::operator::source;
-use dataflow::{Stream, Scope};
+use crate::Data;
+use crate::dataflow::channels::Message;
+use crate::dataflow::operators::generic::operator::source;
+use crate::dataflow::{Stream, Scope};
 
 /// Converts to a timely `Stream`.
 pub trait ToStream<T: Timestamp, D: Data> {

--- a/src/dataflow/operators/unordered_input.rs
+++ b/src/dataflow/operators/unordered_input.rs
@@ -4,21 +4,21 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use std::default::Default;
 
-use scheduling::{Schedule, Activations, ActivateOnDrop};
+use crate::scheduling::{Schedule, Activations, ActivateOnDrop};
 
-use progress::frontier::Antichain;
-use progress::{Operate, operate::SharedProgress, Timestamp};
-use progress::Source;
-use progress::ChangeBatch;
+use crate::progress::frontier::Antichain;
+use crate::progress::{Operate, operate::SharedProgress, Timestamp};
+use crate::progress::Source;
+use crate::progress::ChangeBatch;
 
-use Data;
-use dataflow::channels::pushers::{Tee, Counter as PushCounter};
-use dataflow::channels::pushers::buffer::{Buffer as PushBuffer, AutoflushSession};
+use crate::Data;
+use crate::dataflow::channels::pushers::{Tee, Counter as PushCounter};
+use crate::dataflow::channels::pushers::buffer::{Buffer as PushBuffer, AutoflushSession};
 
-use dataflow::operators::Capability;
-use dataflow::operators::capability::mint as mint_capability;
+use crate::dataflow::operators::Capability;
+use crate::dataflow::operators::capability::mint as mint_capability;
 
-use dataflow::{Stream, Scope};
+use crate::dataflow::{Stream, Scope};
 
 /// Create a new `Stream` and `Handle` through which to supply input.
 pub trait UnorderedInput<G: Scope> {

--- a/src/dataflow/scopes/child.rs
+++ b/src/dataflow/scopes/child.rs
@@ -3,16 +3,16 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use communication::{Data, Push, Pull};
-use communication::allocator::thread::{ThreadPusher, ThreadPuller};
-use scheduling::Scheduler;
-use scheduling::activate::Activations;
-use progress::{Timestamp, Operate, SubgraphBuilder};
-use progress::{Source, Target};
-use progress::timestamp::Refines;
-use order::Product;
-use logging::TimelyLogger as Logger;
-use worker::AsWorker;
+use crate::communication::{Data, Push, Pull};
+use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
+use crate::scheduling::Scheduler;
+use crate::scheduling::activate::Activations;
+use crate::progress::{Timestamp, Operate, SubgraphBuilder};
+use crate::progress::{Source, Target};
+use crate::progress::timestamp::Refines;
+use crate::order::Product;
+use crate::logging::TimelyLogger as Logger;
+use crate::worker::AsWorker;
 
 use super::{ScopeParent, Scope};
 
@@ -63,7 +63,7 @@ where
     fn new_identifier(&mut self) -> usize {
         self.parent.new_identifier()
     }
-    fn log_register(&self) -> ::std::cell::RefMut<::logging_core::Registry<::logging::WorkerIdentifier>> {
+    fn log_register(&self) -> ::std::cell::RefMut<crate::logging_core::Registry<crate::logging::WorkerIdentifier>> {
         self.parent.log_register()
     }
 }
@@ -131,7 +131,7 @@ where
     }
 }
 
-use communication::Message;
+use crate::communication::Message;
 
 impl<'a, G, T> Clone for Child<'a, G, T>
 where

--- a/src/dataflow/scopes/mod.rs
+++ b/src/dataflow/scopes/mod.rs
@@ -1,10 +1,10 @@
 //! Hierarchical organization of timely dataflow graphs.
 
-use progress::{Timestamp, Operate, Source, Target};
-use order::Product;
-use progress::timestamp::Refines;
-use communication::Allocate;
-use worker::AsWorker;
+use crate::progress::{Timestamp, Operate, Source, Target};
+use crate::order::Product;
+use crate::progress::timestamp::Refines;
+use crate::communication::Allocate;
+use crate::worker::AsWorker;
 
 pub mod child;
 
@@ -16,7 +16,7 @@ pub trait ScopeParent: AsWorker+Clone {
     type Timestamp : Timestamp;
 }
 
-impl<A: Allocate> ScopeParent for ::worker::Worker<A> {
+impl<A: Allocate> ScopeParent for crate::worker::Worker<A> {
     type Timestamp = ();
 }
 

--- a/src/dataflow/stream.rs
+++ b/src/dataflow/stream.rs
@@ -4,12 +4,12 @@
 //! operator output. Extension methods on the `Stream` type provide the appearance of higher-level
 //! declarative programming, while constructing a dataflow graph underneath.
 
-use progress::{Source, Target};
+use crate::progress::{Source, Target};
 
-use communication::Push;
-use dataflow::Scope;
-use dataflow::channels::pushers::tee::TeeHelper;
-use dataflow::channels::Bundle;
+use crate::communication::Push;
+use crate::dataflow::Scope;
+use crate::dataflow::channels::pushers::tee::TeeHelper;
+use crate::dataflow::channels::Bundle;
 
 // use dataflow::scopes::root::loggers::CHANNELS_Q;
 
@@ -35,7 +35,7 @@ impl<S: Scope, D> Stream<S, D> {
     pub fn connect_to<P: Push<Bundle<S::Timestamp, D>>+'static>(&self, target: Target, pusher: P, identifier: usize) {
 
         let mut logging = self.scope().logging();
-        logging.as_mut().map(|l| l.log(::logging::ChannelsEvent {
+        logging.as_mut().map(|l| l.log(crate::logging::ChannelsEvent {
             id: identifier,
             scope_addr: self.scope.addr(),
             source: (self.name.index, self.name.port),

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1,8 +1,8 @@
 //! Starts a timely dataflow execution from configuration information and per-worker logic.
 
-use communication::{initialize, initialize_from, Configuration, Allocator, allocator::AllocateBuilder, WorkerGuards};
-use dataflow::scopes::Child;
-use worker::Worker;
+use crate::communication::{initialize, initialize_from, Configuration, Allocator, allocator::AllocateBuilder, WorkerGuards};
+use crate::dataflow::scopes::Child;
+use crate::worker::Worker;
 // use logging::{LoggerConfig, TimelyLogger};
 
 /// Executes a single-threaded timely dataflow computation.
@@ -129,15 +129,15 @@ where
             if let Ok(addr) = ::std::env::var("TIMELY_COMM_LOG_ADDR") {
 
                 use ::std::net::TcpStream;
-                use ::logging::BatchLogger;
-                use ::dataflow::operators::capture::EventWriter;
+                use crate::logging::BatchLogger;
+                use crate::dataflow::operators::capture::EventWriter;
 
                 eprintln!("enabled COMM logging to {}", addr);
 
                 if let Ok(stream) = TcpStream::connect(&addr) {
                     let writer = EventWriter::new(stream);
                     let mut logger = BatchLogger::new(writer);
-                    result = Some(::logging_core::Logger::new(
+                    result = Some(crate::logging_core::Logger::new(
                         ::std::time::Instant::now(),
                         events_setup,
                         move |time, data| logger.publish_batch(time, data)
@@ -161,8 +161,8 @@ where
         if let Ok(addr) = ::std::env::var("TIMELY_WORKER_LOG_ADDR") {
 
             use ::std::net::TcpStream;
-            use ::logging::{BatchLogger, TimelyEvent};
-            use ::dataflow::operators::capture::EventWriter;
+            use crate::logging::{BatchLogger, TimelyEvent};
+            use crate::dataflow::operators::capture::EventWriter;
 
             if let Ok(stream) = TcpStream::connect(&addr) {
                 let writer = EventWriter::new(stream);
@@ -235,7 +235,7 @@ pub fn execute_from_args<I, T, F>(iter: I, func: F) -> Result<WorkerGuards<T>,St
     where I: Iterator<Item=String>,
           T:Send+'static,
           F: Fn(&mut Worker<Allocator>)->T+Send+Sync+'static, {
-    let configuration = try!(Configuration::from_args(iter));
+    let configuration = Configuration::from_args(iter)?;
     execute(configuration, func)
 }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,12 +3,12 @@
 /// Type alias for logging timely events.
 pub type WorkerIdentifier = usize;
 /// Logger type for worker-local logging.
-pub type Logger<Event> = ::logging_core::Logger<Event, WorkerIdentifier>;
+pub type Logger<Event> = crate::logging_core::Logger<Event, WorkerIdentifier>;
 /// Logger for timely dataflow system events.
 pub type TimelyLogger = Logger<TimelyEvent>;
 
 use std::time::Duration;
-use dataflow::operators::capture::{Event, EventPusher};
+use crate::dataflow::operators::capture::{Event, EventPusher};
 
 /// Logs events as a timely stream, with progress statements.
 pub struct BatchLogger<T, E, P> where P: EventPusher<Duration, (Duration, E, T)> {

--- a/src/order.rs
+++ b/src/order.rs
@@ -50,8 +50,8 @@ implement_total!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, (), ::std::
 
 use std::fmt::{Formatter, Error, Debug};
 
-use progress::Timestamp;
-use progress::timestamp::Refines;
+use crate::progress::Timestamp;
+use crate::progress::timestamp::Refines;
 
 impl<TOuter: Timestamp, TInner: Timestamp> Refines<TOuter> for Product<TOuter, TInner> {
     fn to_inner(other: TOuter) -> Self {
@@ -105,7 +105,7 @@ impl<TOuter: Timestamp, TInner: Timestamp> Timestamp for Product<TOuter, TInner>
     type Summary = Product<TOuter::Summary, TInner::Summary>;
 }
 
-use progress::timestamp::PathSummary;
+use crate::progress::timestamp::PathSummary;
 impl<TOuter: Timestamp, TInner: Timestamp> PathSummary<Product<TOuter, TInner>> for Product<TOuter::Summary, TInner::Summary> {
     #[inline]
     fn results_in(&self, product: &Product<TOuter, TInner>) -> Option<Product<TOuter, TInner>> {

--- a/src/progress/broadcast.rs
+++ b/src/progress/broadcast.rs
@@ -1,9 +1,9 @@
 //! Broadcasts progress information among workers.
 
-use progress::{ChangeBatch, Timestamp};
-use progress::Location;
-use communication::{Message, Push, Pull};
-use logging::TimelyLogger as Logger;
+use crate::progress::{ChangeBatch, Timestamp};
+use crate::progress::Location;
+use crate::communication::{Message, Push, Pull};
+use crate::logging::TimelyLogger as Logger;
 
 /// A list of progress updates corresponding to `((child_scope, [in/out]_port, timestamp), delta)`
 pub type ProgressVec<T> = Vec<((Location, T), i64)>;
@@ -30,13 +30,13 @@ pub struct Progcaster<T:Timestamp> {
 
 impl<T:Timestamp+Send> Progcaster<T> {
     /// Creates a new `Progcaster` using a channel from the supplied worker.
-    pub fn new<A: ::worker::AsWorker>(worker: &mut A, path: &Vec<usize>, mut logging: Option<Logger>) -> Progcaster<T> {
+    pub fn new<A: crate::worker::AsWorker>(worker: &mut A, path: &Vec<usize>, mut logging: Option<Logger>) -> Progcaster<T> {
 
         let channel_identifier = worker.new_identifier();
         let (pushers, puller) = worker.allocate(channel_identifier, &path[..]);
-        logging.as_mut().map(|l| l.log(::logging::CommChannelsEvent {
+        logging.as_mut().map(|l| l.log(crate::logging::CommChannelsEvent {
             identifier: channel_identifier,
-            kind: ::logging::CommChannelKind::Progress,
+            kind: crate::logging::CommChannelKind::Progress,
         }));
         let worker_index = worker.index();
         let addr = path.clone();
@@ -58,7 +58,7 @@ impl<T:Timestamp+Send> Progcaster<T> {
         changes.compact();
         if !changes.is_empty() {
 
-            self.logging.as_ref().map(|l| l.log(::logging::ProgressEvent {
+            self.logging.as_ref().map(|l| l.log(crate::logging::ProgressEvent {
                 is_send: true,
                 source: self.source,
                 channel: self.channel_identifier,
@@ -108,7 +108,7 @@ impl<T:Timestamp+Send> Progcaster<T> {
 
             let addr = &mut self.addr;
             let channel = self.channel_identifier;
-            self.logging.as_ref().map(|l| l.log(::logging::ProgressEvent {
+            self.logging.as_ref().map(|l| l.log(crate::logging::ProgressEvent {
                 is_send: false,
                 source: source,
                 seq_no: counter,

--- a/src/progress/frontier.rs
+++ b/src/progress/frontier.rs
@@ -1,7 +1,7 @@
 //! Tracks minimal sets of mutually incomparable elements of a partial order.
 
-use progress::ChangeBatch;
-use order::PartialOrder;
+use crate::progress::ChangeBatch;
+use crate::order::PartialOrder;
 
 /// A set of mutually incomparable elements.
 ///

--- a/src/progress/operate.rs
+++ b/src/progress/operate.rs
@@ -3,8 +3,8 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use scheduling::Schedule;
-use progress::{Timestamp, ChangeBatch, Antichain};
+use crate::scheduling::Schedule;
+use crate::progress::{Timestamp, ChangeBatch, Antichain};
 
 /// Methods for describing an operators topology, and the progress it makes.
 pub trait Operate<T: Timestamp> : Schedule {

--- a/src/progress/reachability.rs
+++ b/src/progress/reachability.rs
@@ -75,13 +75,13 @@
 use std::collections::{BinaryHeap, HashMap, VecDeque};
 use std::cmp::Reverse;
 
-use progress::Timestamp;
-use progress::{Source, Target};
-use progress::ChangeBatch;
-use progress::{Location, Port};
+use crate::progress::Timestamp;
+use crate::progress::{Source, Target};
+use crate::progress::ChangeBatch;
+use crate::progress::{Location, Port};
 
-use progress::frontier::{Antichain, MutableAntichain};
-use progress::timestamp::PathSummary;
+use crate::progress::frontier::{Antichain, MutableAntichain};
+use crate::progress::timestamp::PathSummary;
 
 
 /// A topology builder, which can summarize reachability along paths.

--- a/src/progress/subgraph.rs
+++ b/src/progress/subgraph.rs
@@ -10,19 +10,19 @@ use std::cell::RefCell;
 use std::collections::BinaryHeap;
 use std::cmp::Reverse;
 
-use logging::TimelyLogger as Logger;
+use crate::logging::TimelyLogger as Logger;
 
-use scheduling::Schedule;
-use scheduling::activate::Activations;
+use crate::scheduling::Schedule;
+use crate::scheduling::activate::Activations;
 
-use progress::frontier::{Antichain, MutableAntichain, MutableAntichainFilter};
-use progress::{Timestamp, Operate, operate::SharedProgress};
-use progress::{Location, Port, Source, Target};
+use crate::progress::frontier::{Antichain, MutableAntichain, MutableAntichainFilter};
+use crate::progress::{Timestamp, Operate, operate::SharedProgress};
+use crate::progress::{Location, Port, Source, Target};
 
-use progress::ChangeBatch;
-use progress::broadcast::Progcaster;
-use progress::reachability;
-use progress::timestamp::Refines;
+use crate::progress::ChangeBatch;
+use crate::progress::broadcast::Progcaster;
+use crate::progress::reachability;
+use crate::progress::timestamp::Refines;
 
 // IMPORTANT : by convention, a child identifier of zero is used to indicate inputs and outputs of
 // the Subgraph itself. An identifier greater than zero corresponds to an actual child, which can
@@ -126,7 +126,7 @@ where
         {
             let mut child_path = self.path.clone();
             child_path.push(index);
-            self.logging.as_mut().map(|l| l.log(::logging::OperatesEvent {
+            self.logging.as_mut().map(|l| l.log(crate::logging::OperatesEvent {
                 id: identifier,
                 addr: child_path,
                 name: child.name().to_owned(),
@@ -136,7 +136,7 @@ where
     }
 
     /// Now that initialization is complete, actually build a subgraph.
-    pub fn build<A: ::worker::AsWorker>(mut self, worker: &mut A) -> Subgraph<TOuter, TInner> {
+    pub fn build<A: crate::worker::AsWorker>(mut self, worker: &mut A) -> Subgraph<TOuter, TInner> {
         // at this point, the subgraph is frozen. we should initialize any internal state which
         // may have been determined after construction (e.g. the numbers of inputs and outputs).
         // we also need to determine what to return as a summary and initial capabilities, which
@@ -447,7 +447,7 @@ where
         // Drain propagated information into shared progress structure.
         for ((location, time), diff) in self.pointstamp_tracker.pushed().drain() {
             // Targets are actionable, sources are not.
-            if let ::progress::Port::Target(port) = location.port {
+            if let crate::progress::Port::Target(port) = location.port {
                 if self.children[location.node].notify {
                     self.temp_active.push(Reverse(location.node));
                 }
@@ -637,17 +637,17 @@ impl<T: Timestamp> PerOperatorState<T> {
                 // TODO:  Perhaps fold this in to `ScheduleEvent::start()` as a "reason"?
                 let frontiers = &mut self.shared_progress.borrow_mut().frontiers[..];
                 if frontiers.iter_mut().any(|buffer| !buffer.is_empty()) {
-                    l.log(::logging::PushProgressEvent { op_id: self.id })
+                    l.log(crate::logging::PushProgressEvent { op_id: self.id })
                 }
 
-                l.log(::logging::ScheduleEvent::start(self.id));
+                l.log(crate::logging::ScheduleEvent::start(self.id));
             }
 
             let incomplete = operator.schedule();
 
             // Perhaps log information about the stop of the schedule call.
             if let Some(l) = self.logging.as_mut() {
-                l.log(::logging::ScheduleEvent::stop(self.id));
+                l.log(crate::logging::ScheduleEvent::stop(self.id));
             }
 
             incomplete

--- a/src/progress/timestamp.rs
+++ b/src/progress/timestamp.rs
@@ -5,8 +5,8 @@ use std::any::Any;
 use std::default::Default;
 use std::hash::Hash;
 
-use communication::Data;
-use order::PartialOrder;
+use crate::communication::Data;
+use crate::order::PartialOrder;
 
 /// A composite trait for types that serve as timestamps in timely dataflow.
 pub trait Timestamp: Clone+Eq+PartialOrder+Default+Debug+Send+Any+Data+Hash+Ord {
@@ -85,7 +85,7 @@ implement_timestamp_add!(usize, u64, u32, u16, u8, i32, ::std::time::Duration,);
 pub use self::refines::Refines;
 mod refines {
 
-    use progress::Timestamp;
+    use crate::progress::Timestamp;
 
     /// Conversion between pointstamp types.
     ///

--- a/src/synchronization/barrier.rs
+++ b/src/synchronization/barrier.rs
@@ -1,8 +1,8 @@
 //! Barrier synchronization.
 
-use ::communication::Allocate;
-use dataflow::{InputHandle, ProbeHandle};
-use worker::Worker;
+use crate::communication::Allocate;
+use crate::dataflow::{InputHandle, ProbeHandle};
+use crate::worker::Worker;
 
 /// A re-usable barrier synchronization mechanism.
 pub struct Barrier<A: Allocate> {
@@ -15,7 +15,7 @@ impl<A: Allocate> Barrier<A> {
 
     /// Allocates a new barrier.
     pub fn new(worker: &mut Worker<A>) -> Self {
-        use dataflow::operators::{Input, Probe};
+        use crate::dataflow::operators::{Input, Probe};
         let (input, probe) = worker.dataflow(|scope| {
             let (handle, stream) = scope.new_input::<()>();
             (handle, stream.probe())

--- a/src/synchronization/sequence.rs
+++ b/src/synchronization/sequence.rs
@@ -5,13 +5,13 @@ use std::cell::RefCell;
 use std::time::{Instant, Duration};
 use std::collections::VecDeque;
 
-use ::{communication::Allocate, ExchangeData, PartialOrder};
-use ::scheduling::Scheduler;
-use worker::Worker;
-use dataflow::channels::pact::Exchange;
-use dataflow::operators::generic::operator::source;
-use dataflow::operators::generic::operator::Operator;
-use scheduling::activate::Activator;
+use crate::{communication::Allocate, ExchangeData, PartialOrder};
+use crate::scheduling::Scheduler;
+use crate::worker::Worker;
+use crate::dataflow::channels::pact::Exchange;
+use crate::dataflow::operators::generic::operator::source;
+use crate::dataflow::operators::generic::operator::Operator;
+use crate::scheduling::activate::Activator;
 
 // A Sequencer needs all operators firing with high frequency, because
 // it uses the timer to gauge progress. If other workers cease

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -7,14 +7,14 @@ use std::time::Instant;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 
-use communication::{Allocate, Data, Push, Pull};
-use communication::allocator::thread::{ThreadPusher, ThreadPuller};
-use scheduling::{Schedule, Scheduler, Activations};
-use progress::timestamp::{Refines};
-use progress::SubgraphBuilder;
-use progress::operate::Operate;
-use dataflow::scopes::Child;
-use logging::TimelyLogger;
+use crate::communication::{Allocate, Data, Push, Pull};
+use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
+use crate::scheduling::{Schedule, Scheduler, Activations};
+use crate::progress::timestamp::{Refines};
+use crate::progress::SubgraphBuilder;
+use crate::progress::operate::Operate;
+use crate::dataflow::scopes::Child;
+use crate::logging::TimelyLogger;
 
 /// Methods provided by the root Worker.
 ///
@@ -45,9 +45,9 @@ pub trait AsWorker : Scheduler {
     /// Allocates a new worker-unique identifier.
     fn new_identifier(&mut self) -> usize;
     /// Provides access to named logging streams.
-    fn log_register(&self) -> ::std::cell::RefMut<::logging_core::Registry<::logging::WorkerIdentifier>>;
+    fn log_register(&self) -> ::std::cell::RefMut<crate::logging_core::Registry<crate::logging::WorkerIdentifier>>;
     /// Provides access to the timely logging stream.
-    fn logging(&self) -> Option<::logging::TimelyLogger> { self.log_register().get("timely") }
+    fn logging(&self) -> Option<crate::logging::TimelyLogger> { self.log_register().get("timely") }
 }
 
 /// A `Worker` is the entry point to a timely dataflow computation. It wraps a `Allocate`,
@@ -60,7 +60,7 @@ pub struct Worker<A: Allocate> {
     // dataflows: Rc<RefCell<Vec<Wrapper>>>,
     dataflows: Rc<RefCell<HashMap<usize, Wrapper>>>,
     dataflow_counter: Rc<RefCell<usize>>,
-    logging: Rc<RefCell<::logging_core::Registry<::logging::WorkerIdentifier>>>,
+    logging: Rc<RefCell<crate::logging_core::Registry<crate::logging::WorkerIdentifier>>>,
 
     activations: Rc<RefCell<Activations>>,
     active_dataflows: Vec<usize>,
@@ -89,7 +89,7 @@ impl<A: Allocate> AsWorker for Worker<A> {
     }
 
     fn new_identifier(&mut self) -> usize { self.new_identifier() }
-    fn log_register(&self) -> RefMut<::logging_core::Registry<::logging::WorkerIdentifier>> {
+    fn log_register(&self) -> RefMut<crate::logging_core::Registry<crate::logging::WorkerIdentifier>> {
         self.log_register()
     }
 }
@@ -112,7 +112,7 @@ impl<A: Allocate> Worker<A> {
             identifiers: Rc::new(RefCell::new(0)),
             dataflows: Rc::new(RefCell::new(HashMap::new())),
             dataflow_counter: Rc::new(RefCell::new(0)),
-            logging: Rc::new(RefCell::new(::logging_core::Registry::new(now, index))),
+            logging: Rc::new(RefCell::new(crate::logging_core::Registry::new(now, index))),
             activations: Rc::new(RefCell::new(Activations::new())),
             active_dataflows: Vec::new(),
             temp_channel_ids: Rc::new(RefCell::new(Vec::new())),
@@ -290,7 +290,7 @@ impl<A: Allocate> Worker<A> {
     ///           );
     /// });
     /// ```
-    pub fn log_register(&self) -> ::std::cell::RefMut<::logging_core::Registry<::logging::WorkerIdentifier>> {
+    pub fn log_register(&self) -> ::std::cell::RefMut<crate::logging_core::Registry<crate::logging::WorkerIdentifier>> {
         self.logging.borrow_mut()
     }
 
@@ -367,7 +367,7 @@ impl<A: Allocate> Worker<A> {
 
         let mut operator = subscope.into_inner().build(self);
 
-        logging.as_mut().map(|l| l.log(::logging::OperatesEvent {
+        logging.as_mut().map(|l| l.log(crate::logging::OperatesEvent {
             id: identifier,
             addr: operator.path().to_vec(),
             name: operator.name().to_string(),
@@ -401,7 +401,7 @@ impl<A: Allocate> Worker<A> {
     }
 }
 
-use communication::Message;
+use crate::communication::Message;
 
 impl<A: Allocate> Clone for Worker<A> {
     fn clone(&self) -> Self {
@@ -438,7 +438,7 @@ impl Wrapper {
 
         // Perhaps log information about the start of the schedule call.
         if let Some(l) = self.logging.as_mut() {
-            l.log(::logging::ScheduleEvent::start(self.identifier));
+            l.log(crate::logging::ScheduleEvent::start(self.identifier));
         }
 
         let incomplete = self.operate.as_mut().map(|op| op.schedule()).unwrap_or(false);
@@ -449,7 +449,7 @@ impl Wrapper {
 
         // Perhaps log information about the stop of the schedule call.
         if let Some(l) = self.logging.as_mut() {
-            l.log(::logging::ScheduleEvent::stop(self.identifier));
+            l.log(crate::logging::ScheduleEvent::stop(self.identifier));
         }
 
         incomplete


### PR DESCRIPTION
There were three changes in the 2018 edition of Rust that required
changes:

  1. Removal of the `try!` macro. (Or, rather, the fact that `try` is
     now a keyword means that using the `try!` macro requires using an
     ugly raw identifier, i.e., `r#try!`.) Use the `?` operator instead.

  2. Handling of paths in `use` declarations. Referring to other modules
     in the same crate now requires an explicit `crate::` prefix.

  3. Removal of anonymous trait parameters. All trait parameters now
     require a name. Simply use the name `_` for trait parameters that
     were previously anonymous.