### PR TITLE
Fix broken links to simple example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use timely dataflow, add the following to the dependencies section of your pr
 timely="*"
 ```
 
-This will bring in the [`timely` crate](https://crates.io/crates/timely) from [crates.io](http://crates.io), which should allow you to start writing timely dataflow programs like this one (also available in [examples/simple.rs](https://github.com/timelydataflow/timely-dataflow/blob/master/examples/simple.rs)):
+This will bring in the [`timely` crate](https://crates.io/crates/timely) from [crates.io](http://crates.io), which should allow you to start writing timely dataflow programs like this one (also available in [timely/examples/simple.rs](https://github.com/timelydataflow/timely-dataflow/blob/master/timely/examples/simple.rs)):
 
 ```rust
 extern crate timely;

--- a/mdbook/src/chapter_2/chapter_2.md
+++ b/mdbook/src/chapter_2/chapter_2.md
@@ -4,7 +4,7 @@ Let's talk about how to create timely dataflows.
 
 This section will be a bit of a tour through the dataflow construction process, ignoring for the moment details about the interesting ways in which you can get data in to and out of your dataflow; those will show up in the "Running Timely Dataflows" section. For now we are going to work with examples with fixed input data and no interactivity to speak of, focusing on what we can cause to happen to that data.
 
-Here is a relatively simple example, taken from `examples/simple.rs`, that turns the numbers zero through nine into a stream, and then feeds them through an `inspect` operator printing them to the screen.
+Here is a relatively simple example, taken from `timely/examples/simple.rs`, that turns the numbers zero through nine into a stream, and then feeds them through an `inspect` operator printing them to the screen.
 
 ```rust
 extern crate timely;


### PR DESCRIPTION
I don't know if you want to change all the references in the book to add the `timely/` prefix or not, but I think the link in the readme should be updated ;)