### PR TITLE
Provide for worker-configuration parameters

### DIFF
--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -13,7 +13,11 @@ repository = "https://github.com/TimelyDataflow/timely-dataflow.git"
 keywords = ["timely", "dataflow"]
 license = "MIT"
 
+[features]
+default = ["getopts"]
+
 [dependencies]
+getopts = { version = "0.2.14", optional = true }
 bincode = { version = "1.0", optional = true }
 serde_derive = "1.0"
 serde = "1.0"

--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -13,11 +13,7 @@ repository = "https://github.com/TimelyDataflow/timely-dataflow.git"
 keywords = ["timely", "dataflow"]
 license = "MIT"
 
-[features]
-default = ["getopts"]
-
 [dependencies]
-getopts = { version = "0.2.14", optional = true}
 bincode = { version = "1.0", optional = true }
 serde_derive = "1.0"
 serde = "1.0"

--- a/communication/examples/comm_hello.rs
+++ b/communication/examples/comm_hello.rs
@@ -5,8 +5,14 @@ use timely_communication::{Message, Allocate};
 
 fn main() {
 
-    // extract the configuration from user-supplied arguments, initialize the computation.
-    let config = timely_communication::Configuration::from_args(std::env::args()).unwrap();
+    // use a hardcoded configuration
+    let config = timely_communication::CommunicationConfig::Cluster {
+        threads: 4,
+        process: 0,
+        addresses: vec!["localhost:2101".into()],
+        report: false,
+        log_fn: Box::new(|_| None),
+    };
     let guards = timely_communication::initialize(config, |mut allocator| {
 
         println!("worker {} of {} started", allocator.index(), allocator.peers());

--- a/communication/examples/comm_hello.rs
+++ b/communication/examples/comm_hello.rs
@@ -5,14 +5,8 @@ use timely_communication::{Message, Allocate};
 
 fn main() {
 
-    // use a hardcoded configuration
-    let config = timely_communication::CommunicationConfig::Cluster {
-        threads: 4,
-        process: 0,
-        addresses: vec!["localhost:2101".into()],
-        report: false,
-        log_fn: Box::new(|_| None),
-    };
+    // extract the configuration from user-supplied arguments, initialize the computation.
+    let config = timely_communication::Config::from_args(std::env::args()).unwrap();
     let guards = timely_communication::initialize(config, |mut allocator| {
 
         println!("worker {} of {} started", allocator.index(), allocator.peers());

--- a/communication/src/lib.rs
+++ b/communication/src/lib.rs
@@ -19,7 +19,7 @@
 //! use timely_communication::Allocate;
 //!
 //! // configure for two threads, just one process.
-//! let config = timely_communication::Configuration::Process(2);
+//! let config = timely_communication::CommunicationConfig::Process(2);
 //!
 //! // initializes communication, spawns workers
 //! let guards = timely_communication::initialize(config, |mut allocator| {
@@ -104,7 +104,7 @@ use abomonation::Abomonation;
 
 pub use allocator::Generic as Allocator;
 pub use allocator::Allocate;
-pub use initialize::{initialize, initialize_from, Configuration, WorkerGuards};
+pub use initialize::{initialize, initialize_from, CommunicationConfig, WorkerGuards};
 pub use message::Message;
 
 /// A composite trait for types that may be used with channels.

--- a/communication/src/lib.rs
+++ b/communication/src/lib.rs
@@ -19,7 +19,7 @@
 //! use timely_communication::Allocate;
 //!
 //! // configure for two threads, just one process.
-//! let config = timely_communication::CommunicationConfig::Process(2);
+//! let config = timely_communication::Config::Process(2);
 //!
 //! // initializes communication, spawns workers
 //! let guards = timely_communication::initialize(config, |mut allocator| {
@@ -104,7 +104,7 @@ use abomonation::Abomonation;
 
 pub use allocator::Generic as Allocator;
 pub use allocator::Allocate;
-pub use initialize::{initialize, initialize_from, CommunicationConfig, WorkerGuards};
+pub use initialize::{initialize, initialize_from, Config, WorkerGuards};
 pub use message::Message;
 
 /// A composite trait for types that may be used with channels.

--- a/timely/Cargo.toml
+++ b/timely/Cargo.toml
@@ -19,6 +19,7 @@ license = "MIT"
 bincode= ["timely_communication/bincode"]
 
 [dependencies]
+getopts = "0.2.14"
 serde = "1.0"
 serde_derive = "1.0"
 abomonation = "0.7.3"

--- a/timely/Cargo.toml
+++ b/timely/Cargo.toml
@@ -16,10 +16,12 @@ keywords = ["timely", "dataflow"]
 license = "MIT"
 
 [features]
+default = ["getopts"]
 bincode= ["timely_communication/bincode"]
+getopts = ["getopts-dep", "timely_communication/getopts"]
 
 [dependencies]
-getopts = "0.2.14"
+getopts-dep = { package = "getopts", version = "0.2.14", optional = true }
 serde = "1.0"
 serde_derive = "1.0"
 abomonation = "0.7.3"

--- a/timely/examples/logging-send.rs
+++ b/timely/examples/logging-send.rs
@@ -9,8 +9,7 @@ use timely::logging::TimelyEvent;
 
 fn main() {
     // initializes and runs a timely dataflow.
-    let config = timely::Configuration::from_args(::std::env::args()).unwrap();
-    timely::execute(config, |worker| {
+    timely::execute_from_args(std::env::args(), |worker| {
 
         let batch = std::env::args().nth(1).unwrap().parse::<usize>().unwrap();
         let rounds = std::env::args().nth(2).unwrap().parse::<usize>().unwrap();

--- a/timely/examples/sequence.rs
+++ b/timely/examples/sequence.rs
@@ -2,11 +2,11 @@ extern crate timely;
 
 use std::time::{Instant, Duration};
 
-use timely::execute::ExecuteConfig;
+use timely::Config;
 use timely::synchronization::Sequencer;
 
 fn main() {
-    timely::execute(ExecuteConfig::process(4), |worker| {
+    timely::execute(Config::process(4), |worker| {
 
         let timer = Instant::now();
         let mut sequencer = Sequencer::new(worker, Instant::now());

--- a/timely/examples/sequence.rs
+++ b/timely/examples/sequence.rs
@@ -2,11 +2,11 @@ extern crate timely;
 
 use std::time::{Instant, Duration};
 
-use timely::Configuration;
+use timely::execute::ExecuteConfig;
 use timely::synchronization::Sequencer;
 
 fn main() {
-    timely::execute(Configuration::Process(4), |worker| {
+    timely::execute(ExecuteConfig::process(4), |worker| {
 
         let timer = Instant::now();
         let mut sequencer = Sequencer::new(worker, Instant::now());
@@ -21,6 +21,6 @@ fn main() {
             }
             worker.step();
         }
-        
+
     }).unwrap(); // asserts error-free execution;
 }

--- a/timely/examples/threadless.rs
+++ b/timely/examples/threadless.rs
@@ -2,7 +2,7 @@ extern crate timely;
 
 use timely::dataflow::{InputHandle, ProbeHandle};
 use timely::dataflow::operators::{Inspect, Probe};
-use timely::worker::WorkerConfig;
+use timely::WorkerConfig;
 
 fn main() {
 

--- a/timely/examples/threadless.rs
+++ b/timely/examples/threadless.rs
@@ -2,12 +2,13 @@ extern crate timely;
 
 use timely::dataflow::{InputHandle, ProbeHandle};
 use timely::dataflow::operators::{Inspect, Probe};
+use timely::worker::WorkerConfig;
 
 fn main() {
 
     // create a naked single-threaded worker.
     let allocator = timely::communication::allocator::Thread::new();
-    let mut worker = timely::worker::Worker::new(allocator);
+    let mut worker = timely::worker::Worker::new(WorkerConfig::default(), allocator);
 
     // create input and probe handles.
     let mut input = InputHandle::new();

--- a/timely/examples/unordered_input.rs
+++ b/timely/examples/unordered_input.rs
@@ -2,11 +2,11 @@ extern crate timely;
 extern crate timely_communication;
 
 use timely::dataflow::operators::*;
-use timely_communication::Configuration;
+use timely::execute::ExecuteConfig;
 // use timely::progress::timestamp::RootTimestamp;
 
 fn main() {
-    timely::execute(Configuration::Thread, |worker| {
+    timely::execute(ExecuteConfig::thread(), |worker| {
         let (mut input, mut cap) = worker.dataflow::<usize,_,_>(|scope| {
             let (input, stream) = scope.new_unordered_input();
             stream.inspect_batch(|t, x| println!("{:?} -> {:?}", t, x));

--- a/timely/examples/unordered_input.rs
+++ b/timely/examples/unordered_input.rs
@@ -2,11 +2,11 @@ extern crate timely;
 extern crate timely_communication;
 
 use timely::dataflow::operators::*;
-use timely::execute::ExecuteConfig;
+use timely::Config;
 // use timely::progress::timestamp::RootTimestamp;
 
 fn main() {
-    timely::execute(ExecuteConfig::thread(), |worker| {
+    timely::execute(Config::thread(), |worker| {
         let (mut input, mut cap) = worker.dataflow::<usize,_,_>(|scope| {
             let (input, stream) = scope.new_unordered_input();
             stream.inspect_batch(|t, x| println!("{:?} -> {:?}", t, x));

--- a/timely/src/dataflow/operators/capture/capture.rs
+++ b/timely/src/dataflow/operators/capture/capture.rs
@@ -36,7 +36,7 @@ pub trait Capture<T: Timestamp, D: Data> {
     /// let (send, recv) = ::std::sync::mpsc::channel();
     /// let send = Arc::new(Mutex::new(send));
     ///
-    /// timely::execute(timely::Configuration::Thread, move |worker| {
+    /// timely::execute(timely::ExecuteConfig::thread(), move |worker| {
     ///
     ///     // this is only to validate the output.
     ///     let send = send.lock().unwrap().clone();
@@ -76,7 +76,7 @@ pub trait Capture<T: Timestamp, D: Data> {
     /// let (send0, recv0) = ::std::sync::mpsc::channel();
     /// let send0 = Arc::new(Mutex::new(send0));
     ///
-    /// timely::execute(timely::Configuration::Thread, move |worker| {
+    /// timely::execute(timely::ExecuteConfig::thread(), move |worker| {
     ///
     ///     // this is only to validate the output.
     ///     let send0 = send0.lock().unwrap().clone();

--- a/timely/src/dataflow/operators/capture/capture.rs
+++ b/timely/src/dataflow/operators/capture/capture.rs
@@ -36,7 +36,7 @@ pub trait Capture<T: Timestamp, D: Data> {
     /// let (send, recv) = ::std::sync::mpsc::channel();
     /// let send = Arc::new(Mutex::new(send));
     ///
-    /// timely::execute(timely::ExecuteConfig::thread(), move |worker| {
+    /// timely::execute(timely::Config::thread(), move |worker| {
     ///
     ///     // this is only to validate the output.
     ///     let send = send.lock().unwrap().clone();
@@ -76,7 +76,7 @@ pub trait Capture<T: Timestamp, D: Data> {
     /// let (send0, recv0) = ::std::sync::mpsc::channel();
     /// let send0 = Arc::new(Mutex::new(send0));
     ///
-    /// timely::execute(timely::ExecuteConfig::thread(), move |worker| {
+    /// timely::execute(timely::Config::thread(), move |worker| {
     ///
     ///     // this is only to validate the output.
     ///     let send0 = send0.lock().unwrap().clone();

--- a/timely/src/dataflow/operators/capture/extract.rs
+++ b/timely/src/dataflow/operators/capture/extract.rs
@@ -22,7 +22,7 @@ pub trait Extract<T: Ord, D: Ord> {
     /// let (send, recv) = ::std::sync::mpsc::channel();
     /// let send = Arc::new(Mutex::new(send));
     ///
-    /// timely::execute(timely::Configuration::Thread, move |worker| {
+    /// timely::execute(timely::ExecuteConfig::thread(), move |worker| {
     ///
     ///     // this is only to validate the output.
     ///     let send = send.lock().unwrap().clone();

--- a/timely/src/dataflow/operators/capture/extract.rs
+++ b/timely/src/dataflow/operators/capture/extract.rs
@@ -22,7 +22,7 @@ pub trait Extract<T: Ord, D: Ord> {
     /// let (send, recv) = ::std::sync::mpsc::channel();
     /// let send = Arc::new(Mutex::new(send));
     ///
-    /// timely::execute(timely::ExecuteConfig::thread(), move |worker| {
+    /// timely::execute(timely::Config::thread(), move |worker| {
     ///
     ///     // this is only to validate the output.
     ///     let send = send.lock().unwrap().clone();

--- a/timely/src/dataflow/operators/capture/mod.rs
+++ b/timely/src/dataflow/operators/capture/mod.rs
@@ -24,7 +24,7 @@
 //! use timely::dataflow::operators::{Capture, ToStream, Inspect};
 //! use timely::dataflow::operators::capture::{EventLink, Replay};
 //!
-//! timely::execute(timely::ExecuteConfig::thread(), |worker| {
+//! timely::execute(timely::Config::thread(), |worker| {
 //!     let handle1 = Rc::new(EventLink::new());
 //!     let handle2 = Some(handle1.clone());
 //!
@@ -52,7 +52,7 @@
 //! use timely::dataflow::operators::{Capture, ToStream, Inspect};
 //! use timely::dataflow::operators::capture::{EventReader, EventWriter, Replay};
 //!
-//! timely::execute(timely::ExecuteConfig::thread(), |worker| {
+//! timely::execute(timely::Config::thread(), |worker| {
 //!     let list = TcpListener::bind("127.0.0.1:8000").unwrap();
 //!     let send = TcpStream::connect("127.0.0.1:8000").unwrap();
 //!     let recv = list.incoming().next().unwrap().unwrap();

--- a/timely/src/dataflow/operators/capture/mod.rs
+++ b/timely/src/dataflow/operators/capture/mod.rs
@@ -24,7 +24,7 @@
 //! use timely::dataflow::operators::{Capture, ToStream, Inspect};
 //! use timely::dataflow::operators::capture::{EventLink, Replay};
 //!
-//! timely::execute(timely::Configuration::Thread, |worker| {
+//! timely::execute(timely::ExecuteConfig::thread(), |worker| {
 //!     let handle1 = Rc::new(EventLink::new());
 //!     let handle2 = Some(handle1.clone());
 //!
@@ -52,7 +52,7 @@
 //! use timely::dataflow::operators::{Capture, ToStream, Inspect};
 //! use timely::dataflow::operators::capture::{EventReader, EventWriter, Replay};
 //!
-//! timely::execute(timely::Configuration::Thread, |worker| {
+//! timely::execute(timely::ExecuteConfig::thread(), |worker| {
 //!     let list = TcpListener::bind("127.0.0.1:8000").unwrap();
 //!     let send = TcpStream::connect("127.0.0.1:8000").unwrap();
 //!     let recv = list.incoming().next().unwrap().unwrap();

--- a/timely/src/dataflow/operators/generic/notificator.rs
+++ b/timely/src/dataflow/operators/generic/notificator.rs
@@ -189,7 +189,7 @@ fn notificator_delivers_notifications_in_topo_order() {
 /// use timely::dataflow::operators::generic::operator::Operator;
 /// use timely::dataflow::channels::pact::Pipeline;
 ///
-/// timely::execute(timely::ExecuteConfig::thread(), |worker| {
+/// timely::execute(timely::Config::thread(), |worker| {
 ///     let (mut in1, mut in2) = worker.dataflow::<usize,_,_>(|scope| {
 ///         let (in1_handle, in1) = scope.new_input();
 ///         let (in2_handle, in2) = scope.new_input();

--- a/timely/src/dataflow/operators/generic/notificator.rs
+++ b/timely/src/dataflow/operators/generic/notificator.rs
@@ -189,7 +189,7 @@ fn notificator_delivers_notifications_in_topo_order() {
 /// use timely::dataflow::operators::generic::operator::Operator;
 /// use timely::dataflow::channels::pact::Pipeline;
 ///
-/// timely::execute(timely::Configuration::Thread, |worker| {
+/// timely::execute(timely::ExecuteConfig::thread(), |worker| {
 ///     let (mut in1, mut in2) = worker.dataflow::<usize,_,_>(|scope| {
 ///         let (in1_handle, in1) = scope.new_input();
 ///         let (in2_handle, in2) = scope.new_input();

--- a/timely/src/dataflow/operators/generic/operator.rs
+++ b/timely/src/dataflow/operators/generic/operator.rs
@@ -147,7 +147,7 @@ pub trait Operator<G: Scope, D1: Data> {
     /// use timely::dataflow::operators::generic::operator::Operator;
     /// use timely::dataflow::channels::pact::Pipeline;
     ///
-    /// timely::execute(timely::ExecuteConfig::thread(), |worker| {
+    /// timely::execute(timely::Config::thread(), |worker| {
     ///    let (mut in1, mut in2) = worker.dataflow::<usize,_,_>(|scope| {
     ///        let (in1_handle, in1) = scope.new_input();
     ///        let (in2_handle, in2) = scope.new_input();
@@ -208,7 +208,7 @@ pub trait Operator<G: Scope, D1: Data> {
     /// use timely::dataflow::operators::generic::operator::Operator;
     /// use timely::dataflow::channels::pact::Pipeline;
     ///
-    /// timely::execute(timely::ExecuteConfig::thread(), |worker| {
+    /// timely::execute(timely::Config::thread(), |worker| {
     ///    let (mut in1, mut in2) = worker.dataflow::<usize,_,_>(|scope| {
     ///        let (in1_handle, in1) = scope.new_input();
     ///        let (in2_handle, in2) = scope.new_input();

--- a/timely/src/dataflow/operators/generic/operator.rs
+++ b/timely/src/dataflow/operators/generic/operator.rs
@@ -147,7 +147,7 @@ pub trait Operator<G: Scope, D1: Data> {
     /// use timely::dataflow::operators::generic::operator::Operator;
     /// use timely::dataflow::channels::pact::Pipeline;
     ///
-    /// timely::execute(timely::Configuration::Thread, |worker| {
+    /// timely::execute(timely::ExecuteConfig::thread(), |worker| {
     ///    let (mut in1, mut in2) = worker.dataflow::<usize,_,_>(|scope| {
     ///        let (in1_handle, in1) = scope.new_input();
     ///        let (in2_handle, in2) = scope.new_input();
@@ -208,7 +208,7 @@ pub trait Operator<G: Scope, D1: Data> {
     /// use timely::dataflow::operators::generic::operator::Operator;
     /// use timely::dataflow::channels::pact::Pipeline;
     ///
-    /// timely::execute(timely::Configuration::Thread, |worker| {
+    /// timely::execute(timely::ExecuteConfig::thread(), |worker| {
     ///    let (mut in1, mut in2) = worker.dataflow::<usize,_,_>(|scope| {
     ///        let (in1_handle, in1) = scope.new_input();
     ///        let (in2_handle, in2) = scope.new_input();

--- a/timely/src/dataflow/operators/input.rs
+++ b/timely/src/dataflow/operators/input.rs
@@ -39,7 +39,7 @@ pub trait Input : Scope {
     /// use timely::dataflow::operators::{Input, Inspect};
     ///
     /// // construct and execute a timely dataflow
-    /// timely::execute(ExecuteConfig::thread(), |worker| {
+    /// timely::execute(Config::thread(), |worker| {
     ///
     ///     // add an input and base computation off of it
     ///     let mut input = worker.dataflow(|scope| {
@@ -71,7 +71,7 @@ pub trait Input : Scope {
     /// use timely::dataflow::operators::input::Handle;
     ///
     /// // construct and execute a timely dataflow
-    /// timely::execute(ExecuteConfig::thread(), |worker| {
+    /// timely::execute(Config::thread(), |worker| {
     ///
     ///     // add an input and base computation off of it
     ///     let mut input = Handle::new();
@@ -189,7 +189,7 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
     /// use timely::dataflow::operators::input::Handle;
     ///
     /// // construct and execute a timely dataflow
-    /// timely::execute(ExecuteConfig::thread(), |worker| {
+    /// timely::execute(Config::thread(), |worker| {
     ///
     ///     // add an input and base computation off of it
     ///     let mut input = Handle::new();
@@ -226,7 +226,7 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
     /// use timely::dataflow::operators::input::Handle;
     ///
     /// // construct and execute a timely dataflow
-    /// timely::execute(ExecuteConfig::thread(), |worker| {
+    /// timely::execute(Config::thread(), |worker| {
     ///
     ///     // add an input and base computation off of it
     ///     let mut input = Handle::new();

--- a/timely/src/dataflow/operators/input.rs
+++ b/timely/src/dataflow/operators/input.rs
@@ -39,7 +39,7 @@ pub trait Input : Scope {
     /// use timely::dataflow::operators::{Input, Inspect};
     ///
     /// // construct and execute a timely dataflow
-    /// timely::execute(Configuration::Thread, |worker| {
+    /// timely::execute(ExecuteConfig::thread(), |worker| {
     ///
     ///     // add an input and base computation off of it
     ///     let mut input = worker.dataflow(|scope| {
@@ -71,7 +71,7 @@ pub trait Input : Scope {
     /// use timely::dataflow::operators::input::Handle;
     ///
     /// // construct and execute a timely dataflow
-    /// timely::execute(Configuration::Thread, |worker| {
+    /// timely::execute(ExecuteConfig::thread(), |worker| {
     ///
     ///     // add an input and base computation off of it
     ///     let mut input = Handle::new();
@@ -189,7 +189,7 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
     /// use timely::dataflow::operators::input::Handle;
     ///
     /// // construct and execute a timely dataflow
-    /// timely::execute(Configuration::Thread, |worker| {
+    /// timely::execute(ExecuteConfig::thread(), |worker| {
     ///
     ///     // add an input and base computation off of it
     ///     let mut input = Handle::new();
@@ -226,7 +226,7 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
     /// use timely::dataflow::operators::input::Handle;
     ///
     /// // construct and execute a timely dataflow
-    /// timely::execute(Configuration::Thread, |worker| {
+    /// timely::execute(ExecuteConfig::thread(), |worker| {
     ///
     ///     // add an input and base computation off of it
     ///     let mut input = Handle::new();

--- a/timely/src/dataflow/operators/probe.rs
+++ b/timely/src/dataflow/operators/probe.rs
@@ -26,7 +26,7 @@ pub trait Probe<G: Scope, D: Data> {
     /// use timely::dataflow::operators::{Input, Probe, Inspect};
     ///
     /// // construct and execute a timely dataflow
-    /// timely::execute(ExecuteConfig::thread(), |worker| {
+    /// timely::execute(Config::thread(), |worker| {
     ///
     ///     // add an input and base computation off of it
     ///     let (mut input, probe) = worker.dataflow(|scope| {
@@ -56,7 +56,7 @@ pub trait Probe<G: Scope, D: Data> {
     /// use timely::dataflow::operators::probe::Handle;
     ///
     /// // construct and execute a timely dataflow
-    /// timely::execute(ExecuteConfig::thread(), |worker| {
+    /// timely::execute(Config::thread(), |worker| {
     ///
     ///     // add an input and base computation off of it
     ///     let mut probe = Handle::new();
@@ -181,14 +181,14 @@ impl<T: Timestamp> Clone for Handle<T> {
 #[cfg(test)]
 mod tests {
 
-    use crate::execute::ExecuteConfig;
+    use crate::Config;
     use crate::dataflow::operators::{Input, Probe};
 
     #[test]
     fn probe() {
 
         // initializes and runs a timely dataflow computation
-        crate::execute(ExecuteConfig::thread(), |worker| {
+        crate::execute(Config::thread(), |worker| {
 
             // create a new input, and inspect its output
             let (mut input, probe) = worker.dataflow(move |scope| {

--- a/timely/src/dataflow/operators/probe.rs
+++ b/timely/src/dataflow/operators/probe.rs
@@ -26,7 +26,7 @@ pub trait Probe<G: Scope, D: Data> {
     /// use timely::dataflow::operators::{Input, Probe, Inspect};
     ///
     /// // construct and execute a timely dataflow
-    /// timely::execute(Configuration::Thread, |worker| {
+    /// timely::execute(ExecuteConfig::thread(), |worker| {
     ///
     ///     // add an input and base computation off of it
     ///     let (mut input, probe) = worker.dataflow(|scope| {
@@ -56,7 +56,7 @@ pub trait Probe<G: Scope, D: Data> {
     /// use timely::dataflow::operators::probe::Handle;
     ///
     /// // construct and execute a timely dataflow
-    /// timely::execute(Configuration::Thread, |worker| {
+    /// timely::execute(ExecuteConfig::thread(), |worker| {
     ///
     ///     // add an input and base computation off of it
     ///     let mut probe = Handle::new();
@@ -181,14 +181,14 @@ impl<T: Timestamp> Clone for Handle<T> {
 #[cfg(test)]
 mod tests {
 
-    use crate::communication::Configuration;
+    use crate::execute::ExecuteConfig;
     use crate::dataflow::operators::{Input, Probe};
 
     #[test]
     fn probe() {
 
         // initializes and runs a timely dataflow computation
-        crate::execute(Configuration::Thread, |worker| {
+        crate::execute(ExecuteConfig::thread(), |worker| {
 
             // create a new input, and inspect its output
             let (mut input, probe) = worker.dataflow(move |scope| {

--- a/timely/src/dataflow/operators/unordered_input.rs
+++ b/timely/src/dataflow/operators/unordered_input.rs
@@ -49,7 +49,7 @@ pub trait UnorderedInput<G: Scope> {
     /// let (send, recv) = ::std::sync::mpsc::channel();
     /// let send = Arc::new(Mutex::new(send));
     ///
-    /// timely::execute(Configuration::Thread, move |worker| {
+    /// timely::execute(ExecuteConfig::thread(), move |worker| {
     ///
     ///     // this is only to validate the output.
     ///     let send = send.lock().unwrap().clone();

--- a/timely/src/dataflow/operators/unordered_input.rs
+++ b/timely/src/dataflow/operators/unordered_input.rs
@@ -49,7 +49,7 @@ pub trait UnorderedInput<G: Scope> {
     /// let (send, recv) = ::std::sync::mpsc::channel();
     /// let send = Arc::new(Mutex::new(send));
     ///
-    /// timely::execute(ExecuteConfig::thread(), move |worker| {
+    /// timely::execute(Config::thread(), move |worker| {
     ///
     ///     // this is only to validate the output.
     ///     let send = send.lock().unwrap().clone();

--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -12,7 +12,7 @@ use crate::progress::{Source, Target};
 use crate::progress::timestamp::Refines;
 use crate::order::Product;
 use crate::logging::TimelyLogger as Logger;
-use crate::worker::{AsWorker, WorkerConfig};
+use crate::worker::{AsWorker, Config};
 
 use super::{ScopeParent, Scope};
 
@@ -52,7 +52,7 @@ where
     G: ScopeParent,
     T: Timestamp+Refines<G::Timestamp>
 {
-    fn config(&self) -> &WorkerConfig { self.parent.config() }
+    fn config(&self) -> &Config { self.parent.config() }
     fn index(&self) -> usize { self.parent.index() }
     fn peers(&self) -> usize { self.parent.peers() }
     fn allocate<D: Data>(&mut self, identifier: usize, address: &[usize]) -> (Vec<Box<dyn Push<Message<D>>>>, Box<dyn Pull<Message<D>>>) {

--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -12,7 +12,7 @@ use crate::progress::{Source, Target};
 use crate::progress::timestamp::Refines;
 use crate::order::Product;
 use crate::logging::TimelyLogger as Logger;
-use crate::worker::AsWorker;
+use crate::worker::{AsWorker, WorkerConfig};
 
 use super::{ScopeParent, Scope};
 
@@ -52,6 +52,7 @@ where
     G: ScopeParent,
     T: Timestamp+Refines<G::Timestamp>
 {
+    fn config(&self) -> &WorkerConfig { self.parent.config() }
     fn index(&self) -> usize { self.parent.index() }
     fn peers(&self) -> usize { self.parent.peers() }
     fn allocate<D: Data>(&mut self, identifier: usize, address: &[usize]) -> (Vec<Box<dyn Push<Message<D>>>>, Box<dyn Pull<Message<D>>>) {

--- a/timely/src/lib.rs
+++ b/timely/src/lib.rs
@@ -67,10 +67,10 @@ extern crate timely_communication;
 extern crate timely_bytes;
 extern crate timely_logging;
 
-pub use execute::{execute, execute_directly, execute_from_args, example};
+pub use execute::{execute, execute_directly, execute_from_args, example, ExecuteConfig};
 pub use order::PartialOrder;
 
-pub use timely_communication::Configuration;
+pub use timely_communication::CommunicationConfig;
 
 /// Re-export of the `timely_communication` crate.
 pub mod communication {

--- a/timely/src/lib.rs
+++ b/timely/src/lib.rs
@@ -67,10 +67,14 @@ extern crate timely_communication;
 extern crate timely_bytes;
 extern crate timely_logging;
 
-pub use execute::{execute, execute_directly, execute_from_args, example, ExecuteConfig};
+pub use execute::{execute, execute_directly, example};
+#[cfg(feature = "getopts")]
+pub use execute::execute_from_args;
 pub use order::PartialOrder;
 
-pub use timely_communication::CommunicationConfig;
+pub use timely_communication::Config as CommunicationConfig;
+pub use worker::Config as WorkerConfig;
+pub use execute::Config as Config;
 
 /// Re-export of the `timely_communication` crate.
 pub mod communication {

--- a/timely/src/synchronization/sequence.rs
+++ b/timely/src/synchronization/sequence.rs
@@ -65,10 +65,10 @@ impl<T: ExchangeData> Sequencer<T> {
     /// ```rust
     /// use std::time::{Instant, Duration};
     ///
-    /// use timely::Configuration;
+    /// use timely::ExecuteConfig;
     /// use timely::synchronization::Sequencer;
     ///
-    /// timely::execute(Configuration::Process(4), |worker| {
+    /// timely::execute(ExecuteConfig::process(4), |worker| {
     ///     let timer = Instant::now();
     ///     let mut sequencer = Sequencer::new(worker, timer);
     ///

--- a/timely/src/synchronization/sequence.rs
+++ b/timely/src/synchronization/sequence.rs
@@ -65,10 +65,10 @@ impl<T: ExchangeData> Sequencer<T> {
     /// ```rust
     /// use std::time::{Instant, Duration};
     ///
-    /// use timely::ExecuteConfig;
+    /// use timely::Config;
     /// use timely::synchronization::Sequencer;
     ///
-    /// timely::execute(ExecuteConfig::process(4), |worker| {
+    /// timely::execute(Config::process(4), |worker| {
     ///     let timer = Instant::now();
     ///     let mut sequencer = Sequencer::new(worker, timer);
     ///

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -3,9 +3,11 @@
 use std::rc::Rc;
 use std::cell::{RefCell, RefMut};
 use std::any::Any;
+use std::str::FromStr;
 use std::time::{Instant, Duration};
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
+use std::sync::Arc;
 
 use crate::communication::{Allocate, Data, Push, Pull};
 use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
@@ -16,11 +18,79 @@ use crate::progress::operate::Operate;
 use crate::dataflow::scopes::Child;
 use crate::logging::TimelyLogger;
 
+/// Progress mode. (???)
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ProgressMode {
+    /// ???
+    Eager,
+    /// ???
+    Demand,
+}
+
+impl Default for ProgressMode {
+    fn default() -> ProgressMode {
+        ProgressMode::Eager
+    }
+}
+
+impl FromStr for ProgressMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<ProgressMode, String> {
+        match s {
+            "eager" => Ok(ProgressMode::Eager),
+            "demand" => Ok(ProgressMode::Demand),
+            _ => Err(format!("unknown progress mode: {}", s)),
+        }
+    }
+}
+
+/// Worker configuration.
+#[derive(Debug, Default, Clone)]
+pub struct WorkerConfig {
+    /// The progress mode to use.
+    pub(crate) progress_mode: ProgressMode,
+    /// A map from parameter name to typed parameter values.
+    registry: HashMap<String, Arc<dyn Any + Send + Sync>>,
+}
+
+impl WorkerConfig {
+    /// Sets the progress mode to `progress_mode`.
+    pub fn progress_mode(mut self, progress_mode: ProgressMode) -> Self {
+        self.progress_mode = progress_mode;
+        self
+    }
+
+    /// Sets a typed configuration parameter for the given `key`.
+    ///
+    /// It is recommended to install a single configuration struct using a key
+    /// that uniquely identifies your project, to avoid clashes. For example,
+    /// differential dataflow registers a configuration struct under the key
+    /// "differential".
+    pub fn set<T>(&mut self, key: String, val: T) -> &mut Self
+    where
+        T: Send + Sync + 'static,
+    {
+        self.registry.insert(key, Arc::new(val));
+        self
+    }
+
+    /// Gets the value for configured parameter `key`.
+    ///
+    /// Returns `None` if `key` has not previously been set with
+    /// [`WorkerConfig::set`], or if the specified `T` does not match the `T`
+    /// from the call to `set`.
+    pub fn get<T: 'static>(&self, key: &str) -> Option<&T> {
+        self.registry.get(key).and_then(|val| val.downcast_ref())
+    }
+}
+
 /// Methods provided by the root Worker.
 ///
 /// These methods are often proxied by child scopes, and this trait provides access.
 pub trait AsWorker : Scheduler {
-
+    /// Returns the worker configuration parameters.
+    fn config(&self) -> &WorkerConfig;
     /// Index of the worker among its peers.
     fn index(&self) -> usize;
     /// Number of peer workers.
@@ -53,6 +123,7 @@ pub trait AsWorker : Scheduler {
 /// A `Worker` is the entry point to a timely dataflow computation. It wraps a `Allocate`,
 /// and has a list of dataflows that it manages.
 pub struct Worker<A: Allocate> {
+    config: WorkerConfig,
     timer: Instant,
     paths: Rc<RefCell<HashMap<usize, Vec<usize>>>>,
     allocator: Rc<RefCell<A>>,
@@ -71,6 +142,7 @@ pub struct Worker<A: Allocate> {
 }
 
 impl<A: Allocate> AsWorker for Worker<A> {
+    fn config(&self) -> &WorkerConfig { &self.config }
     fn index(&self) -> usize { self.allocator.borrow().index() }
     fn peers(&self) -> usize { self.allocator.borrow().peers() }
     fn allocate<D: Data>(&mut self, identifier: usize, address: &[usize]) -> (Vec<Box<dyn Push<Message<D>>>>, Box<dyn Pull<Message<D>>>) {
@@ -102,10 +174,11 @@ impl<A: Allocate> Scheduler for Worker<A> {
 
 impl<A: Allocate> Worker<A> {
     /// Allocates a new `Worker` bound to a channel allocator.
-    pub fn new(c: A) -> Worker<A> {
+    pub fn new(config: WorkerConfig, c: A) -> Worker<A> {
         let now = Instant::now();
         let index = c.index();
         Worker {
+            config,
             timer: now.clone(),
             paths:  Default::default(),
             allocator: Rc::new(RefCell::new(c)),
@@ -512,6 +585,7 @@ use crate::communication::Message;
 impl<A: Allocate> Clone for Worker<A> {
     fn clone(&self) -> Self {
         Worker {
+            config: self.config.clone(),
             timer: self.timer,
             paths: self.paths.clone(),
             allocator: self.allocator.clone(),

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -47,14 +47,44 @@ impl FromStr for ProgressMode {
 
 /// Worker configuration.
 #[derive(Debug, Default, Clone)]
-pub struct WorkerConfig {
+pub struct Config {
     /// The progress mode to use.
     pub(crate) progress_mode: ProgressMode,
     /// A map from parameter name to typed parameter values.
     registry: HashMap<String, Arc<dyn Any + Send + Sync>>,
 }
 
-impl WorkerConfig {
+impl Config {
+    /// Installs options into a [`getopts::Options`] struct that correspond
+    /// to the parameters in the configuration.
+    ///
+    /// It is the caller's responsibility to ensure that the installed options
+    /// do not conflict with any other options that may exist in `opts`, or
+    /// that may be installed into `opts` in the future.
+    ///
+    /// This method is only available if the `getopts` feature is enabled, which
+    /// it is by default.
+    #[cfg(feature = "getopts")]
+    pub fn install_options(opts: &mut getopts_dep::Options) {
+        opts.optopt("", "progress-mode", "progress tracking mode (eager or demand)", "MODE");
+    }
+
+    /// Instantiates a configuration based upon the parsed options in `matches`.
+    ///
+    /// The `matches` object must have been constructed from a
+    /// [`getopts::Options`] which contained at least the options installed by
+    /// [`Self::install_options`].
+    ///
+    /// This method is only available if the `getopts` feature is enabled, which
+    /// it is by default.
+    #[cfg(feature = "getopts")]
+    pub fn from_matches(matches: &getopts_dep::Matches) -> Result<Config, String> {
+        let progress_mode = matches
+            .opt_get_default("progress-mode", ProgressMode::Eager)
+            .map_err(|e| e.to_string())?;
+        Ok(Config::default().progress_mode(progress_mode))
+    }
+
     /// Sets the progress mode to `progress_mode`.
     pub fn progress_mode(mut self, progress_mode: ProgressMode) -> Self {
         self.progress_mode = progress_mode;
@@ -90,7 +120,7 @@ impl WorkerConfig {
 /// These methods are often proxied by child scopes, and this trait provides access.
 pub trait AsWorker : Scheduler {
     /// Returns the worker configuration parameters.
-    fn config(&self) -> &WorkerConfig;
+    fn config(&self) -> &Config;
     /// Index of the worker among its peers.
     fn index(&self) -> usize;
     /// Number of peer workers.
@@ -123,7 +153,7 @@ pub trait AsWorker : Scheduler {
 /// A `Worker` is the entry point to a timely dataflow computation. It wraps a `Allocate`,
 /// and has a list of dataflows that it manages.
 pub struct Worker<A: Allocate> {
-    config: WorkerConfig,
+    config: Config,
     timer: Instant,
     paths: Rc<RefCell<HashMap<usize, Vec<usize>>>>,
     allocator: Rc<RefCell<A>>,
@@ -142,7 +172,7 @@ pub struct Worker<A: Allocate> {
 }
 
 impl<A: Allocate> AsWorker for Worker<A> {
-    fn config(&self) -> &WorkerConfig { &self.config }
+    fn config(&self) -> &Config { &self.config }
     fn index(&self) -> usize { self.allocator.borrow().index() }
     fn peers(&self) -> usize { self.allocator.borrow().peers() }
     fn allocate<D: Data>(&mut self, identifier: usize, address: &[usize]) -> (Vec<Box<dyn Push<Message<D>>>>, Box<dyn Pull<Message<D>>>) {
@@ -174,7 +204,7 @@ impl<A: Allocate> Scheduler for Worker<A> {
 
 impl<A: Allocate> Worker<A> {
     /// Allocates a new `Worker` bound to a channel allocator.
-    pub fn new(config: WorkerConfig, c: A) -> Worker<A> {
+    pub fn new(config: Config, c: A) -> Worker<A> {
         let now = Instant::now();
         let index = c.index();
         Worker {

--- a/timely/tests/barrier.rs
+++ b/timely/tests/barrier.rs
@@ -1,11 +1,9 @@
 extern crate timely;
 
-use timely::CommunicationConfig;
-use timely::execute::ExecuteConfig;
+use timely::{Config, CommunicationConfig, WorkerConfig};
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::{Feedback, ConnectLoop};
 use timely::dataflow::operators::generic::operator::Operator;
-use timely::worker::WorkerConfig;
 
 #[test] fn barrier_sync_1w() { barrier_sync_helper(CommunicationConfig::Thread); }
 #[test] fn barrier_sync_2w() { barrier_sync_helper(CommunicationConfig::Process(2)); }
@@ -13,7 +11,7 @@ use timely::worker::WorkerConfig;
 
 // This method asserts that each round of execution is notified of at most one time.
 fn barrier_sync_helper(comm_config: ::timely::CommunicationConfig) {
-    let config = ExecuteConfig {
+    let config = Config {
         communication: comm_config,
         worker: WorkerConfig::default(),
     };

--- a/timely/tests/barrier.rs
+++ b/timely/tests/barrier.rs
@@ -1,16 +1,22 @@
 extern crate timely;
 
-use timely::Configuration;
+use timely::CommunicationConfig;
+use timely::execute::ExecuteConfig;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::{Feedback, ConnectLoop};
 use timely::dataflow::operators::generic::operator::Operator;
+use timely::worker::WorkerConfig;
 
-#[test] fn barrier_sync_1w() { barrier_sync_helper(Configuration::Thread); }
-#[test] fn barrier_sync_2w() { barrier_sync_helper(Configuration::Process(2)); }
-#[test] fn barrier_sync_3w() { barrier_sync_helper(Configuration::Process(3)); }
+#[test] fn barrier_sync_1w() { barrier_sync_helper(CommunicationConfig::Thread); }
+#[test] fn barrier_sync_2w() { barrier_sync_helper(CommunicationConfig::Process(2)); }
+#[test] fn barrier_sync_3w() { barrier_sync_helper(CommunicationConfig::Process(3)); }
 
 // This method asserts that each round of execution is notified of at most one time.
-fn barrier_sync_helper(config: ::timely::Configuration) {
+fn barrier_sync_helper(comm_config: ::timely::CommunicationConfig) {
+    let config = ExecuteConfig {
+        communication: comm_config,
+        worker: WorkerConfig::default(),
+    };
     timely::execute(config, move |worker| {
         worker.dataflow(move |scope| {
             let (handle, stream) = scope.feedback::<u64>(1);


### PR DESCRIPTION
@frankmcsherry, as discussed on Slack! No promises that any of this is appealing!

Tweak the execution API so that worker configuration parameters can be
specified along with communication fabric configuration parameters. In
particular, this permits the DEFAULT_PROGRESS_MODE environment variable
to be replaced with a typed ProgressMode enum, and for its value to be
controllable with a command-line option.

The new WorkerConfig struct also admits arbitrary typed configuration
parameters, which downstream libraries (e.g., differential) can use to
store their own worker configuration variables.