### PR TITLE
add step_or_park

### DIFF
--- a/communication/src/allocator/counters.rs
+++ b/communication/src/allocator/counters.rs
@@ -93,6 +93,7 @@ impl<T, P: Push<T>> Push<T> for ArcPusher<T, P> {
         // }
         self.events
             .send((self.index, Event::Pushed(1)))
+            // TODO : Perhaps this shouldn't be a fatal error (e.g. in shutdown).
             .expect("Failed to send message count");
 
         self.pusher.push(element)

--- a/communication/src/allocator/mod.rs
+++ b/communication/src/allocator/mod.rs
@@ -2,6 +2,7 @@
 
 use std::rc::Rc;
 use std::cell::RefCell;
+use std::time::Duration;
 use std::collections::VecDeque;
 
 pub use self::thread::Thread;
@@ -50,6 +51,14 @@ pub trait Allocate {
     /// fail to do so the event queue may become quite large, and turn
     /// into a performance problem.
     fn events(&self) -> &Rc<RefCell<VecDeque<(usize, Event)>>>;
+
+    /// Awaits communication events.
+    ///
+    /// This method may park the current thread, for at most `duration`,
+    /// until new events arrive.
+    /// The method is not guaranteed to wait for any amount of time, but
+    /// good implementations should use this as a hint to park the thread.
+    fn await_events(&self, _duration: Duration) { }
 
     /// Ensure that received messages are surfaced in each channel.
     ///

--- a/communication/src/allocator/mod.rs
+++ b/communication/src/allocator/mod.rs
@@ -58,7 +58,7 @@ pub trait Allocate {
     /// until new events arrive.
     /// The method is not guaranteed to wait for any amount of time, but
     /// good implementations should use this as a hint to park the thread.
-    fn await_events(&self, _duration: Duration) { }
+    fn await_events(&self, _duration: Option<Duration>) { }
 
     /// Ensure that received messages are surfaced in each channel.
     ///

--- a/communication/src/allocator/thread.rs
+++ b/communication/src/allocator/thread.rs
@@ -35,9 +35,14 @@ impl Allocate for Thread {
     fn events(&self) -> &Rc<RefCell<VecDeque<(usize, Event)>>> {
         &self.events
     }
-    fn await_events(&self, duration: Duration) {
+    fn await_events(&self, duration: Option<Duration>) {
         if self.events.borrow().is_empty() {
-            std::thread::park_timeout(duration);
+            if let Some(duration) = duration {
+                std::thread::park_timeout(duration);
+            }
+            else {
+                std::thread::park();
+            }
         }
     }
 }

--- a/communication/src/allocator/thread.rs
+++ b/communication/src/allocator/thread.rs
@@ -2,6 +2,7 @@
 
 use std::rc::Rc;
 use std::cell::RefCell;
+use std::time::Duration;
 use std::collections::VecDeque;
 
 use crate::allocator::{Allocate, AllocateBuilder, Event};
@@ -33,6 +34,11 @@ impl Allocate for Thread {
     }
     fn events(&self) -> &Rc<RefCell<VecDeque<(usize, Event)>>> {
         &self.events
+    }
+    fn await_events(&self, duration: Duration) {
+        if self.events.borrow().is_empty() {
+            std::thread::park_timeout(duration);
+        }
     }
 }
 

--- a/timely/src/execute.rs
+++ b/timely/src/execute.rs
@@ -84,7 +84,7 @@ where
     let alloc = crate::communication::allocator::thread::Thread::new();
     let mut worker = crate::worker::Worker::new(alloc);
     let result = func(&mut worker);
-    while worker.step_or_park() { }
+    while worker.step_or_park(None) { }
     result
 }
 

--- a/timely/src/execute.rs
+++ b/timely/src/execute.rs
@@ -84,7 +84,7 @@ where
     let alloc = crate::communication::allocator::thread::Thread::new();
     let mut worker = crate::worker::Worker::new(alloc);
     let result = func(&mut worker);
-    while worker.step() { }
+    while worker.step_or_park() { }
     result
 }
 
@@ -199,7 +199,7 @@ where
         }
 
         let result = func(&mut worker);
-        while worker.step() { }
+        while worker.step_or_park(None) { }
         result
     })
 }
@@ -284,7 +284,7 @@ where
     initialize_from(builders, others, move |allocator| {
         let mut worker = Worker::new(allocator);
         let result = func(&mut worker);
-        while worker.step() { }
+        while worker.step_or_park(None) { }
         result
     })
 }

--- a/timely/src/scheduling/activate.rs
+++ b/timely/src/scheduling/activate.rs
@@ -24,6 +24,11 @@ impl Activations {
         }
     }
 
