### PR TITLE
Add support for native async stream sources

### DIFF
--- a/timely/Cargo.toml
+++ b/timely/Cargo.toml
@@ -30,7 +30,10 @@ timely_bytes = { path = "../bytes", version = "0.11" }
 timely_logging = { path = "../logging", version = "0.11" }
 timely_communication = { path = "../communication", version = "0.11" }
 crossbeam-channel = "0.5.0"
+futures-core = "0.3"
 
 [dev-dependencies]
 timely_sort="0.1.6"
 rand="0.4"
+tokio = { version = "1", features = [ "full" ] }
+futures-util = "0.3"

--- a/timely/Cargo.toml
+++ b/timely/Cargo.toml
@@ -30,10 +30,8 @@ timely_bytes = { path = "../bytes", version = "0.11" }
 timely_logging = { path = "../logging", version = "0.11" }
 timely_communication = { path = "../communication", version = "0.11" }
 crossbeam-channel = "0.5.0"
-futures-core = "0.3"
+futures-util = "0.3"
 
 [dev-dependencies]
 timely_sort="0.1.6"
 rand="0.4"
-tokio = { version = "1", features = [ "full" ] }
-futures-util = "0.3"

--- a/timely/src/dataflow/operators/capability.rs
+++ b/timely/src/dataflow/operators/capability.rs
@@ -371,10 +371,14 @@ impl<T: Timestamp> CapabilitySet<T> {
     /// Downgrades the set of capabilities to correspond with the times in `frontier`.
     ///
     /// This method panics if any element of `frontier` is not greater or equal to some element of `self.elements`.
-    pub fn downgrade(&mut self, frontier: &[T]) {
+    pub fn downgrade<B, F>(&mut self, frontier: F)
+    where
+        B: std::borrow::Borrow<T>,
+        F: IntoIterator<Item=B>,
+    {
         let count = self.elements.len();
-        for time in frontier.iter() {
-            let capability = self.delayed(time);
+        for time in frontier.into_iter() {
+            let capability = self.delayed(time.borrow());
             self.elements.push(capability);
         }
         self.elements.drain(..count);

--- a/timely/src/dataflow/operators/mod.rs
+++ b/timely/src/dataflow/operators/mod.rs
@@ -22,7 +22,7 @@ pub use self::delay::Delay;
 pub use self::exchange::Exchange;
 pub use self::broadcast::Broadcast;
 pub use self::probe::Probe;
-pub use self::to_stream::ToStream;
+pub use self::to_stream::{ToStream, ToStreamAsync, Event};
 pub use self::capture::Capture;
 pub use self::branch::{Branch, BranchWhen};
 pub use self::ok_err::OkErr;

--- a/timely/src/dataflow/operators/to_stream.rs
+++ b/timely/src/dataflow/operators/to_stream.rs
@@ -1,15 +1,14 @@
 //! Conversion to the `Stream` type from iterators.
 
-use std::future::Future;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex};
-use std::task::{Context, Poll, Waker};
+use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use crate::dataflow::channels::Message;
 use crate::dataflow::operators::generic::operator::source;
+use crate::dataflow::operators::CapabilitySet;
 use crate::dataflow::{Scope, Stream};
 use crate::progress::Timestamp;
-use crate::scheduling::SyncActivator;
 use crate::Data;
 
 /// Converts to a timely `Stream`.
@@ -62,215 +61,81 @@ impl<T: Timestamp, I: IntoIterator+'static> ToStream<T, I::Item> for I where I::
     }
 }
 
-/// Errors encountered during event streaming
-#[derive(Clone, Copy, Debug)]
-pub enum StreamError {
-    /// Encountered time less than the most recent Progress event
-    TimeMovedBackwards,
-    /// The error returned when activation fails across thread boundaries because the receiving end
-    /// has hung up.
-    SyncActivationError,
-}
-
 /// Data and progress events of the native stream.
-pub enum Event<T, D> {
-    /// Indicates that timestamps have advanced to time T
-    Progress(T),
+pub enum Event<F: IntoIterator, D> {
+    /// Indicates that timestamps have advanced to frontier F
+    Progress(F),
     /// Indicates that event D happened at time T
-    Message(T, D),
-}
-
-struct SharedState {
-    waker: Option<Waker>,
-    state: Poll<Result<(), StreamError>>,
-}
-
-/// Interop between native async futures and timely's fibers
-///
-/// This structs holds on to both wakers (Waker and SyncActivator) and translates wakes and results
-/// between the two systems
-pub struct TimelyFuture {
-    shared_state: Arc<Mutex<SharedState>>,
-    activator: SyncActivator,
-}
-
-impl Future for TimelyFuture {
-    type Output = Result<(), StreamError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // Look at the shared state to see if the operator has already completed.
-        let mut shared_state = self.shared_state.lock().unwrap();
-
-        match shared_state.state {
-            // The operator has finished, just return its result
-            Poll::Ready(result) => Poll::Ready(result),
-            // There is some work for the operator to do
-            Poll::Pending => {
-                // Set waker so that timely can wake up the current task when the work has
-                // completed, ensuring that the future is polled again and sees that `state =
-                // Poll::Ready(_)`.
-                let new_waker = cx.waker();
-                match &mut shared_state.waker {
-                    Some(waker) if waker.will_wake(new_waker) => (),
-                    waker => *waker = Some(new_waker.clone()),
-                };
-
-                // Release the mutex and activate the operator to do some work
-                drop(shared_state);
-                match self.activator.activate() {
-                    Ok(()) => Poll::Pending,
-                    Err(_) => {
-                        let mut shared_state = self.shared_state.lock().unwrap();
-                        let err_state = Poll::Ready(Err(StreamError::SyncActivationError));
-                        shared_state.waker = None;
-                        shared_state.state = err_state;
-
-                        err_state
-                    }
-                }
-            }
-        }
-    }
+    Message(F::Item, D),
 }
 
 /// Converts to a timely `Stream`.
 pub trait ToStreamAsync<T: Timestamp, D: Data> {
     /// Converts a [native `Stream`](futures_util::stream::Stream) of [`Event`s](Event) into a [timely
-    /// `Stream`](crate::dataflow::Stream). It returns a pair of future and timely stream. The
-    /// future resolves when the entirety of the native stream has been consumed or an error has
-    /// occured.
-    ///
-    /// It is necessary to poll the returned future to drive the stream, usually by spawning as a
-    /// separate task with an executor;
+    /// `Stream`](crate::dataflow::Stream).
     ///
     /// # Examples
     ///
-    /// ```notest,rust
-    /// use timely::dataflow::operators::{Event, ToStreamAsync};
-    /// use timely::dataflow::operators::Inspect;
-    ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///     let iter = (0..4)
-    ///         .map(|x| Event::Message(0, x))
-    ///         .chain(Some(Event::Progress(1)));
-    ///     let stream = futures_util::stream::iter(iter);
-    ///
-    ///     timely::example(move |scope| {
-    ///         let (future, stream) = stream.to_stream(scope);
-    ///         tokio::spawn(future);
-    ///         stream.inspect(|x| println!("seen: {:?}", x));
-    ///     });
-    /// }
     /// ```
-    fn to_stream<S: Scope<Timestamp = T>>(self: Pin<Box<Self>>, scope: &S) -> (TimelyFuture, Stream<S, D>);
+    /// use futures_util::stream;
+    ///
+    /// use timely::dataflow::operators::{Capture, Event, ToStream, ToStreamAsync};
+    /// use timely::dataflow::operators::capture::Extract;
+    ///
+    /// let native_stream = stream::iter(vec![
+    ///     Event::Message(0, 0),
+    ///     Event::Message(0, 1),
+    ///     Event::Message(0, 2),
+    ///     Event::Progress(Some(0)),
+    /// ]);
+    ///
+    /// let native_stream = Box::pin(native_stream);
+    ///
+    /// let (data1, data2) = timely::example(|scope| {
+    ///     let data1 = native_stream.to_stream(scope).capture();
+    ///     let data2 = vec![0,1,2].to_stream(scope).capture();
+    ///
+    ///     (data1, data2)
+    /// });
+    ///
+    /// assert_eq!(data1.extract(), data2.extract());
+    /// ```
+    fn to_stream<S: Scope<Timestamp = T>>(self: Pin<Box<Self>>, scope: &S) -> Stream<S, D>;
 }
 
-impl<T, D, I> ToStreamAsync<T, D> for I
+impl<T, D, F, I> ToStreamAsync<T, D> for I
 where
-    T: Timestamp,
     D: Data,
-    I: futures_core::Stream<Item = Event<T, D>> + ?Sized + 'static,
+    T: Timestamp,
+    F: IntoIterator<Item = T>,
+    I: futures_util::stream::Stream<Item = Event<F, D>> + ?Sized + 'static,
 {
-    fn to_stream<S: Scope<Timestamp = T>>(self: Pin<Box<Self>>, scope: &S) -> (TimelyFuture, Stream<S, D>) {
-        let mut activator = None;
-        let shared_state = Arc::new(Mutex::new(SharedState {
-            state: Poll::Pending,
-            waker: None,
-        }));
+    fn to_stream<S: Scope<Timestamp = T>>(mut self: Pin<Box<Self>>, scope: &S) -> Stream<S, D> {
+        source(scope, "ToStreamAsync", move |capability, info| {
+            let activator = Arc::new(scope.sync_activator_for(&info.address[..]));
 
-        // Closure state
-        let mut source_stream = self;
-        let source_shared_state = shared_state.clone();
-        let source_activator = &mut activator;
-        let source_scope = &scope;
+            let mut cap_set = CapabilitySet::from_elem(capability);
 
-        let timely_stream = source(scope, "ToStreamAsync", move |capability, info| {
-            // Acquire an activator, so that the operator can reschedule itself.
-            *source_activator = Some(source_scope.sync_activator_for(&info.address[..]));
-
-            let mut capability = Some(capability);
             move |output| {
-                let mut shared_state = source_shared_state.lock().unwrap();
+                let waker = futures_util::task::waker_ref(&activator);
+                let mut context = Context::from_waker(&waker);
 
-                // If the outer future hasn't been polled yet, there is nothing to do
-                if let (Some(waker), Poll::Pending) =
-                    (shared_state.waker.take(), shared_state.state)
-                {
-                    let mut context = Context::from_waker(&waker);
-
-                    // Consume all the ready items of the source_stream and issue them to the operator
-                    while let Poll::Ready(item) = source_stream.as_mut().poll_next(&mut context) {
-                        match item {
-                            Some(Event::Progress(time)) => {
-                                let cap = capability.as_mut().unwrap();
-                                if !cap.time().less_equal(&time) {
-                                    shared_state.state =
-                                        Poll::Ready(Err(StreamError::TimeMovedBackwards));
-                                    break;
-                                }
-                                cap.downgrade(&time);
-                            }
-                            Some(Event::Message(time, data)) => {
-                                let cap = capability.as_ref().unwrap();
-                                if !cap.time().less_equal(&time) {
-                                    shared_state.state =
-                                        Poll::Ready(Err(StreamError::TimeMovedBackwards));
-                                    break;
-                                }
-                                output.session(&cap.delayed(&time)).give(data);
-                            }
-                            None => {
-                                capability = None;
-                                shared_state.state = Poll::Ready(Ok(()));
-                                break;
-                            }
+                // Consume all the ready items of the source_stream and issue them to the operator
+                while let Poll::Ready(item) = self.as_mut().poll_next(&mut context) {
+                    match item {
+                        Some(Event::Progress(time)) => {
+                            cap_set.downgrade(time);
                         }
-                    }
-                    if let Poll::Ready(_) = shared_state.state {
-                        // Release the mutex and wake up the native task to communicate progress
-                        drop(shared_state);
-                        waker.wake();
+                        Some(Event::Message(time, data)) => {
+                            output.session(&cap_set.delayed(&time)).give(data);
+                        }
+                        None => {
+                            cap_set.downgrade(&[]);
+                            break;
+                        }
                     }
                 }
             }
-        });
-
-        // `source` promises to call the provided closure before returning,
-        // so we are guaranteed that `activator` is non-None.
-        let activator = activator.unwrap();
-        let future = TimelyFuture {
-            shared_state,
-            activator,
-        };
-
-        (future, timely_stream)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_async_stream() {
-        use crate::dataflow::operators::Capture;
-        use crate::dataflow::operators::capture::Extract;
-        use crate::example;
-
-        let native_stream = futures_util::stream::iter((0..3).map(|x| Event::Message(0, x)));
-        let native_stream = Box::pin(native_stream);
-
-        let (data1, data2) = example(|scope| {
-            let (future, stream) = native_stream.to_stream(scope);
-            tokio::spawn(future);
-
-            let data1 = stream.capture();
-            let data2 = vec![0,1,2].to_stream(scope).capture();
-
-            (data1, data2)
-        });
-
-        assert_eq!(data1.extract(), data2.extract());
+        })
     }
 }

--- a/timely/src/dataflow/operators/to_stream.rs
+++ b/timely/src/dataflow/operators/to_stream.rs
@@ -1,11 +1,16 @@
 //! Conversion to the `Stream` type from iterators.
 
-use crate::progress::Timestamp;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
 
-use crate::Data;
 use crate::dataflow::channels::Message;
 use crate::dataflow::operators::generic::operator::source;
-use crate::dataflow::{Stream, Scope};
+use crate::dataflow::{Scope, Stream};
+use crate::progress::Timestamp;
+use crate::scheduling::SyncActivator;
+use crate::Data;
 
 /// Converts to a timely `Stream`.
 pub trait ToStream<T: Timestamp, D: Data> {
@@ -54,5 +59,218 @@ impl<T: Timestamp, I: IntoIterator+'static> ToStream<T, I::Item> for I where I::
                 }
             }
         })
+    }
+}
+
+/// Errors encountered during event streaming
+#[derive(Clone, Copy, Debug)]
+pub enum StreamError {
+    /// Encountered time less than the most recent Progress event
+    TimeMovedBackwards,
+    /// The error returned when activation fails across thread boundaries because the receiving end
+    /// has hung up.
+    SyncActivationError,
+}
+
+/// Data and progress events of the native stream.
+pub enum Event<T, D> {
+    /// Indicates that timestamps have advanced to time T
+    Progress(T),
+    /// Indicates that event D happened at time T
+    Message(T, D),
+}
+
+struct SharedState {
+    waker: Option<Waker>,
+    state: Poll<Result<(), StreamError>>,
+}
+
+/// Interop between native async futures and timely's fibers
+///
+/// This structs holds on to both wakers (Waker and SyncActivator) and translates wakes and results
+/// between the two systems
+pub struct TimelyFuture {
+    shared_state: Arc<Mutex<SharedState>>,
+    activator: SyncActivator,
+}
+
+impl Future for TimelyFuture {
+    type Output = Result<(), StreamError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Look at the shared state to see if the operator has already completed.
+        let mut shared_state = self.shared_state.lock().unwrap();
+
+        match shared_state.state {
+            // The operator has finished, just return its result
+            Poll::Ready(result) => Poll::Ready(result),
+            // There is some work for the operator to do
+            Poll::Pending => {
+                // Set waker so that timely can wake up the current task when the work has
+                // completed, ensuring that the future is polled again and sees that `state =
+                // Poll::Ready(_)`.
+                let new_waker = cx.waker();
+                match &mut shared_state.waker {
+                    Some(waker) if waker.will_wake(new_waker) => (),
+                    waker => *waker = Some(new_waker.clone()),
+                };
+
+                // Release the mutex and activate the operator to do some work
+                drop(shared_state);
+                match self.activator.activate() {
+                    Ok(()) => Poll::Pending,
+                    Err(_) => {
+                        let mut shared_state = self.shared_state.lock().unwrap();
+                        let err_state = Poll::Ready(Err(StreamError::SyncActivationError));
+                        shared_state.waker = None;
+                        shared_state.state = err_state;
+
+                        err_state
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Converts to a timely `Stream`.
+pub trait ToStreamAsync<T: Timestamp, D: Data> {
+    /// Converts a [native `Stream`](futures_util::stream::Stream) of [`Event`s](Event) into a [timely
+    /// `Stream`](crate::dataflow::Stream). It returns a pair of future and timely stream. The
+    /// future resolves when the entirety of the native stream has been consumed or an error has
+    /// occured.
+    ///
+    /// It is necessary to poll the returned future to drive the stream, usually by spawning as a
+    /// separate task with an executor;
+    ///
+    /// # Examples
+    ///
+    /// ```notest,rust
+    /// use timely::dataflow::operators::{Event, ToStreamAsync};
+    /// use timely::dataflow::operators::Inspect;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let iter = (0..4)
+    ///         .map(|x| Event::Message(0, x))
+    ///         .chain(Some(Event::Progress(1)));
+    ///     let stream = futures_util::stream::iter(iter);
+    ///
+    ///     timely::example(move |scope| {
+    ///         let (future, stream) = stream.to_stream(scope);
+    ///         tokio::spawn(future);
+    ///         stream.inspect(|x| println!("seen: {:?}", x));
+    ///     });
+    /// }
+    /// ```
+    fn to_stream<S: Scope<Timestamp = T>>(self: Pin<Box<Self>>, scope: &S) -> (TimelyFuture, Stream<S, D>);
+}
+
+impl<T, D, I> ToStreamAsync<T, D> for I
+where
+    T: Timestamp,
+    D: Data,
+    I: futures_core::Stream<Item = Event<T, D>> + ?Sized + 'static,
+{
+    fn to_stream<S: Scope<Timestamp = T>>(self: Pin<Box<Self>>, scope: &S) -> (TimelyFuture, Stream<S, D>) {
+        let mut activator = None;
+        let shared_state = Arc::new(Mutex::new(SharedState {
+            state: Poll::Pending,
+            waker: None,
+        }));
+
+        // Closure state
+        let mut source_stream = self;
+        let source_shared_state = shared_state.clone();
+        let source_activator = &mut activator;
+        let source_scope = &scope;
+
+        let timely_stream = source(scope, "ToStreamAsync", move |capability, info| {
+            // Acquire an activator, so that the operator can reschedule itself.
+            *source_activator = Some(source_scope.sync_activator_for(&info.address[..]));
+
+            let mut capability = Some(capability);
+            move |output| {
+                let mut shared_state = source_shared_state.lock().unwrap();
+
+                // If the outer future hasn't been polled yet, there is nothing to do
+                if let (Some(waker), Poll::Pending) =
+                    (shared_state.waker.take(), shared_state.state)
+                {
+                    let mut context = Context::from_waker(&waker);
+
+                    // Consume all the ready items of the source_stream and issue them to the operator
+                    while let Poll::Ready(item) = source_stream.as_mut().poll_next(&mut context) {
+                        match item {
+                            Some(Event::Progress(time)) => {
+                                let cap = capability.as_mut().unwrap();
+                                if !cap.time().less_equal(&time) {
+                                    shared_state.state =
+                                        Poll::Ready(Err(StreamError::TimeMovedBackwards));
+                                    break;
+                                }
+                                cap.downgrade(&time);
+                            }
+                            Some(Event::Message(time, data)) => {
+                                let cap = capability.as_ref().unwrap();
+                                if !cap.time().less_equal(&time) {
+                                    shared_state.state =
+                                        Poll::Ready(Err(StreamError::TimeMovedBackwards));
+                                    break;
+                                }
+                                output.session(&cap.delayed(&time)).give(data);
+                            }
+                            None => {
+                                capability = None;
+                                shared_state.state = Poll::Ready(Ok(()));
+                                break;
+                            }
+                        }
+                    }
+                    if let Poll::Ready(_) = shared_state.state {
+                        // Release the mutex and wake up the native task to communicate progress
+                        drop(shared_state);
+                        waker.wake();
+                    }
+                }
+            }
+        });
+
+        // `source` promises to call the provided closure before returning,
+        // so we are guaranteed that `activator` is non-None.
+        let activator = activator.unwrap();
+        let future = TimelyFuture {
+            shared_state,
+            activator,
+        };
+
+        (future, timely_stream)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_async_stream() {
+        use crate::dataflow::operators::Capture;
+        use crate::dataflow::operators::capture::Extract;
+        use crate::example;
+
+        let native_stream = futures_util::stream::iter((0..3).map(|x| Event::Message(0, x)));
+        let native_stream = Box::pin(native_stream);
+
+        let (data1, data2) = example(|scope| {
+            let (future, stream) = native_stream.to_stream(scope);
+            tokio::spawn(future);
+
+            let data1 = stream.capture();
+            let data2 = vec![0,1,2].to_stream(scope).capture();
+
+            (data1, data2)
+        });
+
+        assert_eq!(data1.extract(), data2.extract());
     }
 }

--- a/timely/src/scheduling/activate.rs
+++ b/timely/src/scheduling/activate.rs
@@ -1,12 +1,14 @@
 //! Parking and unparking timely fibers.
 
 use std::rc::Rc;
+use std::sync::Arc;
 use std::cell::RefCell;
 use std::thread::Thread;
 use std::collections::BinaryHeap;
 use std::time::{Duration, Instant};
 use std::cmp::Reverse;
 use crossbeam_channel::{Sender, Receiver};
+use futures_util::task::ArcWake;
 
 /// Methods required to act as a timely scheduler.
 ///
@@ -265,6 +267,12 @@ impl SyncActivator {
     /// Activates the associated path and unparks the associated worker thread.
     pub fn activate(&self) -> Result<(), SyncActivationError> {
         self.queue.activate(self.path.clone())
+    }
+}
+
+impl ArcWake for SyncActivator {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        arc_self.activate().unwrap();
     }
 }
 


### PR DESCRIPTION
Example usage:

```rust
use timely::dataflow::operators::{Event, ToStreamAsync};
use timely::dataflow::operators::Inspect;

#[tokio::main]
async fn main() {
    let iter = (0..4)
        .map(|x| Event::Message(0, x))
        .chain(Some(Event::Progress(1)));
    let stream = futures::stream::iter(iter);

    timely::example(move |scope| {
        let (future, stream) = stream.to_stream(scope);
        tokio::spawn(future);
        stream.inspect(|x| println!("seen: {:?}", x));
    });
}
```