### PR TITLE
Change fn to fnmut

### DIFF
--- a/timely/src/dataflow/operators/enterleave.rs
+++ b/timely/src/dataflow/operators/enterleave.rs
@@ -74,11 +74,11 @@ pub trait EnterAt<G: Scope, T: Timestamp, D: Data> {
     ///     });
     /// });
     /// ```
-    fn enter_at<'a, F:Fn(&D)->T+'static>(&self, scope: &Iterative<'a, G, T>, initial: F) -> Stream<Iterative<'a, G, T>, D> ;
+    fn enter_at<'a, F:FnMut(&D)->T+'static>(&self, scope: &Iterative<'a, G, T>, initial: F) -> Stream<Iterative<'a, G, T>, D> ;
 }
 
 impl<G: Scope, T: Timestamp, D: Data, E: Enter<G, Product<<G as ScopeParent>::Timestamp, T>, D>> EnterAt<G, T, D> for E {
-    fn enter_at<'a, F:Fn(&D)->T+'static>(&self, scope: &Iterative<'a, G, T>, initial: F) ->
+    fn enter_at<'a, F:FnMut(&D)->T+'static>(&self, scope: &Iterative<'a, G, T>, mut initial: F) ->
         Stream<Iterative<'a, G, T>, D> {
             self.enter(scope).delay(move |datum, time| Product::new(time.clone().to_outer(), initial(datum)))
     }

--- a/timely/src/dataflow/operators/filter.rs
+++ b/timely/src/dataflow/operators/filter.rs
@@ -19,11 +19,11 @@ pub trait Filter<D: Data> {
     ///            .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn filter(&self, predicate: impl Fn(&D)->bool+'static) -> Self;
+    fn filter<P: FnMut(&D)->bool+'static>(&self, predicate: P) -> Self;
 }
 
 impl<G: Scope, D: Data> Filter<D> for Stream<G, D> {
-    fn filter(&self, predicate: impl Fn(&D)->bool+'static) -> Stream<G, D> {
+    fn filter<P: FnMut(&D)->bool+'static>(&self, mut predicate: P) -> Stream<G, D> {
         let mut vector = Vec::new();
         self.unary(Pipeline, "Filter", move |_,_| move |input, output| {
             input.for_each(|time, data| {

--- a/timely/src/dataflow/operators/map.rs
+++ b/timely/src/dataflow/operators/map.rs
@@ -19,7 +19,7 @@ pub trait Map<S: Scope, D: Data> {
     ///            .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn map<D2: Data>(&self, logic: impl Fn(D)->D2+'static) -> Stream<S, D2>;
+    fn map<D2: Data, L: FnMut(D)->D2+'static>(&self, logic: L) -> Stream<S, D2>;
     /// Updates each element of the stream and yields the element, re-using memory where possible.
     ///
     /// # Examples
@@ -32,7 +32,7 @@ pub trait Map<S: Scope, D: Data> {
     ///            .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn map_in_place(&self, logic: impl Fn(&mut D)+'static) -> Stream<S, D>;
+    fn map_in_place<L: FnMut(&mut D)+'static>(&self, logic: L) -> Stream<S, D>;
     /// Consumes each element of the stream and yields some number of new elements.
     ///
     /// # Examples
@@ -45,11 +45,11 @@ pub trait Map<S: Scope, D: Data> {
     ///            .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn flat_map<I: IntoIterator>(&self, logic: impl Fn(D)->I+'static) -> Stream<S, I::Item> where I::Item: Data;
+    fn flat_map<I: IntoIterator, L: FnMut(D)->I+'static>(&self, logic: L) -> Stream<S, I::Item> where I::Item: Data;
 }
 
 impl<S: Scope, D: Data> Map<S, D> for Stream<S, D> {
-    fn map<D2: Data>(&self, logic: impl Fn(D)->D2+'static) -> Stream<S, D2> {
+    fn map<D2: Data, L: FnMut(D)->D2+'static>(&self, mut logic: L) -> Stream<S, D2> {
         let mut vector = Vec::new();
         self.unary(Pipeline, "Map", move |_,_| move |input, output| {
             input.for_each(|time, data| {
@@ -58,7 +58,7 @@ impl<S: Scope, D: Data> Map<S, D> for Stream<S, D> {
             });
         })
     }
-    fn map_in_place(&self, logic: impl Fn(&mut D)+'static) -> Stream<S, D> {
+    fn map_in_place<L: FnMut(&mut D)+'static>(&self, mut logic: L) -> Stream<S, D> {
         let mut vector = Vec::new();
         self.unary(Pipeline, "MapInPlace", move |_,_| move |input, output| {
             input.for_each(|time, data| {
@@ -71,7 +71,7 @@ impl<S: Scope, D: Data> Map<S, D> for Stream<S, D> {
     // TODO : This would be more robust if it captured an iterator and then pulled an appropriate
     // TODO : number of elements from the iterator. This would allow iterators that produce many
     // TODO : records without taking arbitrarily long and arbitrarily much memory.
-    fn flat_map<I: IntoIterator>(&self, logic: impl Fn(D)->I+'static) -> Stream<S, I::Item> where I::Item: Data {
+    fn flat_map<I: IntoIterator, L: FnMut(D)->I+'static>(&self, mut logic: L) -> Stream<S, I::Item> where I::Item: Data {
         let mut vector = Vec::new();
         self.unary(Pipeline, "FlatMap", move |_,_| move |input, output| {
             input.for_each(|time, data| {


### PR DESCRIPTION
This PR changes various occurrences of `Fn` to `FnMut` to allow more flexibility in operator closures. In particular, the allows closures to capture and re-use buffers, which they previously struggled to do.

cc @jamii