### PR TITLE
log operator shutdown

### DIFF
--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -740,3 +740,10 @@ impl<T: Timestamp> PerOperatorState<T> {
         }
     }
 }
+
+// Explicitly shut down the operator to get logged information.
+impl<T: Timestamp> Drop for PerOperatorState<T> {
+    fn drop(&mut self) {
+        self.shut_down();
+    }
+}


### PR DESCRIPTION
This PR explicitly shuts down operators in their drop code, to ensure that we produce logging events as this happens, instead of just incidentally dropping operators if a containing subgraph can determine that we have concluded.