### PR TITLE
v0.9 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 0.9.0
 
 ### Added
 
@@ -14,7 +14,7 @@ The `source` operator requires a closure that accepts an `OperatorInfo` struct i
 
 The address associated with each operator, a `[usize]` used to start with the identifier of the worker hosting the operator, followed by the dataflow identifier and the path down the dataflow to the operator. The worker identifier has been removed.
 
-The `Worker` and the `Subgraph` operator no longer schedules all of their child dataflows and scopes by default. Instead, they track "active" children and schedule only those. Operators become active by receiving a message, a progress update, or by explicit activation. Some operators, source as `source`, have no inputs and will require explicit activation to run more than once. Operators that yield before completing all of their work (good for you!) should explicitly re-activate themselves to ensure they are re-scheduled even if they receive no further messages or progress updates.
+The `Worker` and the `Subgraph` operator no longer schedules all of their child dataflows and scopes by default. Instead, they track "active" children and schedule only those. Operators become active by receiving a message, a progress update, or by explicit activation. Some operators, source as `source`, have no inputs and will require explicit activation to run more than once. Operators that yield before completing all of their work (good for you!) should explicitly re-activate themselves to ensure they are re-scheduled even if they receive no further messages or progress updates. Documentation examples for the `source` method demonstrate this.
 
 The `dataflow_using` method has been generalized to support arbitrary dataflow names, loggers, and additional resources the dataflow should keep alive. Its name has been chaged to `dataflow_core`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "timely"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 readme = "README.md"
 edition = "2018"
@@ -9,7 +9,7 @@ edition = "2018"
 description = "A low-latency data-parallel dataflow system in Rust"
 
 # These URLs point to more information about the repository
-documentation = "https://frankmcsherry.github.com/timely-dataflow"
+documentation = "https://docs.rs/timely/"
 homepage = "https://github.com/TimelyDataflow/timely-dataflow"
 repository = "https://github.com/TimelyDataflow/timely-dataflow.git"
 keywords = ["timely", "dataflow"]
@@ -23,9 +23,9 @@ serde = "1.0"
 serde_derive = "1.0"
 abomonation = "0.7"
 abomonation_derive = "0.3"
-timely_bytes = { path = "./bytes", version = "0.7" }
-timely_logging = { path = "./logging", version = "0.7" }
-timely_communication = { path = "./communication", version = "0.8" }
+timely_bytes = { path = "./bytes", version = "0.9" }
+timely_logging = { path = "./logging", version = "0.9" }
+timely_communication = { path = "./communication", version = "0.9" }
 
 [dev-dependencies]
 timely_sort="0.1.6"

--- a/bytes/Cargo.toml
+++ b/bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timely_bytes"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 
 description = "Disjoint mutable byte slices from a common allocation"

--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timely_communication"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 description = "Communication layer for timely dataflow"
 
@@ -21,8 +21,8 @@ serde_derive = "1.0"
 serde = "1.0"
 abomonation = "0.7"
 abomonation_derive = "0.3"
-timely_bytes = { path = "../bytes", version = "0.7" }
-timely_logging = { path = "../logging", version = "0.7" }
+timely_bytes = { path = "../bytes", version = "0.9" }
+timely_logging = { path = "../logging", version = "0.9" }
 
 [profile.release]
 opt-level = 3

--- a/communication/examples/hello.rs
+++ b/communication/examples/hello.rs
@@ -1,3 +1,5 @@
+extern crate timely_communication;
+
 use std::ops::Deref;
 use timely_communication::{Message, Allocate};
 
@@ -23,14 +25,14 @@ fn main() {
         let mut received = 0;
         while received < allocator.peers() {
 
-            allocator.pre_work();
+            allocator.receive();
 
             if let Some(message) = receiver.recv() {
                 println!("worker {}: received: <{}>", allocator.index(), message.deref());
                 received += 1;
             }
 
-            allocator.post_work();
+            allocator.release();
         }
 
         allocator.index()

--- a/communication/src/allocator/zero_copy/allocator.rs
+++ b/communication/src/allocator/zero_copy/allocator.rs
@@ -37,7 +37,7 @@ pub struct TcpBuilder<A: AllocateBuilder> {
 /// `threads` is the number of workers in a single process, `processes` is the
 /// total number of processes.
 /// The returned tuple contains
-/// ```
+/// ```ignore
 /// (
 ///   AllocateBuilder for local threads,
 ///   info to spawn egress comm threads,

--- a/communication/src/initialize.rs
+++ b/communication/src/initialize.rs
@@ -148,13 +148,13 @@ impl Configuration {
 ///     // we have to count down ourselves.
 ///     let mut expecting = 2;
 ///     while expecting > 0 {
-///         allocator.pre_work();
+///         allocator.receive();
 ///         if let Some(message) = receiver.recv() {
 ///             use std::ops::Deref;
 ///             println!("worker {}: received: <{}>", allocator.index(), message.deref());
 ///             expecting -= 1;
 ///         }
-///         allocator.post_work();
+///         allocator.release();
 ///     }
 ///
 ///     // optionally, return something
@@ -220,13 +220,13 @@ pub fn initialize<T:Send+'static, F: Fn(Generic)->T+Send+Sync+'static>(
 ///     // we have to count down ourselves.
 ///     let mut expecting = 2;
 ///     while expecting > 0 {
-///         allocator.pre_work();
+///         allocator.receive();
 ///         if let Some(message) = receiver.recv() {
 ///             use std::ops::Deref;
 ///             println!("worker {}: received: <{}>", allocator.index(), message.deref());
 ///             expecting -= 1;
 ///         }
-///         allocator.post_work();
+///         allocator.release();
 ///     }
 ///
 ///     // optionally, return something

--- a/communication/src/lib.rs
+++ b/communication/src/lib.rs
@@ -38,13 +38,13 @@
 //!     let mut expecting = 2;
 //!     while expecting > 0 {
 //!
-//!         allocator.pre_work();
+//!         allocator.receive();
 //!         if let Some(message) = receiver.recv() {
 //!             use std::ops::Deref;
 //!             println!("worker {}: received: <{}>", allocator.index(), message.deref());
 //!             expecting -= 1;
 //!         }
-//!         allocator.post_work();
+//!         allocator.release();
 //!     }
 //!
 //!     // optionally, return something

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timely_logging"
-version = "0.7.1"
+version = "0.9.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 
 description = "Common timely logging infrastructure"


### PR DESCRIPTION
This PR has the necessary updates for each of the `Cargo.toml` files to push the current master out as a timely 0.9 release (with subcrates too).