### PR TITLE
Include a magic number in the TCP stream handshake

### DIFF
--- a/communication/src/initialize.rs
+++ b/communication/src/initialize.rs
@@ -106,11 +106,11 @@ impl Configuration {
                 Ok((Process::new_vector(threads).into_iter().map(|x| GenericBuilder::Process(x)).collect(), Box::new(())))
             },
             Configuration::Cluster { threads, process, addresses, report, log_fn } => {
-                if let Ok((stuff, guard)) = initialize_networking(addresses, process, threads, report, log_fn) {
-                    Ok((stuff.into_iter().map(|x| GenericBuilder::ZeroCopy(x)).collect(), Box::new(guard)))
-                }
-                else {
-                    Err("failed to initialize networking".to_owned())
+                match initialize_networking(addresses, process, threads, report, log_fn) {
+                    Ok((stuff, guard)) => {
+                        Ok((stuff.into_iter().map(|x| GenericBuilder::ZeroCopy(x)).collect(), Box::new(guard)))
+                    },
+                    Err(err) => Err(format!("failed to initialize networking: {}", err))
                 }
             },
         }

--- a/communication/src/networking.rs
+++ b/communication/src/networking.rs
@@ -1,5 +1,6 @@
 //! Networking code for sending and receiving fixed size `Vec<u8>` between machines.
 
+use std::io;
 use std::io::{Read, Result};
 use std::net::{TcpListener, TcpStream};
 use std::sync::Arc;
@@ -8,6 +9,11 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use abomonation::{encode, decode};
+
+// This constant is sent along immediately after establishing a TCP stream, so
+// that it is easy to sniff out Timely traffic when it is multiplexed with
+// other traffic on the same port.
+const HANDSHAKE_MAGIC: u64 = 0xc2f1fb770118add9;
 
 /// Framing data for each `Vec<u8>` transmission, indicating a typed channel, the source and
 /// destination workers, and the length in bytes.
@@ -83,6 +89,7 @@ pub fn start_connections(addresses: Arc<Vec<String>>, my_index: usize, noisy: bo
             match TcpStream::connect(address) {
                 Ok(mut stream) => {
                     stream.set_nodelay(true).expect("set_nodelay call failed");
+                    unsafe { encode(&HANDSHAKE_MAGIC, &mut stream) }.expect("failed to encode/send handshake magic");
                     unsafe { encode(&(my_index as u64), &mut stream) }.expect("failed to encode/send worker index");
                     if noisy { println!("worker {}:\tconnection to worker {}", my_index, index); }
                     break Some(stream);
@@ -106,8 +113,13 @@ pub fn await_connections(addresses: Arc<Vec<String>>, my_index: usize, noisy: bo
     for _ in (my_index + 1) .. addresses.len() {
         let mut stream = listener.accept()?.0;
         stream.set_nodelay(true).expect("set_nodelay call failed");
-        let mut buffer = [0u8;8];
-        stream.read_exact(&mut buffer).expect("failed to read worker index");
+        let mut buffer = [0u8;16];
+        stream.read_exact(&mut buffer)?;
+        let (magic, mut buffer) = unsafe { decode::<u64>(&mut buffer) }.expect("failed to decode magic");
+        if magic != &HANDSHAKE_MAGIC {
+            return Err(io::Error::new(io::ErrorKind::InvalidData,
+                "received incorrect timely handshake"));
+        }
         let identifier = unsafe { decode::<u64>(&mut buffer) }.expect("failed to decode worker index").0.clone() as usize;
         results[identifier - my_index - 1] = Some(stream);
         if noisy { println!("worker {}:\tconnection from worker {}", my_index, identifier); }


### PR DESCRIPTION
Higher layers may want to multiplex Timely traffic on a port that is also used for other protocols (e.g., HTTP). Sending a magic number immediately after establishing the stream makes it easy to sniff out Timely traffic.