### PR TITLE
Properly log progress messages

### DIFF
--- a/timely/src/dataflow/operators/mod.rs
+++ b/timely/src/dataflow/operators/mod.rs
@@ -25,6 +25,7 @@ pub use self::probe::Probe;
 pub use self::to_stream::ToStream;
 pub use self::capture::Capture;
 pub use self::branch::{Branch, BranchWhen};
+pub use self::ok_err::OkErr;
 
 pub use self::generic::Operator;
 pub use self::generic::{Notificator, FrontierNotificator};
@@ -49,6 +50,7 @@ pub mod probe;
 pub mod to_stream;
 pub mod capture;
 pub mod branch;
+pub mod ok_err;
 
 pub mod aggregation;
 pub mod generic;

--- a/timely/src/dataflow/operators/ok_err.rs
+++ b/timely/src/dataflow/operators/ok_err.rs
@@ -1,0 +1,82 @@
+//! Operators that separate one stream into two streams based on some condition
+
+use crate::dataflow::channels::pact::Pipeline;
+use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
+use crate::dataflow::{Scope, Stream};
+use crate::Data;
+
+/// Extension trait for `Stream`.
+pub trait OkErr<S: Scope, D: Data> {
+    /// Takes one input stream and splits it into two output streams.
+    /// For each record, the supplied closure is called with a reference to
+    /// the data and its time. If it returns true, the record will be sent
+    /// to the second returned stream, otherwise it will be sent to the first.
+    ///
+    /// If the result of the closure only depends on the time, not the data,
+    /// `branch_when` should be used instead.
+    ///
+    /// # Examples
+    /// ```
+    /// use timely::dataflow::operators::{ToStream, OkErr, Inspect};
+    ///
+    /// timely::example(|scope| {
+    ///     let (odd, even) = (0..10)
+    ///         .to_stream(scope)
+    ///         .ok_err(|x| if x % 2 == 0 { Ok(x) } else { Err(x) });
+    ///
+    ///     even.inspect(|x| println!("even numbers: {:?}", x));
+    ///     odd.inspect(|x| println!("odd numbers: {:?}", x));
+    /// });
+    /// ```
+    fn ok_err<D1, D2, L>(
+        &self,
+        logic: L,
+    ) -> (Stream<S, D1>, Stream<S, D2>)
+
+    where
+        D1: Data,
+        D2: Data,
+        L: FnMut(D) -> Result<D1,D2>+'static
+    ;
+}
+
+impl<S: Scope, D: Data> OkErr<S, D> for Stream<S, D> {
+    fn ok_err<D1, D2, L>(
+        &self,
+        mut logic: L,
+    ) -> (Stream<S, D1>, Stream<S, D2>)
+
+    where
+        D1: Data,
+        D2: Data,
+        L: FnMut(D) -> Result<D1,D2>+'static
+    {
+        let mut builder = OperatorBuilder::new("OkErr".to_owned(), self.scope());
+
+        let mut input = builder.new_input(self, Pipeline);
+        let (mut output1, stream1) = builder.new_output();
+        let (mut output2, stream2) = builder.new_output();
+
+        builder.build(move |_| {
+            let mut vector = Vec::new();
+            move |_frontiers| {
+                let mut output1_handle = output1.activate();
+                let mut output2_handle = output2.activate();
+
+                input.for_each(|time, data| {
+                    data.swap(&mut vector);
+                    let mut out1 = output1_handle.session(&time);
+                    let mut out2 = output2_handle.session(&time);
+                    for datum in vector.drain(..) {
+                        match logic(datum) {
+                            Ok(datum) => out1.give(datum),
+                            Err(datum) => out2.give(datum),
+                        }
+                    }
+                });
+            }
+        });
+
+        (stream1, stream2)
+    }
+}

--- a/timely/src/progress/broadcast.rs
+++ b/timely/src/progress/broadcast.rs
@@ -1,7 +1,7 @@
 //! Broadcasts progress information among workers.
 
 use crate::progress::{ChangeBatch, Timestamp};
-use crate::progress::Location;
+use crate::progress::{Location, Port};
 use crate::communication::{Message, Push, Pull};
 use crate::logging::TimelyLogger as Logger;
 
