### PR TITLE
Separate the progress logging stream, use dyn trait instead of String for timestamps

### DIFF
--- a/timely/examples/logging-send.rs
+++ b/timely/examples/logging-send.rs
@@ -5,7 +5,7 @@ use timely::dataflow::operators::{Input, Exchange, Probe};
 
 // use timely::dataflow::operators::capture::EventWriter;
 // use timely::dataflow::ScopeParent;
-use timely::logging::TimelyEvent;
+use timely::logging::{TimelyEvent, TimelyProgressEvent};
 
 fn main() {
     // initializes and runs a timely dataflow.
@@ -19,6 +19,11 @@ fn main() {
         // Register timely worker logging.
         worker.log_register().insert::<TimelyEvent,_>("timely", |_time, data|
             data.iter().for_each(|x| println!("LOG1: {:?}", x))
+        );
+
+        // Register timely progress logging.
+        worker.log_register().insert::<TimelyProgressEvent,_>("timely/progress", |_time, data|
+            data.iter().for_each(|x| println!("PROGRESS: {:?}", x))
         );
 
         // create a new input, exchange data, and inspect its output

--- a/timely/examples/logging-send.rs
+++ b/timely/examples/logging-send.rs
@@ -22,8 +22,23 @@ fn main() {
         );
 
         // Register timely progress logging.
+        // Less generally useful: intended for debugging advanced custom operators or timely
+        // internals.
         worker.log_register().insert::<TimelyProgressEvent,_>("timely/progress", |_time, data|
-            data.iter().for_each(|x| println!("PROGRESS: {:?}", x))
+            data.iter().for_each(|x| {
+                println!("PROGRESS: {:?}", x);
+                let (_, _, ev) = x;
+                print!("PROGRESS: TYPED MESSAGES: ");
+                for (n, p, t, d) in ev.messages.iter() {
+                    print!("{:?}, ", (n, p, t.as_any().downcast_ref::<usize>(), d));
+                }
+                println!();
+                print!("PROGRESS: TYPED INTERNAL: ");
+                for (n, p, t, d) in ev.internal.iter() {
+                    print!("{:?}, ", (n, p, t.as_any().downcast_ref::<usize>(), d));
+                }
+                println!();
+            })
         );
 
         // create a new input, exchange data, and inspect its output

--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -12,6 +12,7 @@ use crate::progress::{Source, Target};
 use crate::progress::timestamp::Refines;
 use crate::order::Product;
 use crate::logging::TimelyLogger as Logger;
+use crate::logging::TimelyProgressLogger as ProgressLogger;
 use crate::worker::{AsWorker, Config};
 
 use super::{ScopeParent, Scope};
@@ -32,6 +33,8 @@ where
     pub parent:   G,
     /// The log writer for this scope.
     pub logging:  Option<Logger>,
+    /// The progress log writer for this scope.
+    pub progress_logging:  Option<ProgressLogger>,
 }
 
 impl<'a, G, T> Child<'a, G, T>
@@ -115,12 +118,13 @@ where
         let index = self.subgraph.borrow_mut().allocate_child_id();
         let path = self.subgraph.borrow().path.clone();
 
-        let subscope = RefCell::new(SubgraphBuilder::new_from(index, path, self.logging().clone(), name));
+        let subscope = RefCell::new(SubgraphBuilder::new_from(index, path, self.logging().clone(), self.progress_logging.clone(), name));
         let result = {
             let mut builder = Child {
                 subgraph: &subscope,
                 parent: self.clone(),
                 logging: self.logging.clone(),
+                progress_logging: self.progress_logging.clone(),
             };
             func(&mut builder)
         };
@@ -143,7 +147,8 @@ where
         Child {
             subgraph: self.subgraph,
             parent: self.parent.clone(),
-            logging: self.logging.clone()
+            logging: self.logging.clone(),
+            progress_logging: self.progress_logging.clone(),
         }
     }
 }

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -107,6 +107,11 @@ impl<T: crate::Data + std::fmt::Debug + std::any::Any> ProgressEventTimestamp fo
 }
 
 /// A vector of progress updates in logs
