### PR TITLE
Use crossbeam-channel instead of std::sync::mpsc

### DIFF
--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -25,3 +25,4 @@ abomonation = "0.7"
 abomonation_derive = "0.5"
 timely_bytes = { path = "../bytes", version = "0.11" }
 timely_logging = { path = "../logging", version = "0.11" }
+crossbeam-channel = "0.4.3"

--- a/communication/src/allocator/counters.rs
+++ b/communication/src/allocator/counters.rs
@@ -53,7 +53,7 @@ impl<T, P: Push<T>> Push<T> for Pusher<T, P> {
     }
 }
 
-use std::sync::mpsc::Sender;
+use crossbeam_channel::Sender;
 
 /// The push half of an intra-thread channel.
 pub struct ArcPusher<T, P: Push<T>> {

--- a/communication/src/allocator/process.rs
+++ b/communication/src/allocator/process.rs
@@ -4,9 +4,9 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
 use std::any::Any;
-use std::sync::mpsc::{Sender, Receiver, channel};
 use std::time::Duration;
 use std::collections::{HashMap, VecDeque};
+use crossbeam_channel::{Sender, Receiver};
 
 use crate::allocator::thread::{ThreadBuilder};
 use crate::allocator::{Allocate, AllocateBuilder, Event, Thread};
@@ -76,7 +76,7 @@ impl Process {
         let mut counters_send = Vec::new();
         let mut counters_recv = Vec::new();
         for _ in 0 .. peers {
-            let (send, recv) = channel();
+            let (send, recv) = crossbeam_channel::unbounded();
             counters_send.push(send);
             counters_recv.push(recv);
         }
@@ -126,7 +126,7 @@ impl Allocate for Process {
                 let mut pushers = Vec::new();
                 let mut pullers = Vec::new();
                 for index in 0 .. self.peers {
-                    let (s, r): (Sender<Message<T>>, Receiver<Message<T>>) = channel();
+                    let (s, r): (Sender<Message<T>>, Receiver<Message<T>>) = crossbeam_channel::unbounded();
                     // TODO: the buzzer in the pusher may be redundant, because we need to buzz post-counter.
                     pushers.push((Pusher { target: s }, self.buzzers[index].clone()));
                     pullers.push(Puller { source: r, current: None });

--- a/communication/src/allocator/zero_copy/allocator.rs
+++ b/communication/src/allocator/zero_copy/allocator.rs
@@ -2,7 +2,7 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::collections::{VecDeque, HashMap, hash_map::Entry};
-use std::sync::mpsc::{Sender, Receiver};
+use crossbeam_channel::{Sender, Receiver};
 
 use bytes::arc::Bytes;
 

--- a/communication/src/allocator/zero_copy/allocator_process.rs
+++ b/communication/src/allocator/zero_copy/allocator_process.rs
@@ -3,7 +3,7 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::collections::{VecDeque, HashMap, hash_map::Entry};
-use std::sync::mpsc::{Sender, Receiver};
+use crossbeam_channel::{Sender, Receiver};
 
 use bytes::arc::Bytes;
 

--- a/communication/src/allocator/zero_copy/tcp.rs
+++ b/communication/src/allocator/zero_copy/tcp.rs
@@ -2,7 +2,7 @@
 
 use std::io::{Read, Write};
 use std::net::TcpStream;
-use std::sync::mpsc::{Sender, Receiver};
+use crossbeam_channel::{Sender, Receiver};
 
 use crate::networking::MessageHeader;
 

--- a/communication/src/lib.rs
+++ b/communication/src/lib.rs
@@ -167,7 +167,7 @@ impl<T, P: ?Sized + Pull<T>> Pull<T> for Box<P> {
 }
 
 
-use std::sync::mpsc::{Sender, Receiver, channel};
+use crossbeam_channel::{Sender, Receiver};
 
 /// Allocate a matrix of send and receive changes to exchange items.
 ///
@@ -181,7 +181,7 @@ fn promise_futures<T>(sends: usize, recvs: usize) -> (Vec<Vec<Sender<T>>>, Vec<V
 
     for sender in 0 .. sends {
         for recver in 0 .. recvs {
-            let (send, recv) = channel();
+            let (send, recv) = crossbeam_channel::unbounded();
             senders[sender].push(send);
             recvers[recver].push(recv);
         }

--- a/timely/Cargo.toml
+++ b/timely/Cargo.toml
@@ -26,6 +26,7 @@ abomonation_derive = "0.5"
 timely_bytes = { path = "../bytes", version = "0.11" }
 timely_logging = { path = "../logging", version = "0.11" }
 timely_communication = { path = "../communication", version = "0.11" }
+crossbeam-channel = "0.4.3"
 
 [dev-dependencies]
 timely_sort="0.1.6"

--- a/timely/src/scheduling/activate.rs
+++ b/timely/src/scheduling/activate.rs
@@ -2,11 +2,11 @@
 
 use std::rc::Rc;
 use std::cell::RefCell;
-use std::sync::mpsc::{Sender, Receiver};
 use std::thread::Thread;
 use std::collections::BinaryHeap;
 use std::time::{Duration, Instant};
 use std::cmp::Reverse;
+use crossbeam_channel::{Sender, Receiver};
 
 /// Methods required to act as a timely scheduler.
 ///
@@ -55,7 +55,7 @@ impl Activations {
 
     /// Creates a new activation tracker.
     pub fn new(timer: Instant) -> Self {
-        let (tx, rx) = std::sync::mpsc::channel();
+        let (tx, rx) = crossbeam_channel::unbounded();
         Self {
             clean: 0,
             bounds: Vec::new(),


### PR DESCRIPTION
See MaterializeInc/materialize#3870 for the context. I admit this might be scary and a totally bad idea!

There are two reasons motivating this change:

* Crossbeam senders implement the `Sync` trait. This is particularly
  useful for the `SyncActivator`. It is much more ergonomic if the
  `SyncActivator` implements the `Sync` trait, which is only possible if
  the contained channel transmitter itself implements `Sync`.

* Crossbeam channels seem faster. A very simple benchmark via

      $ cargo run --example exchange --release -- 10000 10000 -w2

  decreases from 604ms to 568ms.