+    /// Indicates if there no pending activations.
+    pub fn is_empty(&self) -> bool {
+        self.bounds.is_empty()
+    }
+
     /// Unparks task addressed by `path`.
     pub fn activate(&mut self, path: &[usize]) {
         self.bounds.push((self.slices.len(), path.len()));

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -165,7 +165,7 @@ impl<A: Allocate> Worker<A> {
     ///             .inspect(|x| println!("{:?}", x));
     ///     });
     ///
-    ///     worker.step_or_park(Duration::from_secs(1));
+    ///     worker.step_or_park(Some(Duration::from_secs(1)));
     /// });
     /// ```
     pub fn step_or_park(&mut self, duration: Option<Duration>) -> bool {

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -3,7 +3,7 @@
 use std::rc::Rc;
 use std::cell::{RefCell, RefMut};
 use std::any::Any;
-use std::time::Instant;
+use std::time::{Instant, Duration};
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 
@@ -119,6 +119,7 @@ impl<A: Allocate> Worker<A> {
         }
     }
 
+
     /// Performs one step of the computation.
     ///
     /// A step gives each dataflow operator a chance to run, and is the
@@ -141,6 +142,32 @@ impl<A: Allocate> Worker<A> {
     /// });
     /// ```
     pub fn step(&mut self) -> bool {
+        self.step_or_park(Duration::from_secs(0))
+    }
+
+    /// Performs one step of the computation.
+    ///
+    /// A step gives each dataflow operator a chance to run, and is the
+    /// main way to ensure that a computation proceeds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// timely::execute_from_args(::std::env::args(), |worker| {
+    ///
+    ///     use std::time::Duration;
+    ///     use timely::dataflow::operators::{ToStream, Inspect};
+    ///
+    ///     worker.dataflow::<usize,_,_>(|scope| {
+    ///         (0 .. 10)
+    ///             .to_stream(scope)
+    ///             .inspect(|x| println!("{:?}", x));
+    ///     });
+    ///
+    ///     worker.step_or_park(Duration::from_secs(1));
+    /// });
+    /// ```
+    pub fn step_or_park(&mut self, duration: Duration) -> bool {
 
         {   // Process channel events. Activate responders.
             let mut allocator = self.allocator.borrow_mut();
@@ -168,7 +195,12 @@ impl<A: Allocate> Worker<A> {
             .borrow_mut()
             .advance();
 
-        {   // Schedule active dataflows.
+        if self.activations.borrow().is_empty() {
+            self.allocator
+                .borrow()
+                .await_events(duration);
+        }
+        else {   // Schedule active dataflows.
 
             let active_dataflows = &mut self.active_dataflows;
             self.activations

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -119,7 +119,6 @@ impl<A: Allocate> Worker<A> {
         }
     }
 
-
     /// Performs one step of the computation.
     ///
     /// A step gives each dataflow operator a chance to run, and is the
@@ -142,13 +141,15 @@ impl<A: Allocate> Worker<A> {
     /// });
     /// ```
     pub fn step(&mut self) -> bool {
-        self.step_or_park(Duration::from_secs(0))
+        self.step_or_park(Some(Duration::from_secs(0)))
     }
 
     /// Performs one step of the computation.
     ///
     /// A step gives each dataflow operator a chance to run, and is the
-    /// main way to ensure that a computation proceeds.
+    /// main way to ensure that a computation proceeds. This method may
+    /// park the thread until there is work to perform, with an optional
+    /// timeout.
     ///
     /// # Examples
     ///
@@ -167,7 +168,7 @@ impl<A: Allocate> Worker<A> {
     ///     worker.step_or_park(Duration::from_secs(1));
     /// });
     /// ```
-    pub fn step_or_park(&mut self, duration: Duration) -> bool {
+    pub fn step_or_park(&mut self, duration: Option<Duration>) -> bool {
 
         {   // Process channel events. Activate responders.
             let mut allocator = self.allocator.borrow_mut();


### PR DESCRIPTION
This PR introduces the `step_or_park(Duration)` method to a worker.

The design is that the communication fabric allocator now has a method 

```rust
await_events(&self, duration: Duration)
``` 

which is allowed to park the thread for at most `duration`, or until `self.events()` has some events to report (these are events that prompt the scheduling of operators). The implementation of this is a no-op by default (not parking the thread), but the single-threaded communicator has an implementation that parks itself if its event queue is empty. The plan is to add these in for other communicators so that eventually all of them behave well.

The worker now has a method 

```rust
step_or_park(&mut self, duration: Duration) -> bool
```

which .. drains events from the communicator, and just before it is about to schedule its activations, checks to see if it has any and if not calls in to `await_events(duration)`.

I haven't really thought through the concurrency design here. It is possible that there is a race condition somewhere, but we can take a look at it and see whether it does the right thing in principle.

cc @comnik @ryzhyk @benesch 