### PR TITLE
Re-order channel interactions

### DIFF
--- a/communication/src/allocator/counters.rs
+++ b/communication/src/allocator/counters.rs
@@ -91,13 +91,13 @@ impl<T, P: Push<T>> Push<T> for ArcPusher<T, P> {
         // else {
         //     self.count += 1;
         // }
+        self.pusher.push(element);
+
         let _ =
         self.events
             .send((self.index, Event::Pushed(1)));
             // TODO : Perhaps this shouldn't be a fatal error (e.g. in shutdown).
             // .expect("Failed to send message count");
-
-        self.pusher.push(element)
     }
 }
 

--- a/communication/src/allocator/counters.rs
+++ b/communication/src/allocator/counters.rs
@@ -62,17 +62,19 @@ pub struct ArcPusher<T, P: Push<T>> {
     events: Sender<(usize, Event)>,
     pusher: P,
     phantom: ::std::marker::PhantomData<T>,
+    buzzer: crate::buzzer::Buzzer,
 }
 
 impl<T, P: Push<T>>  ArcPusher<T, P> {
     /// Wraps a pusher with a message counter.
-    pub fn new(pusher: P, index: usize, events: Sender<(usize, Event)>) -> Self {
+    pub fn new(pusher: P, index: usize, events: Sender<(usize, Event)>, buzzer: crate::buzzer::Buzzer) -> Self {
         ArcPusher {
             index,
             // count: 0,
             events,
             pusher,
             phantom: ::std::marker::PhantomData,
+            buzzer,
         }
     }
 }
@@ -93,9 +95,8 @@ impl<T, P: Push<T>> Push<T> for ArcPusher<T, P> {
         // }
         self.pusher.push(element);
 
-        let _ =
-        self.events
-            .send((self.index, Event::Pushed(1)));
+        let _ = self.events.send((self.index, Event::Pushed(1)));
+        self.buzzer.buzz();
             // TODO : Perhaps this shouldn't be a fatal error (e.g. in shutdown).
             // .expect("Failed to send message count");
     }

--- a/communication/src/allocator/counters.rs
+++ b/communication/src/allocator/counters.rs
@@ -93,12 +93,16 @@ impl<T, P: Push<T>> Push<T> for ArcPusher<T, P> {
         // else {
         //     self.count += 1;
         // }
-        self.pusher.push(element);
 
+        // These three calls should happen in this order, to ensure that
+        // we first enqueue data, second enqueue interest in the channel,
+        // and finally awaken the thread. Other orders are defective when
+        // multiple threads are involved.
+        self.pusher.push(element);
         let _ = self.events.send((self.index, Event::Pushed(1)));
-        self.buzzer.buzz();
             // TODO : Perhaps this shouldn't be a fatal error (e.g. in shutdown).
             // .expect("Failed to send message count");
+        self.buzzer.buzz();
     }
 }
 

--- a/communication/src/allocator/process.rs
+++ b/communication/src/allocator/process.rs
@@ -128,7 +128,7 @@ impl Allocate for Process {
                 for index in 0 .. self.peers {
                     let (s, r): (Sender<Message<T>>, Receiver<Message<T>>) = channel();
                     // TODO: the buzzer in the pusher may be redundant, because we need to buzz post-counter.
-                    pushers.push((Pusher { target: s, buzzer: self.buzzers[index].clone() }, self.buzzers[index].clone()));
+                    pushers.push((Pusher { target: s }, self.buzzers[index].clone()));
                     pullers.push(Puller { source: r, current: None });
                 }
 
@@ -193,14 +193,12 @@ impl Allocate for Process {
 /// The push half of an intra-process channel.
 struct Pusher<T> {
     target: Sender<T>,
-    buzzer: Buzzer,
 }
 
 impl<T> Clone for Pusher<T> {
     fn clone(&self) -> Self {
         Self {
             target: self.target.clone(),
-            buzzer: self.buzzer.clone()
         }
     }
 }
@@ -209,7 +207,6 @@ impl<T> Push<T> for Pusher<T> {
     #[inline] fn push(&mut self, element: &mut Option<T>) {
         if let Some(element) = element.take() {
             self.target.send(element).unwrap();
-            self.buzzer.buzz();
         }
     }
 }


### PR DESCRIPTION
This PR amends the order of pushing of elements into shared queues to avoid a race in which a thread is first alerted and then shown data. The details are not 100% clear to me at the moment, but we should try it out.

cc @ryzhyk 