### PR TITLE
Derive impl of Clone for OperatorInfo

### DIFF
--- a/timely/src/dataflow/operators/generic/operator_info.rs
+++ b/timely/src/dataflow/operators/generic/operator_info.rs
@@ -1,5 +1,6 @@
 
 /// Information about the operator being constructed
+#[derive(Clone)]
 pub struct OperatorInfo {
     /// Scope-local index assigned to the operator being constructed.
     pub local_id: usize,


### PR DESCRIPTION
When writing operators, one may need to pass `operator_info` to various bits of logic, and copying `OperatorInfo` would only happen once during dataflow construction.

@frankmcsherry in no-sync, I construct multiple traces in the same operator - each needs its own copy of `operator_info`.