### PR TITLE
Replace #[inline(always)] with #[inline].

### DIFF
--- a/communication/src/allocator/counters.rs
+++ b/communication/src/allocator/counters.rs
@@ -30,7 +30,7 @@ impl<T, P: Push<T>>  Pusher<T, P> {
 }
 
 impl<T, P: Push<T>> Push<T> for Pusher<T, P> {
-    #[inline(always)]
+    #[inline]
     fn push(&mut self, element: &mut Option<T>) {
         // if element.is_none() {
         //     if self.count != 0 {
@@ -78,7 +78,7 @@ impl<T, P: Push<T>>  ArcPusher<T, P> {
 }
 
 impl<T, P: Push<T>> Push<T> for ArcPusher<T, P> {
-    #[inline(always)]
+    #[inline]
     fn push(&mut self, element: &mut Option<T>) {
         // if element.is_none() {
         //     if self.count != 0 {
@@ -121,7 +121,7 @@ impl<T, P: Pull<T>>  Puller<T, P> {
     }
 }
 impl<T, P: Pull<T>> Pull<T> for Puller<T, P> {
-    #[inline(always)]
+    #[inline]
     fn pull(&mut self) -> &mut Option<T> {
         let result = self.puller.pull();
         if result.is_none() {

--- a/communication/src/allocator/thread.rs
+++ b/communication/src/allocator/thread.rs
@@ -69,7 +69,7 @@ pub struct Pusher<T> {
 }
 
 impl<T> Push<T> for Pusher<T> {
-    #[inline(always)]
+    #[inline]
     fn push(&mut self, element: &mut Option<T>) {
         let mut borrow = self.target.borrow_mut();
         if let Some(element) = element.take() {
@@ -86,7 +86,7 @@ pub struct Puller<T> {
 }
 
 impl<T> Pull<T> for Puller<T> {
-    #[inline(always)]
+    #[inline]
     fn pull(&mut self) -> &mut Option<T> {
         let mut borrow = self.source.borrow_mut();
         // if let Some(element) = self.current.take() {

--- a/communication/src/lib.rs
+++ b/communication/src/lib.rs
@@ -132,15 +132,15 @@ pub trait Push<T> {
     /// Pushes `element` with the opportunity to take ownership.
     fn push(&mut self, element: &mut Option<T>);
     /// Pushes `element` and drops any resulting resources.
-    #[inline(always)]
+    #[inline]
     fn send(&mut self, element: T) { self.push(&mut Some(element)); }
     /// Pushes `None`, conventionally signalling a flush.
-    #[inline(always)]
+    #[inline]
     fn done(&mut self) { self.push(&mut None); }
 }
 
 impl<T, P: ?Sized + Push<T>> Push<T> for Box<P> {
-    #[inline(always)]
+    #[inline]
     fn push(&mut self, element: &mut Option<T>) { (**self).push(element) }
 }
 
@@ -156,11 +156,11 @@ pub trait Pull<T> {
     /// at the moment, and the puller should find something better to do.
     fn pull(&mut self) -> &mut Option<T>;
     /// Takes an `Option<T>` and leaves `None` behind.
-    #[inline(always)]
+    #[inline]
     fn recv(&mut self) -> Option<T> { self.pull().take() }
 }
 
 impl<T, P: ?Sized + Pull<T>> Pull<T> for Box<P> {
-    #[inline(always)]
+    #[inline]
     fn pull(&mut self) -> &mut Option<T> { (**self).pull() }
 }

--- a/communication/src/networking.rs
+++ b/communication/src/networking.rs
@@ -27,7 +27,7 @@ pub struct MessageHeader {
 
 impl MessageHeader {
     /// Returns a header when there is enough supporting data
-    #[inline(always)]
+    #[inline]
     pub fn try_read(bytes: &mut [u8]) -> Option<MessageHeader> {
         unsafe { decode::<MessageHeader>(bytes) }
             .and_then(|(header, remaining)| {
@@ -41,13 +41,13 @@ impl MessageHeader {
     }
 
     /// Writes the header as binary data.
-    #[inline(always)]
+    #[inline]
     pub fn write_to<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
         unsafe { encode(self, writer) }
     }
 
     /// The number of bytes required for the header and data.
-    #[inline(always)]
+    #[inline]
     pub fn required_bytes(&self) -> usize {
         ::std::mem::size_of::<MessageHeader>() + self.length
     }

--- a/sort/src/batched_vec.rs
+++ b/sort/src/batched_vec.rs
@@ -7,14 +7,14 @@ pub struct BatchedVecRef<'a, T: 'a> {
 }
 
 impl<'a, T> BatchedVecRef<'a, T> {
-    #[inline(always)]
+    #[inline]
     pub fn is_empty(&self) -> bool {
         // It is sufficient to only check the tail for emptiness, since any time we flush
         // the tail (in .reserve), we also push some elements.
         self.tail.is_empty()
     }
 
-    #[inline(always)]
+    #[inline]
     fn reserve(&mut self, stash: &mut Stash<T>) {
         if self.tail.len() == self.tail.capacity() {
             let complete = mem::replace(self.tail, stash.get());
@@ -24,7 +24,7 @@ impl<'a, T> BatchedVecRef<'a, T> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn push(&mut self, element: T, stash: &mut Stash<T>) {
         self.reserve(stash);
 
@@ -56,7 +56,7 @@ impl<'a, T> BatchedVecRef<'a, T> {
 
     // Note: this method is unsafe because it simply copies `elements`, and relies on the data backing it
     // to be discarded without being dropped.
-    #[inline(always)]
+    #[inline]
     pub unsafe fn push_all(&mut self, elements: &[T], stash: &mut Stash<T>) {
         self.reserve(stash);
 
@@ -69,7 +69,7 @@ impl<'a, T> BatchedVecRef<'a, T> {
         self.tail.set_len(len + elements.len());
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn finish_into(&mut self, target: &mut Vec<Vec<T>>) {
         target.extend(self.batches.drain(..));
         if !self.tail.is_empty() {
@@ -77,7 +77,7 @@ impl<'a, T> BatchedVecRef<'a, T> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn finish(&mut self) -> Vec<Vec<T>> {
         if !self.tail.is_empty() {
             self.batches.push(mem::replace(&mut self.tail, Vec::new()));
@@ -140,7 +140,7 @@ impl<T> BatchedVecX256<T> {
     }
 
     /// Access the `BatchedVec` at the `byte` position.
-    #[inline(always)]
+    #[inline]
     pub fn get_mut(&mut self, byte: usize) -> BatchedVecRef<T> {
         unsafe {
             BatchedVecRef {

--- a/sort/src/lsb.rs
+++ b/sort/src/lsb.rs
@@ -21,7 +21,7 @@ pub struct Sorter<T> {
 
 impl<T, U: Unsigned> RadixSorter<T, U> for Sorter<T> {
 
-    #[inline(always)]
+    #[inline]
     fn push<F: Fn(&T)->U>(&mut self, element: T, function: &F) {
         self.shuffler.push(element, &|x| (function(x).as_u64() % 256) as u8);
     }
@@ -49,7 +49,7 @@ impl<T> RadixSorterBase<T> for Sorter<T> {
 
 impl<T> Sorter<T> {
 
-    #[inline(always)]
+    #[inline]
     fn reshuffle<F: Fn(&T)->u8>(&mut self, buffers: &mut Vec<Vec<T>>, function: &F) {
         for buffer in buffers.drain(..) {
             self.shuffler.push_batch(buffer, function);

--- a/sort/src/lsb_swc.rs
+++ b/sort/src/lsb_swc.rs
@@ -24,7 +24,7 @@ pub struct Sorter<T> {
 
 impl<T, U: Unsigned> RadixSorter<T, U> for Sorter<T> {
 
-    #[inline(always)]
+    #[inline]
     fn push<F: Fn(&T)->U>(&mut self, element: T, key: &F) {
         self.shuffler.push(element, &|x| (key(x).as_u64() % 256) as u8);
     }
@@ -50,7 +50,7 @@ impl<T> RadixSorterBase<T> for Sorter<T> {
 }
 
 impl<T> Sorter<T> {
-    #[inline(always)]
+    #[inline]
     fn reshuffle<F: Fn(&T)->u8>(&mut self, buffers: &mut Vec<Vec<T>>, key: &F) {
         for buffer in buffers.drain(..) {
             self.shuffler.push_batch(buffer, key);

--- a/sort/src/msb.rs
+++ b/sort/src/msb.rs
@@ -50,7 +50,7 @@ pub struct Sorter<T> {
 
 impl<T, U: Unsigned> RadixSorter<T, U> for Sorter<T> {
 
-    #[inline(always)]
+    #[inline]
     fn push<F: Fn(&T)->U>(&mut self, element: T, bytes: &F) {
         let depth = U::bytes() - 1;
         let byte = ((bytes(&element).as_u64() >> (8 * depth)) & 0xFF) as usize;

--- a/sort/src/msb_swc.rs
+++ b/sort/src/msb_swc.rs
@@ -62,7 +62,7 @@ pub enum Work<T> {
 
 impl<T, U: Unsigned> RadixSorter<T, U> for Sorter<T> {
 
-    #[inline(always)]
+    #[inline]
     fn push<F: Fn(&T)->U>(&mut self, element: T, bytes: &F) {
         let depth = U::bytes() - 1;
         let byte = ((bytes(&element).as_u64() >> (8 * depth)) & 0xFF) as usize;
@@ -111,7 +111,7 @@ impl<T> RadixSorterBase<T> for Sorter<T> {
 impl<T> Sorter<T> {
 
     /// Finishes the sorting for the session, using the supplied finalizing action when given the option to exit early.
-    #[inline(always)]
+    #[inline]
     pub fn finish_into_and<U: Unsigned, F: Fn(&T)->U, L: Fn(&mut Vec<T>)>(&mut self, target: &mut Vec<Vec<T>>, bytes: F, action: L) {
 
         let depth = U::bytes() - 1;
@@ -147,7 +147,7 @@ impl<T> Sorter<T> {
     /// so we have an `action` you get to apply to finish things off. We could make this sort by radix, but
     /// there are several use cases where we need to follow up with additional sorting / compaction and would
     /// like to hook this clean-up method anyhow.
-    #[inline(always)]
+    #[inline]
     pub fn sort_and<U: Unsigned, F: Fn(&T)->U, L: Fn(&mut Vec<T>)>(&mut self, source: &mut Vec<Vec<T>>, bytes: F, action: L) {
         if source.len() > 1 {
             self.work.push(Work::Sort(U::bytes(), replace(source, Vec::new())));
@@ -159,7 +159,7 @@ impl<T> Sorter<T> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     fn grind<U: Unsigned, F: Fn(&T)->U, L: Fn(&mut Vec<T>)>(&mut self, bytes: &F, action: &L) {
 
         while let Some(work) = self.work.pop() {
@@ -174,7 +174,7 @@ impl<T> Sorter<T> {
     }
 
     // digests a list of batches, which we assume (for some reason) to be densely packed.
-    #[inline(always)]
+    #[inline]
     fn ingest<U: Unsigned, F: Fn(&T)->U, L: Fn(&mut Vec<T>)>(&mut self, source: &mut Vec<Vec<T>>, bytes: &F, depth: usize, action: &L) {
 
         // in this case, we should have a non-trivial number of elements, and so we can spend some effort

--- a/sort/src/swc_buffer.rs
+++ b/sort/src/swc_buffer.rs
@@ -27,7 +27,7 @@ impl<T> SWCBuffer<T> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn slice(&self, byte: usize) -> &[T] {
         unsafe {
             slice::from_raw_parts(
@@ -37,17 +37,17 @@ impl<T> SWCBuffer<T> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn full(&self, byte: usize) -> bool {
         unsafe { (*self.counts.get_unchecked(byte) as usize) == per_cache_line!(T) }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn count(&self, byte: usize) -> usize {
         unsafe { *self.counts.get_unchecked(byte) as usize }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn push(&mut self, element: T, byte: usize) {
         unsafe {
             let offset = per_cache_line!(T) as isize * byte as isize + *self.counts.get_unchecked(byte as usize) as isize;
@@ -56,7 +56,7 @@ impl<T> SWCBuffer<T> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn drain_into<'a>(&mut self, byte: usize, batch: &mut BatchedVecRef<'a, T>, stash: &mut Stash<T>) where T: 'a {
         unsafe {
             if *self.counts.get_unchecked(byte) > 0 {
@@ -66,7 +66,7 @@ impl<T> SWCBuffer<T> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn drain_into_vec(&mut self, byte: usize, batch: &mut Vec<T>, _stash: &mut Stash<T>) {
         unsafe {
             for i in 0 .. *self.counts.get_unchecked(byte) {

--- a/src/dataflow/channels/mod.rs
+++ b/src/dataflow/channels/mod.rs
@@ -37,7 +37,7 @@ impl<T, D> Message<T, D> {
     }
 
     /// Forms a message, and pushes contents at `pusher`.
-    #[inline(always)]
+    #[inline]
     pub fn push_at<P: Push<Bundle<T, D>>>(buffer: &mut Vec<D>, time: T, pusher: &mut P) {
 
         let data = ::std::mem::replace(buffer, Vec::new());

--- a/src/dataflow/channels/pact.rs
+++ b/src/dataflow/channels/pact.rs
@@ -116,7 +116,7 @@ impl<T, D, P: Push<Bundle<T, D>>> LogPusher<T, D, P> {
 }
 
 impl<T, D, P: Push<Bundle<T, D>>> Push<Bundle<T, D>> for LogPusher<T, D, P> {
-    #[inline(always)]
+    #[inline]
     fn push(&mut self, pair: &mut Option<Bundle<T, D>>) {
         if let Some(bundle) = pair {
             self.counter += 1;
@@ -162,7 +162,7 @@ impl<T, D, P: Pull<Bundle<T, D>>> LogPuller<T, D, P> {
 }
 
 impl<T, D, P: Pull<Bundle<T, D>>> Pull<Bundle<T, D>> for LogPuller<T, D, P> {
-    #[inline(always)]
+    #[inline]
     fn pull(&mut self) -> &mut Option<Bundle<T,D>> {
         let result = self.puller.pull();
         if let Some(bundle) = result {

--- a/src/dataflow/channels/pushers/buffer.rs
+++ b/src/dataflow/channels/pushers/buffer.rs
@@ -95,12 +95,12 @@ pub struct Session<'a, T, D, P: Push<Bundle<T, D>>+'a> where T: Eq+Clone+'a, D: 
 
 impl<'a, T, D, P: Push<Bundle<T, D>>+'a> Session<'a, T, D, P>  where T: Eq+Clone+'a, D: 'a {
     /// Provides one record at the time specified by the `Session`.
-    #[inline(always)]
+    #[inline]
     pub fn give(&mut self, data: D) {
         self.buffer.give(data);
     }
     /// Provides an iterator of records at the time specified by the `Session`.
-    #[inline(always)]
+    #[inline]
     pub fn give_iterator<I: Iterator<Item=D>>(&mut self, iter: I) {
         for item in iter {
             self.give(item);
@@ -111,7 +111,7 @@ impl<'a, T, D, P: Push<Bundle<T, D>>+'a> Session<'a, T, D, P>  where T: Eq+Clone
     /// The `Content` type is the backing memory for communication in timely, and it can
     /// often be more efficient to re-use this memory rather than have timely allocate
     /// new backing memory.
-    #[inline(always)]
+    #[inline]
     pub fn give_vec(&mut self, message: &mut Vec<D>) {
         if message.len() > 0 {
             self.buffer.give_vec(message);
@@ -130,19 +130,19 @@ pub struct AutoflushSession<'a, T: Timestamp, D, P: Push<Bundle<T, D>>+'a> where
 
 impl<'a, T: Timestamp, D, P: Push<Bundle<T, D>>+'a> AutoflushSession<'a, T, D, P> where T: Eq+Clone+'a, D: 'a {
     /// Transmits a single record.
-    #[inline(always)]
+    #[inline]
     pub fn give(&mut self, data: D) {
         self.buffer.give(data);
     }
     /// Transmits records produced by an iterator.
-    #[inline(always)]
+    #[inline]
     pub fn give_iterator<I: Iterator<Item=D>>(&mut self, iter: I) {
         for item in iter {
             self.give(item);
         }
     }
     /// Transmits a pre-packed batch of data.
-    #[inline(always)]
+    #[inline]
     pub fn give_content(&mut self, message: &mut Vec<D>) {
         if message.len() > 0 {
             self.buffer.give_vec(message);

--- a/src/dataflow/channels/pushers/counter.rs
+++ b/src/dataflow/channels/pushers/counter.rs
@@ -15,7 +15,7 @@ pub struct Counter<T: Ord, D, P: Push<Bundle<T, D>>> {
 }
 
 impl<T, D, P> Push<Bundle<T, D>> for Counter<T, D, P> where T : Ord+Clone+'static, P: Push<Bundle<T, D>> {
-    #[inline(always)]
+    #[inline]
     fn push(&mut self, message: &mut Option<Bundle<T, D>>) {
         if let Some(message) = message {
             self.produced.borrow_mut().update(message.time.clone(), message.data.len() as i64);
@@ -38,7 +38,7 @@ impl<T, D, P: Push<Bundle<T, D>>> Counter<T, D, P> where T : Ord+Clone+'static {
         }
     }
     /// A references to shared changes in counts, for cloning or draining.
-    #[inline(always)]
+    #[inline]
     pub fn produced(&self) -> &Rc<RefCell<ChangeBatch<T>>> {
         &self.produced
     }

--- a/src/dataflow/operators/capability.rs
+++ b/src/dataflow/operators/capability.rs
@@ -70,7 +70,7 @@ impl<T: Timestamp> CapabilityTrait<T> for Capability<T> {
 
 impl<T: Timestamp> Capability<T> {
     /// The timestamp associated with this capability.
-    #[inline(always)]
+    #[inline]
     pub fn time(&self) -> &T {
         &self.time
     }
@@ -79,7 +79,7 @@ impl<T: Timestamp> Capability<T> {
     /// the source capability (`self`).
     ///
     /// This method panics if `self.time` is not less or equal to `new_time`.
-    #[inline(always)]
+    #[inline]
     pub fn delayed(&self, new_time: &T) -> Capability<T> {
         if !self.time.less_equal(new_time) {
             panic!("Attempted to delay {:?} to {:?}, which is not `less_equal` the capability's time.", self, new_time);
@@ -90,7 +90,7 @@ impl<T: Timestamp> Capability<T> {
     /// Downgrades the capability to one corresponding to `new_time`.
     ///
     /// This method panics if `self.time` is not less or equal to `new_time`.
-    #[inline(always)]
+    #[inline]
     pub fn downgrade(&mut self, new_time: &T) {
         let new_cap = self.delayed(new_time);
         *self = new_cap;
@@ -100,7 +100,7 @@ impl<T: Timestamp> Capability<T> {
 /// Creates a new capability at `t` while incrementing (and keeping a reference to) the provided
 /// `ChangeBatch`.
 /// Declared separately so that it can be kept private when `Capability` is re-exported.
-#[inline(always)]
+#[inline]
 pub fn mint<T: Timestamp>(time: T, internal: Rc<RefCell<ChangeBatch<T>>>) -> Capability<T> {
     internal.borrow_mut().update(time.clone(), 1);
     Capability {
@@ -181,7 +181,7 @@ impl<'cap, T: Timestamp+'cap> CapabilityTrait<T> for CapabilityRef<'cap, T> {
 
 impl<'cap, T: Timestamp+'cap> CapabilityRef<'cap, T> {
     /// The timestamp associated with this capability.
-    #[inline(always)]
+    #[inline]
     pub fn time(&self) -> &T {
         self.time
     }
@@ -190,7 +190,7 @@ impl<'cap, T: Timestamp+'cap> CapabilityRef<'cap, T> {
     /// the source capability (`self`).
     ///
     /// This method panics if `self.time` is not less or equal to `new_time`.
-    #[inline(always)]
+    #[inline]
     pub fn delayed(&self, new_time: &T) -> Capability<T> {
         self.delayed_for_output(new_time, 0)
     }
@@ -214,7 +214,7 @@ impl<'cap, T: Timestamp+'cap> CapabilityRef<'cap, T> {
     /// This method produces an owned capability which must be dropped to release the
     /// capability. Users should take care that these capabilities are only stored for
     /// as long as they are required, as failing to drop them may result in livelock.
-    #[inline(always)]
+    #[inline]
     pub fn retain(self) -> Capability<T> {
         // mint(self.time.clone(), self.internal)
         self.retain_for_output(0)
@@ -249,7 +249,7 @@ impl<'cap, T: Timestamp> Debug for CapabilityRef<'cap, T> {
 /// Creates a new capability at `t` while incrementing (and keeping a reference to) the provided
 /// `ChangeBatch`.
 /// Declared separately so that it can be kept private when `Capability` is re-exported.
-#[inline(always)]
+#[inline]
 pub fn mint_ref<'cap, T: Timestamp>(time: &'cap T, internal: Rc<RefCell<Vec<Rc<RefCell<ChangeBatch<T>>>>>>) -> CapabilityRef<'cap, T> {
     CapabilityRef {
         time,

--- a/src/dataflow/operators/generic/handles.rs
+++ b/src/dataflow/operators/generic/handles.rs
@@ -41,7 +41,7 @@ impl<'a, T: Timestamp, D: Data, P: Pull<Bundle<T, D>>> InputHandle<T, D, P> {
     /// Reads the next input buffer (at some timestamp `t`) and a corresponding capability for `t`.
     /// The timestamp `t` of the input buffer can be retrieved by invoking `.time()` on the capability.
     /// Returns `None` when there's no more data available.
-    #[inline(always)]
+    #[inline]
     pub fn next(&mut self) -> Option<(CapabilityRef<T>, RefOrMut<Vec<D>>)> {
         let internal = &self.internal;
         self.pull_counter.next().map(|bundle| {
@@ -98,7 +98,7 @@ impl<'a, T: Timestamp, D: Data, P: Pull<Bundle<T, D>>+'a> FrontieredInputHandle<
     /// Reads the next input buffer (at some timestamp `t`) and a corresponding capability for `t`.
     /// The timestamp `t` of the input buffer can be retrieved by invoking `.time()` on the capability.
     /// Returns `None` when there's no more data available.
-    #[inline(always)]
+    #[inline]
     pub fn next(&mut self) -> Option<(CapabilityRef<T>, RefOrMut<Vec<D>>)> {
         self.handle.next()
     }
@@ -127,7 +127,7 @@ impl<'a, T: Timestamp, D: Data, P: Pull<Bundle<T, D>>+'a> FrontieredInputHandle<
     }
 
     /// Inspect the frontier associated with this input.
-    #[inline(always)]
+    #[inline]
     pub fn frontier(&self) -> &'a MutableAntichain<T> {
         self.frontier
     }

--- a/src/dataflow/operators/input.rs
+++ b/src/dataflow/operators/input.rs
@@ -300,7 +300,7 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     /// Sends one record into the corresponding timely dataflow `Stream`, at the current epoch.
     pub fn send(&mut self, data: D) {
         // assert!(self.buffer1.capacity() == Message::<T, D>::default_length());

--- a/src/order.rs
+++ b/src/order.rs
@@ -29,8 +29,8 @@ macro_rules! implement_partial {
     ($($index_type:ty,)*) => (
         $(
             impl PartialOrder for $index_type {
-                #[inline(always)] fn less_than(&self, other: &Self) -> bool { self < other }
-                #[inline(always)] fn less_equal(&self, other: &Self) -> bool { self <= other }
+                #[inline] fn less_than(&self, other: &Self) -> bool { self < other }
+                #[inline] fn less_equal(&self, other: &Self) -> bool { self <= other }
             }
         )*
     )
@@ -95,7 +95,7 @@ impl<TOuter: Debug, TInner: Debug> Debug for Product<TOuter, TInner> {
 }
 
 impl<TOuter: PartialOrder, TInner: PartialOrder> PartialOrder for Product<TOuter, TInner> {
-    #[inline(always)]
+    #[inline]
     fn less_equal(&self, other: &Self) -> bool {
         self.outer.less_equal(&other.outer) && self.inner.less_equal(&other.inner)
     }

--- a/src/progress/reachability.rs
+++ b/src/progress/reachability.rs
@@ -424,7 +424,7 @@ impl<T: Timestamp> PortInformation<T> {
     /// method returns false it means that, temporarily at least, there
     /// are outstanding pointstamp updates that are strictly less than
     /// this pointstamp.
-    #[inline(always)]
+    #[inline]
     fn is_global(&self, time: &T) -> bool {
         let dominated = self.implications.frontier().iter().any(|t| t.less_than(time));
         let redundant = self.implications.count_for(time) > 1;

--- a/src/progress/timestamp.rs
+++ b/src/progress/timestamp.rs
@@ -61,8 +61,8 @@ pub trait PathSummary<T> : Clone+'static+Eq+PartialOrder+Debug+Default {
 
 impl Timestamp for () { type Summary = (); }
 impl PathSummary<()> for () {
-    #[inline(always)] fn results_in(&self, _src: &()) -> Option<()> { Some(()) }
-    #[inline(always)] fn followed_by(&self, _other: &()) -> Option<()> { Some(()) }
+    #[inline] fn results_in(&self, _src: &()) -> Option<()> { Some(()) }
+    #[inline] fn followed_by(&self, _other: &()) -> Option<()> { Some(()) }
 }
 
 /// Implements Timestamp and PathSummary for types with a `checked_add` method.


### PR DESCRIPTION
As a maintainer of another high-performance Rust project (Rust FlatBuffers), I've learned that forcing the compiler to inline can be problematic. The Rust toolchain (LLVM in particular) can make better decisions than we can (usually) when deciding when and what to inline. This PR switches all `#[inline(always)]` attributes to `#[inline]`, in accordance with Rust best practices.

See also https://github.com/TimelyDataflow/differential-dataflow/pull/157