### PR TITLE
address underflow

### DIFF
--- a/timely/src/scheduling/activate.rs
+++ b/timely/src/scheduling/activate.rs
@@ -148,7 +148,11 @@ impl Activations {
             Some(Duration::new(0,0))
         }
         else {
-            self.queue.peek().map(|Reverse((t,_a))| *t - self.timer.elapsed())
+            self.queue.peek().map(|Reverse((t,_a))| {
+                let elapsed = self.timer.elapsed();
+                if t < &elapsed { Duration::new(0,0) }
+                else { *t - elapsed }
+            })
         }
     }
 }


### PR DESCRIPTION
`Duration` cannot be negative, and causes problems if that happens. So we guard that case and flatten down to a zero duration in that case.