+///
+/// This exists to support upcasting of the concrecte progress update vectors to
+/// `dyn ProgressEventTimestamp`. Doing so at the vector granularity allows us to
+/// use a single allocation for the entire vector (as opposed to a `Box` allocation
+/// for each dynamically typed element).
 pub trait ProgressEventTimestampVec: std::fmt::Debug + std::any::Any {
     /// Iterate over the contents of the vector
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item=(&'a usize, &'a usize, &'a dyn ProgressEventTimestamp, &'a i64)>+'a>;

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -77,6 +77,16 @@ pub trait ProgressEventTimestamp: std::fmt::Debug + std::any::Any {
     /// Upcasts this `ProgressEventTimestamp` to `Any`.
     ///
     /// NOTE: This is required until https://github.com/rust-lang/rfcs/issues/2765 is fixed
+    ///
+    /// # Example
+    /// ```rust
+    /// let ts = vec![(0usize, 0usize, (23u64, 10u64), -4i64), (0usize, 0usize, (23u64, 11u64), 1i64)];
+    /// let ts: &timely::logging::ProgressEventTimestampVec = &ts;
+    /// for (n, p, t, d) in ts.iter() {
+    ///     print!("{:?}, ", (n, p, t.as_any().downcast_ref::<(u64, u64)>(), d));
+    /// }
+    /// println!();
+    /// ```
     fn as_any(&self) -> &dyn std::any::Any;
 
     /// Returns the name of the concrete type of this object.

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -6,6 +6,8 @@ pub type WorkerIdentifier = usize;
 pub type Logger<Event> = crate::logging_core::Logger<Event, WorkerIdentifier>;
 /// Logger for timely dataflow system events.
 pub type TimelyLogger = Logger<TimelyEvent>;
+/// Logger for timely dataflow progress events (the "timely/progress" log stream).
+pub type TimelyProgressLogger = Logger<TimelyProgressEvent>;
 
 use std::time::Duration;
 use crate::dataflow::operators::capture::{Event, EventPusher};
@@ -70,9 +72,44 @@ pub struct ChannelsEvent {
     pub target: (usize, usize),
 }
 
-#[derive(Serialize, Deserialize, Abomonation, Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg(not(feature = "bincode"))]
+/// Encapsulates (de)serialization, Debug, Display, for dynamically typed timestamps in logs
+pub trait ProgressEventTimestamp: std::fmt::Debug + std::fmt::Display + std::any::Any {
+    /// Encodes a typed reference into a binary buffer.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe because it is unsafe to transmute typed allocations to binary.
+    /// Furthermore, Rust currently indicates that it is undefined behavior to observe padding
+    /// bytes, which will happen when we `memmcpy` structs which contain padding bytes.
+    unsafe fn encode(&self, write: &mut dyn std::io::Write) -> std::io::Result<()>;
+}
+
+#[cfg(not(feature = "bincode"))]
+impl<T: crate::communication::Data + std::fmt::Debug + std::fmt::Display + std::any::Any> ProgressEventTimestamp for T {
+    unsafe fn encode(&self, mut write: &mut dyn std::io::Write) -> std::io::Result<()> {
+        abomonation::encode(self, &mut write)
+    }
+}
+
+/// A vector of progress updates in logs
+pub trait ProgressEventTimestampVec: std::fmt::Debug + std::any::Any{
+    /// Iterate over the contents of the vector
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item=(&'a usize, &'a usize, &'a dyn ProgressEventTimestamp, &'a i64)>+'a>;
+}
+
+impl<T: ProgressEventTimestamp> ProgressEventTimestampVec for Vec<(usize, usize, T, i64)> {
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item=(&'a usize, &'a usize, &'a dyn ProgressEventTimestamp, &'a i64)>+'a> {
+        Box::new(<[(usize, usize, T, i64)]>::iter(&self[..]).map(|(n, p, t, d)| {
+            let t: &dyn ProgressEventTimestamp = t;
+            (n, p, t, d)
+        }))
+    }
+}
+
+#[derive(Debug)]
 /// Send or receive of progress information.
-pub struct ProgressEvent {
+pub struct TimelyProgressEvent {
     /// `true` if the event is a send, and `false` if it is a receive.
     pub is_send: bool,
     /// Source worker index.
@@ -84,9 +121,9 @@ pub struct ProgressEvent {
     /// Sequence of nested scope identifiers indicating the path from the root to this instance.
     pub addr: Vec<usize>,
     /// List of message updates, containing Target descriptor, timestamp as string, and delta.
-    pub messages: Vec<(usize, usize, String, i64)>,
+    pub messages: Box<dyn ProgressEventTimestampVec>,
     /// List of capability updates, containing Source descriptor, timestamp as string, and delta.
-    pub internal: Vec<(usize, usize, String, i64)>,
+    pub internal: Box<dyn ProgressEventTimestampVec>,
 }
 
 #[derive(Serialize, Deserialize, Abomonation, Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
@@ -225,8 +262,6 @@ pub enum TimelyEvent {
     Operates(OperatesEvent),
     /// Channel creation.
     Channels(ChannelsEvent),
-    /// Progress message send or receive.
-    Progress(ProgressEvent),
     /// Progress propagation (reasoning).
     PushProgress(PushProgressEvent),
     /// Message send or receive.
@@ -257,10 +292,6 @@ impl From<OperatesEvent> for TimelyEvent {
 
 impl From<ChannelsEvent> for TimelyEvent {
     fn from(v: ChannelsEvent) -> TimelyEvent { TimelyEvent::Channels(v) }
-}
-
-impl From<ProgressEvent> for TimelyEvent {
-    fn from(v: ProgressEvent) -> TimelyEvent { TimelyEvent::Progress(v) }
 }
 
 impl From<PushProgressEvent> for TimelyEvent {

--- a/timely/src/progress/broadcast.rs
+++ b/timely/src/progress/broadcast.rs
@@ -133,8 +133,8 @@ impl<T:Timestamp+Send> Progcaster<T> {
             // options for improving it if performance limits users who want other logging.
             self.progress_logging.as_ref().map(|l| {
 
-                let mut messages = Vec::with_capacity(changes.len());
-                let mut internal = Vec::with_capacity(changes.len());
+                let mut messages = Box::new(Vec::with_capacity(changes.len()));
+                let mut internal = Box::new(Vec::with_capacity(changes.len()));
 
                 for ((location, time), diff) in recv_changes.iter() {
 
@@ -154,8 +154,8 @@ impl<T:Timestamp+Send> Progcaster<T> {
                     seq_no: counter,
                     channel,
                     addr: addr.clone(),
-                    messages: Box::new(messages),
-                    internal: Box::new(internal),
+                    messages: messages,
+                    internal: internal,
                 });
             });
 

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -11,6 +11,7 @@ use std::collections::BinaryHeap;
 use std::cmp::Reverse;
 
 use crate::logging::TimelyLogger as Logger;
+use crate::logging::TimelyProgressLogger as ProgressLogger;
 
 use crate::scheduling::Schedule;
 use crate::scheduling::activate::Activations;
@@ -63,6 +64,9 @@ where
 
     /// Logging handle
     logging: Option<Logger>,
+
+    /// Progress logging handle
+    progress_logging: Option<ProgressLogger>,
 }
 
 impl<TOuter, TInner> SubgraphBuilder<TOuter, TInner>
@@ -95,6 +99,7 @@ where
         index: usize,
         mut path: Vec<usize>,
         logging: Option<Logger>,
+        progress_logging: Option<ProgressLogger>,
         name: &str,
     )
         -> SubgraphBuilder<TOuter, TInner>
@@ -114,6 +119,7 @@ where
             input_messages: Vec::new(),
             output_capabilities: Vec::new(),
             logging,
+            progress_logging,
         }
     }
 
@@ -169,7 +175,7 @@ where
 
         let (tracker, scope_summary) = builder.build();
 
-        let progcaster = Progcaster::new(worker, &self.path, self.logging.clone());
+        let progcaster = Progcaster::new(worker, &self.path, self.logging.clone(), self.progress_logging.clone());
 
         let mut incomplete = vec![true; self.children.len()];
         incomplete[0] = false;

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -570,7 +570,8 @@ impl<A: Allocate> Worker<A> {
         let dataflow_index = self.allocate_dataflow_index();
         let identifier = self.new_identifier();
 
-        let subscope = SubgraphBuilder::new_from(dataflow_index, addr, logging.clone(), name);
+        let progress_logging = self.logging.borrow_mut().get("timely/progress");
+        let subscope = SubgraphBuilder::new_from(dataflow_index, addr, logging.clone(), progress_logging.clone(), name);
         let subscope = RefCell::new(subscope);
 
         let result = {
@@ -578,6 +579,7 @@ impl<A: Allocate> Worker<A> {
                 subgraph: &subscope,
                 parent: self.clone(),
                 logging: logging.clone(),
+                progress_logging: progress_logging.clone(),
             };
             func(&mut resources, &mut builder)
         };


### PR DESCRIPTION
This only supports cfg(not(feature = "bincode")), bincode support upcoming.
Currently based on the `log_progress_accurately` branch.

@frankmcsherry 