### PR TITLE
Builder simplification

### DIFF
--- a/timely/src/dataflow/operators/capture/capture.rs
+++ b/timely/src/dataflow/operators/capture/capture.rs
@@ -5,9 +5,6 @@
 //! and there are several default implementations, including a linked-list, Rust's MPSC
 //! queue, and a binary serializer wrapping any `W: Write`.
 
-use std::rc::Rc;
-use std::cell::RefCell;
-
 use crate::Data;
 use crate::dataflow::{Scope, Stream};
 use crate::dataflow::channels::pact::Pipeline;
@@ -117,40 +114,36 @@ pub trait Capture<T: Timestamp, D: Data> {
 }
 
 impl<S: Scope, D: Data> Capture<S::Timestamp, D> for Stream<S, D> {
-    fn capture_into<P: EventPusher<S::Timestamp, D>+'static>(&self, event_pusher: P) {
+    fn capture_into<P: EventPusher<S::Timestamp, D>+'static>(&self, mut event_pusher: P) {
 
         let mut builder = OperatorBuilder::new("Capture".to_owned(), self.scope());
         let mut input = PullCounter::new(builder.new_input(self, Pipeline));
         let mut started = false;
 
-        let event_pusher1 = Rc::new(RefCell::new(event_pusher));
-        let event_pusher2 = event_pusher1.clone();
-
         builder.build(
-            move |frontier| {
+            move |frontier, consumed, _internal, _external| {
 
                 if !started {
+                    // discard initial capability.
                     frontier[0].update(Default::default(), -1);
                     started = true;
                 }
                 if !frontier[0].is_empty() {
+                    // transmit any frontier progress.
                     let to_send = ::std::mem::replace(&mut frontier[0], ChangeBatch::new());
-                    event_pusher1.borrow_mut().push(Event::Progress(to_send.into_inner()));
+                    event_pusher.push(Event::Progress(to_send.into_inner()));
                 }
-            },
-            move |consumed, _internal, _external| {
 
                 use crate::communication::message::RefOrMut;
 
                 // turn each received message into an event.
-                let mut borrow = event_pusher2.borrow_mut();
                 while let Some(message) = input.next() {
                     let (time, data) = match message.as_ref_or_mut() {
                         RefOrMut::Ref(reference) => (&reference.time, RefOrMut::Ref(&reference.data)),
                         RefOrMut::Mut(reference) => (&reference.time, RefOrMut::Mut(&mut reference.data)),
                     };
                     let vector = data.replace(Vec::new());
-                    borrow.push(Event::Messages(time.clone(), vector));
+                    event_pusher.push(Event::Messages(time.clone(), vector));
                 }
                 input.consumed().borrow_mut().drain_into(&mut consumed[0]);
                 false

--- a/timely/src/dataflow/operators/capture/replay.rs
+++ b/timely/src/dataflow/operators/capture/replay.rs
@@ -71,8 +71,7 @@ where I : IntoIterator,
         let mut started = false;
 
         builder.build(
-            move |_frontier| { },
-            move |_consumed, internal, produced| {
+            move |_frontier, _consumed, internal, produced| {
 
                 if !started {
                     // The first thing we do is modify our capabilities to match the number of streams we manage.

--- a/timely/src/dataflow/operators/capture/replay.rs
+++ b/timely/src/dataflow/operators/capture/replay.rs
@@ -71,13 +71,13 @@ where I : IntoIterator,
         let mut started = false;
 
         builder.build(
-            move |_frontier, _consumed, internal, produced| {
+            move |progress| {
 
                 if !started {
                     // The first thing we do is modify our capabilities to match the number of streams we manage.
                     // This should be a simple change of `self.event_streams.len() - 1`. We only do this once, as
                     // our very first action.
-                    internal[0].update(Default::default(), (event_streams.len() as i64) - 1);
+                    progress.internals[0].update(Default::default(), (event_streams.len() as i64) - 1);
                     started = true;
                 }
 
@@ -85,7 +85,7 @@ where I : IntoIterator,
                     while let Some(event) = event_stream.next() {
                         match *event {
                             Event::Progress(ref vec) => {
-                                internal[0].extend(vec.iter().cloned());
+                                progress.internals[0].extend(vec.iter().cloned());
                             },
                             Event::Messages(ref time, ref data) => {
                                 output.session(time).give_iterator(data.iter().cloned());
@@ -98,7 +98,7 @@ where I : IntoIterator,
                 activator.activate();
 
                 output.cease();
-                output.inner().produced().borrow_mut().drain_into(&mut produced[0]);
+                output.inner().produced().borrow_mut().drain_into(&mut progress.produceds[0]);
 
                 false
             }

--- a/timely/src/dataflow/operators/probe.rs
+++ b/timely/src/dataflow/operators/probe.rs
@@ -94,19 +94,20 @@ impl<G: Scope, D: Data> Probe<G, D> for Stream<G, D> {
         let (tee, stream) = builder.new_output();
         let mut output = PushBuffer::new(PushCounter::new(tee));
 
-        let frontier = handle.frontier.clone();
+        let shared_frontier = handle.frontier.clone();
         let mut started = false;
 
         let mut vector = Vec::new();
 
         builder.build(
-            move |changes| {
-                let mut borrow = frontier.borrow_mut();
-                borrow.update_iter(changes[0].drain());
-            },
-            move |consumed, internal, produced| {
+            move |frontier, consumed, internal, produced| {
+
+                // surface all frontier changes to the shared frontier.
+                let mut borrow = shared_frontier.borrow_mut();
+                borrow.update_iter(frontier[0].drain());
 
                 if !started {
+                    // discard initial capability.
                     internal[0].update(Default::default(), -1);
                     started = true;
                 }

--- a/timely/src/dataflow/operators/probe.rs
+++ b/timely/src/dataflow/operators/probe.rs
@@ -100,15 +100,15 @@ impl<G: Scope, D: Data> Probe<G, D> for Stream<G, D> {
         let mut vector = Vec::new();
 
         builder.build(
-            move |frontier, consumed, internal, produced| {
+            move |progress| {
 
                 // surface all frontier changes to the shared frontier.
                 let mut borrow = shared_frontier.borrow_mut();
-                borrow.update_iter(frontier[0].drain());
+                borrow.update_iter(progress.frontiers[0].drain());
 
                 if !started {
                     // discard initial capability.
-                    internal[0].update(Default::default(), -1);
+                    progress.internals[0].update(Default::default(), -1);
                     started = true;
                 }
 
@@ -125,8 +125,8 @@ impl<G: Scope, D: Data> Probe<G, D> for Stream<G, D> {
                 output.cease();
 
                 // extract what we know about progress from the input and output adapters.
-                input.consumed().borrow_mut().drain_into(&mut consumed[0]);
-                output.inner().produced().borrow_mut().drain_into(&mut produced[0]);
+                input.consumed().borrow_mut().drain_into(&mut progress.consumeds[0]);
+                output.inner().produced().borrow_mut().drain_into(&mut progress.produceds[0]);
 
                 false
             },


### PR DESCRIPTION
This PR simplifies the operator builder pattern to use fewer and simpler closures to define an operator. 

Previously, an operator was defined by two closures, "pull internal progress" and "push external progress" as these two methods were managed separately by subgraphs. They have since been unified into one method that does both (and maintains some invariants). The single method now takes a single argument which is their unified state (a mutable reference to the `SharedProgress` object that exchanges progress state between operator and scope, and whose contents define the contract between the two).