### PR TITLE
Mutable exchange

### DIFF
--- a/timely/src/dataflow/channels/pushers/exchange.rs
+++ b/timely/src/dataflow/channels/pushers/exchange.rs
@@ -6,14 +6,14 @@ use crate::dataflow::channels::{Bundle, Message};
 
 // TODO : Software write combining
 /// Distributes records among target pushees according to a distribution function.
-pub struct Exchange<T, D, P: Push<Bundle<T, D>>, H: Fn(&T, &D) -> u64> {
+pub struct Exchange<T, D, P: Push<Bundle<T, D>>, H: FnMut(&T, &D) -> u64> {
     pushers: Vec<P>,
     buffers: Vec<Vec<D>>,
     current: Option<T>,
     hash_func: H,
 }
 
-impl<T: Clone, D, P: Push<Bundle<T, D>>, H: Fn(&T, &D)->u64>  Exchange<T, D, P, H> {
+impl<T: Clone, D, P: Push<Bundle<T, D>>, H: FnMut(&T, &D)->u64>  Exchange<T, D, P, H> {
     /// Allocates a new `Exchange` from a supplied set of pushers and a distribution function.
     pub fn new(pushers: Vec<P>, key: H) -> Exchange<T, D, P, H> {
         let mut buffers = vec![];
@@ -37,7 +37,7 @@ impl<T: Clone, D, P: Push<Bundle<T, D>>, H: Fn(&T, &D)->u64>  Exchange<T, D, P, 
     }
 }
 
-impl<T: Eq+Data, D: Data, P: Push<Bundle<T, D>>, H: Fn(&T, &D)->u64> Push<Bundle<T, D>> for Exchange<T, D, P, H> {
+impl<T: Eq+Data, D: Data, P: Push<Bundle<T, D>>, H: FnMut(&T, &D)->u64> Push<Bundle<T, D>> for Exchange<T, D, P, H> {
     #[inline(never)]
     fn push(&mut self, message: &mut Option<Bundle<T, D>>) {
         // if only one pusher, no exchange

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -198,27 +198,20 @@ pub struct InputEvent {
     pub start_stop: StartStop,
 }
 
-#[derive(Serialize, Deserialize, Abomonation, Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
-/// Input logic start/stop
-pub struct ParkEvent {
-    /// True when activity begins, false when it stops
-    pub event: ParkUnpark
-}
-
-impl ParkEvent {
-    /// Creates a new park event from the supplied duration.
-    pub fn park(duration: Option<Duration>) -> Self { ParkEvent { event: ParkUnpark::Park(duration) } }
-    /// Creates a new unpark event.
-    pub fn unpark() -> Self { ParkEvent { event: ParkUnpark::Unpark } }
-}
-
 /// Records the starting and stopping of an operator.
 #[derive(Serialize, Deserialize, Abomonation, Debug, Clone, Hash, PartialEq, Eq, Ord, PartialOrd)]
-pub enum ParkUnpark {
+pub enum ParkEvent {
     /// Worker parks.
     Park(Option<Duration>),
     /// Worker unparks.
     Unpark,
+}
+
+impl ParkEvent {
+    /// Creates a new park event from the supplied duration.
+    pub fn park(duration: Option<Duration>) -> Self { ParkEvent::Park(duration) }
+    /// Creates a new unpark event.
+    pub fn unpark() -> Self { ParkEvent::Unpark }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Abomonation, Hash, Eq, PartialEq, Ord, PartialOrd)]


### PR DESCRIPTION
This PR changes the closure type used for data exchange from `Fn` to `FnMut`, allowing it to own its own mutable state and preventing it from being called concurrently.

The motivation is that some more sophisticated exchange functions might take e.g. a `Vec<D>` and pick out a subset of elements, and hash the result. This is easiest when the closure owns its own `Vec<D>` that can be populated (or even a `Vec<&D>`, though lifetimes probably prevent that).