### PR TITLE
Add, clone, debug, deref (with target &[Capability<T>]) and from_elem to CapabilitySet

### DIFF
--- a/timely/src/dataflow/operators/capability.rs
+++ b/timely/src/dataflow/operators/capability.rs
@@ -308,6 +308,7 @@ impl<T: Timestamp> Drop for ActivateCapability<T> {
 }
 
 /// A set of capabilities, for possibly incomparable times.
+#[derive(Clone, Debug)]
 pub struct CapabilitySet<T: Timestamp> {
     elements: Vec<Capability<T>>,
 }

--- a/timely/src/dataflow/operators/capability.rs
+++ b/timely/src/dataflow/operators/capability.rs
@@ -319,6 +319,39 @@ impl<T: Timestamp> CapabilitySet<T> {
         CapabilitySet { elements: Vec::new() }
     }
 
+    /// Allocates a capability set containing a single capability.
+    ///
+    /// # Examples
+    /// ```
+    /// use std::collections::HashMap;
+    /// use timely::dataflow::{
+    ///     operators::{ToStream, generic::Operator},
+    ///     channels::pact::Pipeline,
+    /// };
+    /// use timely::dataflow::operators::CapabilitySet;
+    ///
+    /// timely::example(|scope| {
+    ///     vec![()].into_iter().to_stream(scope)
+    ///         .unary_frontier(Pipeline, "example", |default_cap, _info| {
+    ///             let mut cap = CapabilitySet::from_elem(default_cap);
+    ///             let mut vector = Vec::new();
+    ///             move |input, output| {
+    ///                 cap.downgrade(&input.frontier().frontier());
+    ///                 while let Some((time, data)) = input.next() {
+    ///                     data.swap(&mut vector);
+    ///                 }
+    ///                 let a_cap = cap.first();
+    ///                 if let Some(a_cap) = a_cap.as_ref() {
+    ///                     output.session(a_cap).give(());
+    ///                 }
+    ///             }
+    ///         });
+    /// });
+    /// ```
+    pub fn from_elem(cap: Capability<T>) -> Self {
+        CapabilitySet { elements: vec![cap] }
+    }
+
     /// Inserts `capability` into the set, discarding redundant capabilities.
     pub fn insert(&mut self, capability: Capability<T>) {
         if !self.elements.iter().any(|c| c.less_equal(&capability)) {
@@ -344,5 +377,13 @@ impl<T: Timestamp> CapabilitySet<T> {
             self.elements.push(capability);
         }
         self.elements.drain(..count);
+    }
+}
+
+impl<T: Timestamp> Deref for CapabilitySet<T> {
+    type Target=[Capability<T>];
+
+    fn deref(&self) -> &[Capability<T>] {
+        &self.elements[..]
     }
 }


### PR DESCRIPTION
`from_elem` allocates a `CapabilitySet` containing a single capability.
This is useful when making a `CapabilitySet` out of the default
capability provided to a new operator (as shown in the example for
`from_elem`).
This is an ergonomics improvement. `from_elem` is the same name used
in `Antichain`:
https://github.com/TimelyDataflow/timely-dataflow/blob/8f0c22b1523784e28d3ac6e5eab30fa6d0a03839/timely/src/progress/frontier.rs#L73-L82

`deref` lets the operator use the capabilities in the set to e.g. open a
session and send messages (again, as shown in the example for
`from_elem`).