@@ -58,16 +58,33 @@ impl<T:Timestamp+Send> Progcaster<T> {
         changes.compact();
         if !changes.is_empty() {
 
-            self.logging.as_ref().map(|l| l.log(crate::logging::ProgressEvent {
-                is_send: true,
-                source: self.source,
-                channel: self.channel_identifier,
-                seq_no: self.counter,
-                addr: self.addr.clone(),
-                // TODO: fill with additional data
-                messages: Vec::new(),
-                internal: Vec::new(),
-            }));
+            self.logging.as_ref().map(|l| {
+
+                let mut messages = Vec::with_capacity(changes.len());
+                let mut internal = Vec::with_capacity(changes.len());
+
+                // TODO: Reconsider `String` type or perhaps re-use allocation.
+                for ((location, time), diff) in changes.iter() {
+                    match location.port {
+                        Port::Target(port) => {
+                            messages.push((location.node, port, format!("{:?}", time), *diff))
+                        },
+                        Port::Source(port) => {
+                            internal.push((location.node, port, format!("{:?}", time), *diff))
+                        }
+                    }
+                }
+
+                l.log(crate::logging::ProgressEvent {
+                    is_send: true,
+                    source: self.source,
+                    channel: self.channel_identifier,
+                    seq_no: self.counter,
+                    addr: self.addr.clone(),
+                    messages,
+                    internal,
+                });
+            });
 
             for pusher in self.pushers.iter_mut() {
 
@@ -108,16 +125,33 @@ impl<T:Timestamp+Send> Progcaster<T> {
 
             let addr = &mut self.addr;
             let channel = self.channel_identifier;
-            self.logging.as_ref().map(|l| l.log(crate::logging::ProgressEvent {
-                is_send: false,
-                source: source,
-                seq_no: counter,
-                channel,
-                addr: addr.clone(),
-                // TODO: fill with additional data
-                messages: Vec::new(),
-                internal: Vec::new(),
-            }));
+            self.logging.as_ref().map(|l| {
+
+                let mut messages = Vec::with_capacity(changes.len());
+                let mut internal = Vec::with_capacity(changes.len());
+
+                // TODO: Reconsider `String` type or perhaps re-use allocation.
+                for ((location, time), diff) in changes.iter() {
+                    match location.port {
+                        Port::Target(port) => {
+                            messages.push((location.node, port, format!("{:?}", time), *diff))
+                        },
+                        Port::Source(port) => {
+                            internal.push((location.node, port, format!("{:?}", time), *diff))
+                        }
+                    }
+                }
+
+                l.log(crate::logging::ProgressEvent {
+                    is_send: false,
+                    source: source,
+                    seq_no: counter,
+                    channel,
+                    addr: addr.clone(),
+                    messages,
+                    internal,
+                });
+            });
 
             // We clone rather than drain to avoid deserialization.
             for &(ref update, delta) in recv_changes.iter() {

--- a/timely/src/progress/broadcast.rs
+++ b/timely/src/progress/broadcast.rs
@@ -131,7 +131,7 @@ impl<T:Timestamp+Send> Progcaster<T> {
                 let mut internal = Vec::with_capacity(changes.len());
 
                 // TODO: Reconsider `String` type or perhaps re-use allocation.
-                for ((location, time), diff) in changes.iter() {
+                for ((location, time), diff) in recv_changes.iter() {
                     match location.port {
                         Port::Target(port) => {
                             messages.push((location.node, port, format!("{:?}", time), *diff))

--- a/timely/src/progress/change_batch.rs
+++ b/timely/src/progress/change_batch.rs
@@ -201,6 +201,27 @@ impl<T:Ord> ChangeBatch<T> {
         }
     }
 
+    /// Number of compacted updates.
+    ///
+    /// This method requires mutable access to `self` because it may need to compact the
+    /// representation to determine the number of actual updates.
+    ///
+    /// # Examples
+    ///
+    ///```
+    /// use timely::progress::ChangeBatch;
+    ///
+    /// let mut batch = ChangeBatch::<usize>::new_from(17, 1);
+    /// batch.update(17, -1);
+    /// batch.update(14, -1);
+    /// assert_eq!(batch.len(), 1);
+    ///```
+    #[inline]
+    pub fn len(&mut self) -> usize {
+        self.compact();
+        self.updates.len()
+    }
+
     /// Drains `self` into `other`.
     ///
     /// This method has similar a effect to calling `other.extend(self.drain())`, but has the
@@ -251,7 +272,7 @@ impl<T:Ord> ChangeBatch<T> {
     }
 
     /// Expose the internal vector of updates.
-    pub fn unstable_internal_updates(&self) -> &Vec<(T, i64)> { &self.updates }
+    pub fn unstable_internal_updates(&self) -> &[(T, i64)] { &self.updates[..] }
 
     /// Expose the internal value of `clean`.
     pub fn unstable_internal_clean(&self) -> usize { self.clean }


### PR DESCRIPTION
Log progress messages, converting timestamps to strings. This puts more allocation behind each of these messages (from an empty vector to a vector of strings) but there doesn't seem to be much to do about it if we want to see the actual progress contents moving around.

The receive side has the potentially to be much spammier than the send side, as this is a broadcast. Depending on the volume we may want to dial that down and just presume that sent messages are not lost in transit (we would lose the timing information about when they are received though). For the moment, we log lots of things.

cc: @utaal @saradecova