### PR TITLE
Add interfaces for activating across thread boundaries

### DIFF
--- a/timely/src/scheduling/mod.rs
+++ b/timely/src/scheduling/mod.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 
 pub mod activate;
 
-pub use self::activate::{Activations, Activator, ActivateOnDrop};
+pub use self::activate::{Activations, Activator, ActivateOnDrop, SyncActivator};
 
 /// A type that can be scheduled.
 pub trait Schedule {
@@ -24,9 +24,14 @@ pub trait Schedule {
 pub trait Scheduler {
     /// Provides a shared handle to the activation scheduler.
     fn activations(&self) -> Rc<RefCell<Activations>>;
-    ///
+    /// Constructs an `Activator` tied to the specified operator address.
     fn activator_for(&self, path: &[usize]) -> Activator {
         let activations = self.activations().clone();
         Activator::new(path, activations)
+    }
+    /// Constructs a `SyncActivator` tied to the specified operator address.
+    fn sync_activator_for(&self, path: &[usize]) -> SyncActivator {
+        let sync_activations = self.activations().borrow().sync();
+        SyncActivator::new(path, sync_activations)
     }
 }


### PR DESCRIPTION
Add interfaces that make it easy to send activations across thread
boundaries.

The approach is to give `Activations` an MPSC channel which it checks
for activation requests on every call to `advance`. Other threads can
acquire a handle to the send side of this object via `SyncActivations`
or `SyncActivator`, which are careful to also call unpark on the
associated worker thread for easy interop with `Worker.step_or_park`.

@frankmcsherry I created more interfaces than we actually need just to see how it feels–and I think it feels pretty good! My WIP @MaterializeInc branch only uses `SyncActivator`, so we could potentially inline the `SyncActivations` struct, but the symmetry with `Activator` and `Activations` seemed like it might be nice. We could also expose the underlying `SendError` directly, instead of replacing it with a `SyncActivationError`.