### PR TITLE
Add GenericSequencer, ThreadSequencer

### DIFF
--- a/timely/examples/sequence.rs
+++ b/timely/examples/sequence.rs
@@ -1,16 +1,15 @@
 extern crate timely;
 
 use std::time::{Instant, Duration};
-use std::collections::VecDeque;
 
 use timely::Configuration;
 use timely::synchronization::Sequencer;
 
 fn main() {
-    timely::execute(Configuration::Process(2), |worker| {
+    timely::execute(Configuration::Process(4), |worker| {
 
         let timer = Instant::now();
-        let mut sequencer = Sequencer::preloaded(worker, Instant::now(), VecDeque::new());
+        let mut sequencer = Sequencer::new(worker, Instant::now());
 
         for round in 0 .. {
             // if worker.index() < 3 {

--- a/timely/examples/sequence.rs
+++ b/timely/examples/sequence.rs
@@ -1,15 +1,16 @@
 extern crate timely;
 
 use std::time::{Instant, Duration};
+use std::collections::VecDeque;
 
 use timely::Configuration;
 use timely::synchronization::Sequencer;
 
 fn main() {
-    timely::execute(Configuration::Process(4), |worker| {
+    timely::execute(Configuration::Process(2), |worker| {
 
         let timer = Instant::now();
-        let mut sequencer = Sequencer::new(worker, Instant::now());
+        let mut sequencer = Sequencer::preloaded(worker, Instant::now(), VecDeque::new());
 
         for round in 0 .. {
             // if worker.index() < 3 {

--- a/timely/src/synchronization/mod.rs
+++ b/timely/src/synchronization/mod.rs
@@ -4,4 +4,4 @@ pub mod barrier;
 pub mod sequence;
 
 pub use self::barrier::Barrier;
-pub use self::sequence::{GenericSequencer, Sequencing};
+pub use self::sequence::Sequencer;

--- a/timely/src/synchronization/mod.rs
+++ b/timely/src/synchronization/mod.rs
@@ -4,4 +4,4 @@ pub mod barrier;
 pub mod sequence;
 
 pub use self::barrier::Barrier;
-pub use self::sequence::Sequencer;
+pub use self::sequence::{GenericSequencer, Sequencing};

--- a/timely/src/synchronization/sequence.rs
+++ b/timely/src/synchronization/sequence.rs
@@ -99,8 +99,6 @@ impl<T: ExchangeData> Sequencer<T> {
         preload: VecDeque<T>,
     ) -> Self {
         if worker.peers() == 1 {
-            println!("no dataflow");
-            
             let send = Rc::new(RefCell::new(preload));
             let recv = send.clone();
 


### PR DESCRIPTION
The idea here is to have a more generic sequencer that can drop down to specialized implementations, based on the number of workers (similar to the communication allocators). 

The immediate need was to drop down to a glorified `VecDeque` in single worker mode, such that we can easily run 3DF (and maybe interactive as well?) in single-threaded, blocking mode, without hogging the CPU.

When running with blocking I/O we would otherwise have to be very careful to always reconcile the sequencing dataflow fully, otherwise we might stall.

If you think this is a good idea, @frankmcsherry, I can clean up and add a test. Otherwise I can just keep this within declarative.

edit: sorry I `cargo fmt`-ed a bit too carelessly there.