### PR TITLE
Add PartialOrder impls

### DIFF
--- a/timely/src/progress/frontier.rs
+++ b/timely/src/progress/frontier.rs
@@ -138,9 +138,10 @@ impl<T: PartialOrder> Antichain<T> {
     }
 
     /// Returns true if every element of `other` is greater or equal to some element of `self`.
+    #[deprecated(since="0.12.0", note="please use `PartialOrder::less_equal` instead")]
     #[inline]
     pub fn dominates(&self, other: &Antichain<T>) -> bool {
-        other.elements().iter().all(|t2| self.elements().iter().any(|t1| t1.less_equal(t2)))
+        <Self as PartialOrder>::less_equal(self, other)
     }
 
     /// Reveals the elements in the antichain.

--- a/timely/src/progress/frontier.rs
+++ b/timely/src/progress/frontier.rs
@@ -488,10 +488,20 @@ impl<T: PartialOrder+Ord+Clone, I: IntoIterator<Item=(T,i64)>> MutableAntichainF
 }
 
 /// A wrapper for elements of an antichain.
+#[derive(Debug)]
 pub struct AntichainRef<'a, T: 'a> {
     /// Elements contained in the antichain.
     frontier: &'a [T],
 }
+
+impl<'a, T: 'a> Clone for AntichainRef<'a, T> {
+    fn clone(&self) -> Self {
+        Self {
+            frontier: self.frontier.clone(),
+        }
+    }
+}
+impl<'a, T: 'a> Copy for AntichainRef<'a, T> { }
 
 impl<'a, T: 'a> AntichainRef<'a, T> {
     /// Create a new `AntichainRef` from a reference to a slice of elements forming the frontier.
@@ -501,6 +511,22 @@ impl<'a, T: 'a> AntichainRef<'a, T> {
     pub fn new(frontier: &'a [T]) -> Self {
         Self {
             frontier,
+        }
+    }
+
+    /// Constructs an owned antichain from the antichain reference.
+    ///
+    /// # Examples
+    ///
+    ///```
+    /// use timely::progress::{Antichain, frontier::AntichainRef};
+    ///
+    /// let frontier = AntichainRef::new(&[1u64]);
+    /// assert_eq!(frontier.to_owned(), Antichain::from_elem(1u64));
+    ///```
+    pub fn to_owned(&self) -> Antichain<T> where T: Clone {
+        Antichain {
+            elements: self.frontier.to_vec()
         }
     }
 }

--- a/timely/src/progress/frontier.rs
+++ b/timely/src/progress/frontier.rs
@@ -159,7 +159,7 @@ impl<T> Antichain<T> {
     /// use timely::progress::frontier::Antichain;
     ///
     /// let mut frontier = Antichain::from_elem(2);
-    /// assert_eq!(frontier.elements(), &[2]);
+    /// assert_eq!(&*frontier.elements(), &[2]);
     ///```
     #[inline] pub fn elements(&self) -> AntichainRef<T> { AntichainRef::new(&self.elements[..]) }
 }

--- a/timely/src/progress/frontier.rs
+++ b/timely/src/progress/frontier.rs
@@ -9,7 +9,11 @@ use crate::order::PartialOrder;
 /// This antichain implementation allows you to repeatedly introduce elements to the antichain, and
 /// which will evict larger elements to maintain the *minimal* antichain, those incomparable elements
 /// no greater than any other element.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Abomonation, Serialize, Deserialize)]
+///
+/// Two antichains are equal if the contain the same set of elements, even if in different orders.
+/// This can make equality testing quadratic, though linear in the common case that the sequences
+/// are identical.
+#[derive(Clone, Debug, Default, Abomonation, Serialize, Deserialize)]
 pub struct Antichain<T> {
     elements: Vec<T>
 }
@@ -59,44 +63,6 @@ impl<T: PartialOrder> Antichain<T> {
         added
     }
 
-    /// Creates a new empty `Antichain`.
-    ///
-    /// # Examples
-    ///
-    ///```
-    /// use timely::progress::frontier::Antichain;
-    ///
-    /// let mut frontier = Antichain::<u32>::new();
-    ///```
-    pub fn new() -> Antichain<T> { Antichain { elements: Vec::new() } }
-
-    /// Creates a new singleton `Antichain`.
-    ///
-    /// # Examples
-    ///
-    ///```
-    /// use timely::progress::frontier::Antichain;
-    ///
-    /// let mut frontier = Antichain::from_elem(2);
-    ///```
-    pub fn from_elem(element: T) -> Antichain<T> { Antichain { elements: vec![element] } }
-
-    /// Clears the contents of the antichain.
-    ///
-    /// # Examples
-    ///
-    ///```
-    /// use timely::progress::frontier::Antichain;
-    ///
-    /// let mut frontier = Antichain::from_elem(2);
-    /// frontier.clear();
-    /// assert!(frontier.elements().is_empty());
-    ///```
-    pub fn clear(&mut self) { self.elements.clear() }
-
-    /// Sorts the elements so that comparisons between antichains can be made.
-    pub fn sort(&mut self) where T: Ord { self.elements.sort() }
-
     /// Returns true if any item in the antichain is strictly less than the argument.
     ///
     /// # Examples
