### PR TITLE
Expose status of activations

### DIFF
--- a/src/scheduling/activate.rs
+++ b/src/scheduling/activate.rs
@@ -30,6 +30,11 @@ impl Activations {
         self.slices.extend(path);
     }
 
+    /// Are there pending activations?
+    pub fn has_pending(&self) -> bool {
+        (self.bounds.len() - self.clean) > 0
+    }
+
     /// Discards the current active set and presents the next active set.
     pub fn advance(&mut self) {
 


### PR DESCRIPTION
For an event-driven server loop we want to block as long as there is nothing to do.
We don't want to timeout when there are still pending activations and that's the little PR here :) 

We then would not need to probe the sequencer dataflow.

Corresponding stuff over at declarative:
https://github.com/comnik/declarative-dataflow/commit/1a393c4513f93521a43cb8979fe0af266f5eac45