### PR TITLE
Allow a Duration offset to logging times

### DIFF
--- a/timely/src/execute.rs
+++ b/timely/src/execute.rs
@@ -168,6 +168,7 @@ where
                     let mut logger = BatchLogger::new(writer);
                     result = Some(crate::logging_core::Logger::new(
                         ::std::time::Instant::now(),
+                        ::std::time::Duration::default(),
                         events_setup,
                         move |time, data| logger.publish_batch(time, data)
                     ));


### PR DESCRIPTION
This PR allows loggers to be constructed with a `offset: Duration` which will be added to logged times. The underlying `Instant` used to produce the times can not be much modified (e.g. on OSX it is based on uptime, and cannot go negative). If one wanted to put the `Logger` types into a consistent calibration (e.g. the Unix epoch) one can now use a duration to do this.