@@ -143,6 +109,47 @@ impl<T: PartialOrder> Antichain<T> {
     pub fn dominates(&self, other: &Antichain<T>) -> bool {
         <Self as PartialOrder>::less_equal(self, other)
     }
+}
+
+impl<T> Antichain<T> {
+
+    /// Creates a new empty `Antichain`.
+    ///
+    /// # Examples
+    ///
+    ///```
+    /// use timely::progress::frontier::Antichain;
+    ///
+    /// let mut frontier = Antichain::<u32>::new();
+    ///```
+    pub fn new() -> Antichain<T> { Antichain { elements: Vec::new() } }
+
+    /// Creates a new singleton `Antichain`.
+    ///
+    /// # Examples
+    ///
+    ///```
+    /// use timely::progress::frontier::Antichain;
+    ///
+    /// let mut frontier = Antichain::from_elem(2);
+    ///```
+    pub fn from_elem(element: T) -> Antichain<T> { Antichain { elements: vec![element] } }
+
+    /// Clears the contents of the antichain.
+    ///
+    /// # Examples
+    ///
+    ///```
+    /// use timely::progress::frontier::Antichain;
+    ///
+    /// let mut frontier = Antichain::from_elem(2);
+    /// frontier.clear();
+    /// assert!(frontier.elements().is_empty());
+    ///```
+    pub fn clear(&mut self) { self.elements.clear() }
+
+    /// Sorts the elements so that comparisons between antichains can be made.
+    pub fn sort(&mut self) where T: Ord { self.elements.sort() }
 
     /// Reveals the elements in the antichain.
     ///
@@ -156,6 +163,19 @@ impl<T: PartialOrder> Antichain<T> {
     ///```
     #[inline] pub fn elements(&self) -> &[T] { &self.elements[..] }
 }
+
+impl<T: PartialEq> PartialEq for Antichain<T> {
+    fn eq(&self, other: &Self) -> bool {
+        // Lengths should be the same, with the option for fast acceptance if identical.
+        self.elements().len() == other.elements().len() &&
+        (
+            self.elements().iter().zip(other.elements().iter()).all(|(t1,t2)| t1 == t2) ||
+            self.elements().iter().all(|t1| other.elements().iter().any(|t2| t1.eq(t2)))
+        )
+    }
+}
+
+impl<T: Eq> Eq for Antichain<T> { }
 
 impl<T: PartialOrder> PartialOrder for Antichain<T> {
     fn less_equal(&self, other: &Self) -> bool {

--- a/timely/src/progress/frontier.rs
+++ b/timely/src/progress/frontier.rs
@@ -156,6 +156,12 @@ impl<T: PartialOrder> Antichain<T> {
     #[inline] pub fn elements(&self) -> &[T] { &self.elements[..] }
 }
 
+impl<T: PartialOrder> PartialOrder for Antichain<T> {
+    fn less_equal(&self, other: &Self) -> bool {
+        other.elements().iter().all(|t2| self.elements().iter().any(|t1| t1.less_equal(t2)))
+    }
+}
+
 /// An antichain based on a multiset whose elements frequencies can be updated.
 ///
 /// The `MutableAntichain` maintains frequencies for many elements of type `T`, and exposes the set
@@ -539,6 +545,12 @@ impl<'a, T: 'a+PartialOrder> AntichainRef<'a, T> {
     /// Copies `self` into a new `Vec`.
     pub fn to_vec(&self) -> Vec<T> where T: Clone {
         self.frontier.to_vec()
+    }
+}
+
+impl<'a, T: PartialOrder> PartialOrder for AntichainRef<'a, T> {
+    fn less_equal(&self, other: &Self) -> bool {
+        other.iter().all(|t2| self.iter().any(|t1| t1.less_equal(t2)))
     }
 }
 


### PR DESCRIPTION
This PR adds `PartialOrder` implementations for `Antichain` and `AntichainRef`. The methods `less_equal` and `less_than` clash with the per-time implementations (perhaps those should only be for antichains, which each singleton time is), but the inherent methods take priority in resolution, and this doesn't *appear* to cause any breakage.

The intent here is to allow these types to implement `Lattice` in the differential crate, in the interest of tidying up a bunch of bespoke logic.

cc @LorenzSelv