### PR TITLE
small typo in chapter_2_5.md

### DIFF
--- a/mdbook/src/chapter_2/chapter_2_5.md
+++ b/mdbook/src/chapter_2/chapter_2_5.md
@@ -199,7 +199,7 @@ As before, I'm just going to show you the new code, which now lives just after `
                 .unary_frontier(
                     Exchange::new(|x: &(String, i64)| (x.0).len() as u64),
                     "WordCount",
-                    |capability, operator_info| {
+                    |_capability, operator_info| {
 
                     // allocate operator-local storage.
                     let mut queues = HashMap::new();


### PR DESCRIPTION
the capability variable shows up in 2 code blocks -- in the first one it is `capability` and in the 2nd it's `_capability`. This PR changes the first occurrence to match the 2nd.