### PR TITLE
Change naming of long-lived threads

### DIFF
--- a/communication/src/allocator/zero_copy/initialize.rs
+++ b/communication/src/allocator/zero_copy/initialize.rs
@@ -91,7 +91,7 @@ pub fn initialize_networking_from_sockets(
                 let stream = stream.try_clone()?;
                 let join_guard =
                 ::std::thread::Builder::new()
-                    .name(format!("send thread {}", index))
+                    .name(format!("timely:send-{}", index))
                     .spawn(move || {
 
                         let logger = log_sender(CommunicationSetup {
@@ -114,7 +114,7 @@ pub fn initialize_networking_from_sockets(
                 let stream = stream.try_clone()?;
                 let join_guard =
                 ::std::thread::Builder::new()
-                    .name(format!("recv thread {}", index))
+                    .name(format!("timely:recv-{}", index))
                     .spawn(move || {
                         let logger = log_sender(CommunicationSetup {
                             process: my_index,

--- a/communication/src/initialize.rs
+++ b/communication/src/initialize.rs
@@ -263,7 +263,7 @@ where
     for (index, builder) in builders.into_iter().enumerate() {
         let clone = logic.clone();
         guards.push(thread::Builder::new()
-                            .name(format!("worker thread {}", index))
+                            .name(format!("timely:worker-{}", index))
                             .spawn(move || {
                                 let communicator = builder.build();
                                 (*clone)(communicator)


### PR DESCRIPTION
This makes threads obviously come from timely, and is aligned with common
formatting -- no whitespace and a `:` between library name and thread purpose.

It is more common to have all threads have exactly the same name, but obviously
in most libraries threads are completely interchangeable, where they are unique
in timely.