### PR TITLE
Relax pointstamp validation

### DIFF
--- a/kafkaesque/Cargo.toml
+++ b/kafkaesque/Cargo.toml
@@ -10,4 +10,4 @@ abomonation="0.7"
 timely = { path = "../timely" }
 
 [dependencies.rdkafka]
-version = "0.20.0"
+version = "0.23.0"

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -720,8 +720,9 @@ impl<T: Timestamp> PerOperatorState<T> {
             for (time, diff) in internal.iter() {
                 if *diff > 0 {
                     let consumed = shared_progress.consumeds.iter_mut().any(|x| x.iter().any(|(t,d)| *d > 0 && t.less_equal(time)));
-                    let internal = child_state.sources[output].pointstamps.less_equal(time);
+                    let internal = child_state.sources[output].implications.less_equal(time);
                     if !consumed && !internal {
+                        println!("Increment at {:?}, not supported by\n\tconsumed: {:?}\n\tinternal: {:?}", time, shared_progress.consumeds, child_state.sources[output].implications);
                         panic!("Progress error; internal {:?}", self.name);
                     }
                 }
@@ -731,8 +732,9 @@ impl<T: Timestamp> PerOperatorState<T> {
             for (time, diff) in produced.iter() {
                 if *diff > 0 {
                     let consumed = shared_progress.consumeds.iter_mut().any(|x| x.iter().any(|(t,d)| *d > 0 && t.less_equal(time)));
-                    let internal = child_state.sources[output].pointstamps.less_equal(time);
+                    let internal = child_state.sources[output].implications.less_equal(time);
                     if !consumed && !internal {
+                        println!("Increment at {:?}, not supported by\n\tconsumed: {:?}\n\tinternal: {:?}", time, shared_progress.consumeds, child_state.sources[output].implications);
                         panic!("Progress error; produced {:?}", self.name);
                     }
                 }


### PR DESCRIPTION
In #327 the pointstamp validation logic was made more strict, requiring either that an input message be consumed or that a capability existed. This is too strict, owing to the hierarchical nature of progress tracking.

Specifically, running differential's `bfs` the following way, with two processes
```
cargo run --example bfs -- 10 10 10 100000000 no -w1 -n2 -p0
cargo run --example bfs -- 10 10 10 100000000 no -w1 -n2 -p1
```
results in a crash.

The reason here is (I think) that a subgraph, which presents upward as an operator, may internally receive a message from another peer. The subgraph presents the existence of that message upward as an internal capability. However, the subgraph operator may not have yet received notice of any incoming message, nor hold any other capability. Nonetheless, nothing is actually wrong (other than that the protocol is hard to verify locally).

I think the summary is: prior to #327 the `validate_progress` test could pass progress information that could be invalid (as the issue notes, because races could mean that the progress information is about to change). After #327 the `validate_progress` test can fail progress information that is valid.

There is a legit complaint that the progress traffic is hard to locally verify, which I 100% agree with. I think there is a dopey answer that is "operators should buffer progress information that does not yet make sense" which is permitted because (unless there are bugs) there no safety requirements that progress traffic move at any speed.