### PR TITLE
Shave two characters off of worker thread name

### DIFF
--- a/communication/src/initialize.rs
+++ b/communication/src/initialize.rs
@@ -263,7 +263,7 @@ where
     for (index, builder) in builders.into_iter().enumerate() {
         let clone = logic.clone();
         guards.push(thread::Builder::new()
-                            .name(format!("timely:worker-{}", index))
+                            .name(format!("timely:work-{}", index))
                             .spawn(move || {
                                 let communicator = builder.build();
                                 (*clone)(communicator)


### PR DESCRIPTION
Linux limits thread names to 15 characters. This limit interacts poorly
with the naming of worker threads, as e.g. worker thread 10's name gets
truncated to "timely:worker-1".

Use "timely:work" as the prefix instead, which leaves space for three
digits of thread ID, and is nicely symmetric with the "timely:send" and
"timely:recv" threads.