### PR TITLE
Accept subgraph frontiers in setup

### DIFF
--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -12,6 +12,7 @@ use crate::progress::{Source, Target};
 use crate::progress::timestamp::Refines;
 use crate::order::Product;
 use crate::logging::TimelyLogger as Logger;
+use crate::logging::TimelyProgressLogger as ProgressLogger;
 use crate::worker::{AsWorker, Config};
 
 use super::{ScopeParent, Scope};
@@ -32,6 +33,8 @@ where
     pub parent:   G,
     /// The log writer for this scope.
     pub logging:  Option<Logger>,
+    /// The progress log writer for this scope.
+    pub progress_logging:  Option<ProgressLogger>,
 }
 
 impl<'a, G, T> Child<'a, G, T>
@@ -115,12 +118,13 @@ where
         let index = self.subgraph.borrow_mut().allocate_child_id();
         let path = self.subgraph.borrow().path.clone();
 
-        let subscope = RefCell::new(SubgraphBuilder::new_from(index, path, self.logging().clone(), name));
+        let subscope = RefCell::new(SubgraphBuilder::new_from(index, path, self.logging().clone(), self.progress_logging.clone(), name));
         let result = {
             let mut builder = Child {
                 subgraph: &subscope,
                 parent: self.clone(),
                 logging: self.logging.clone(),
+                progress_logging: self.progress_logging.clone(),
             };
             func(&mut builder)
         };
@@ -143,7 +147,8 @@ where
         Child {
             subgraph: self.subgraph,
             parent: self.parent.clone(),
-            logging: self.logging.clone()
+            logging: self.logging.clone(),
+            progress_logging: self.progress_logging.clone(),
         }
     }
 }

--- a/timely/src/progress/broadcast.rs
+++ b/timely/src/progress/broadcast.rs
@@ -4,6 +4,7 @@ use crate::progress::{ChangeBatch, Timestamp};
 use crate::progress::{Location, Port};
 use crate::communication::{Message, Push, Pull};
 use crate::logging::TimelyLogger as Logger;
+use crate::logging::TimelyProgressLogger as ProgressLogger;
 
 /// A list of progress updates corresponding to `((child_scope, [in/out]_port, timestamp), delta)`
 pub type ProgressVec<T> = Vec<((Location, T), i64)>;
@@ -25,12 +26,12 @@ pub struct Progcaster<T:Timestamp> {
     /// Communication channel identifier
     channel_identifier: usize,
 
-    logging: Option<Logger>,
+    progress_logging: Option<ProgressLogger>,
 }
 
 impl<T:Timestamp+Send> Progcaster<T> {
     /// Creates a new `Progcaster` using a channel from the supplied worker.
-    pub fn new<A: crate::worker::AsWorker>(worker: &mut A, path: &Vec<usize>, mut logging: Option<Logger>) -> Progcaster<T> {
+    pub fn new<A: crate::worker::AsWorker>(worker: &mut A, path: &Vec<usize>, mut logging: Option<Logger>, progress_logging: Option<ProgressLogger>) -> Progcaster<T> {
 
         let channel_identifier = worker.new_identifier();
         let (pushers, puller) = worker.allocate(channel_identifier, &path[..]);
@@ -48,7 +49,7 @@ impl<T:Timestamp+Send> Progcaster<T> {
             counter: 0,
             addr,
             channel_identifier,
-            logging,
+            progress_logging,
         }
     }
 
@@ -58,34 +59,26 @@ impl<T:Timestamp+Send> Progcaster<T> {
         changes.compact();
         if !changes.is_empty() {
 
-            // This logging is relatively more expensive than other logging, as we
-            // have formatting and string allocations on the main path. We do have
-            // local type information about the timestamp, and we could log *that*
-            // explicitly, but the consumer would have to know what to look for and
-            // interpret appropriately. That's a big ask, so let's start with this,
-            // and as folks need more performant logging think about allowing users
-            // to select the more efficient variant.
-            self.logging.as_ref().map(|l| {
+            self.progress_logging.as_ref().map(|l| {
 
                 // Pre-allocate enough space; we transfer ownership, so there is not
                 // an apportunity to re-use allocations (w/o changing the logging
                 // interface to accept references).
-                let mut messages = Vec::with_capacity(changes.len());
-                let mut internal = Vec::with_capacity(changes.len());
+                let mut messages = Box::new(Vec::with_capacity(changes.len()));
+                let mut internal = Box::new(Vec::with_capacity(changes.len()));
 
-                // TODO: Reconsider `String` type or perhaps re-use allocation.
                 for ((location, time), diff) in changes.iter() {
                     match location.port {
                         Port::Target(port) => {
-                            messages.push((location.node, port, format!("{:?}", time), *diff))
+                            messages.push((location.node, port, time.clone(), *diff))
                         },
                         Port::Source(port) => {
-                            internal.push((location.node, port, format!("{:?}", time), *diff))
+                            internal.push((location.node, port, time.clone(), *diff))
                         }
                     }
                 }
 
-                l.log(crate::logging::ProgressEvent {
+                l.log(crate::logging::TimelyProgressEvent {
                     is_send: true,
                     source: self.source,
                     channel: self.channel_identifier,
@@ -138,32 +131,31 @@ impl<T:Timestamp+Send> Progcaster<T> {
 
             // See comments above about the relatively high cost of this logging, and our
             // options for improving it if performance limits users who want other logging.
-            self.logging.as_ref().map(|l| {
+            self.progress_logging.as_ref().map(|l| {
 
-                let mut messages = Vec::with_capacity(changes.len());
-                let mut internal = Vec::with_capacity(changes.len());
+                let mut messages = Box::new(Vec::with_capacity(changes.len()));
+                let mut internal = Box::new(Vec::with_capacity(changes.len()));
 
-                // TODO: Reconsider `String` type or perhaps re-use allocation.
                 for ((location, time), diff) in recv_changes.iter() {
 
                     match location.port {
                         Port::Target(port) => {
-                            messages.push((location.node, port, format!("{:?}", time), *diff))
+                            messages.push((location.node, port, time.clone(), *diff))
                         },
                         Port::Source(port) => {
-                            internal.push((location.node, port, format!("{:?}", time), *diff))
+                            internal.push((location.node, port, time.clone(), *diff))
                         }
                     }
                 }
 
-                l.log(crate::logging::ProgressEvent {
+                l.log(crate::logging::TimelyProgressEvent {
                     is_send: false,
                     source: source,
                     seq_no: counter,
                     channel,
                     addr: addr.clone(),
-                    messages,
-                    internal,
+                    messages: messages,
+                    internal: internal,
                 });
             });
 

--- a/timely/src/progress/broadcast.rs
+++ b/timely/src/progress/broadcast.rs
@@ -58,18 +58,6 @@ impl<T:Timestamp+Send> Progcaster<T> {
         changes.compact();
         if !changes.is_empty() {
 
-            // self.logging.as_ref().map(|l| l.log(crate::logging::ProgressEvent {
-            //     is_send: true,
-            //     source: self.source,
-            //     channel: self.channel_identifier,
-            //     seq_no: self.counter,
-            //     addr: self.addr.clone(),
-            //     // TODO: fill with additional data
-            //     messages: Vec::new(),
-            //     internal: Vec::new(),
-            // }));
-
-
             // This logging is relatively more expensive than other logging, as we
             // have formatting and string allocations on the main path. We do have
             // local type information about the timestamp, and we could log *that*
@@ -148,18 +136,8 @@ impl<T:Timestamp+Send> Progcaster<T> {
             let addr = &mut self.addr;
             let channel = self.channel_identifier;
 
-
-            // self.logging.as_ref().map(|l| l.log(crate::logging::ProgressEvent {
-            //     is_send: false,
-            //     source: source,
-            //     seq_no: counter,
-            //     channel,
-            //     addr: addr.clone(),
-            //     // TODO: fill with additional data
-            //     messages: Vec::new(),
-            //     internal: Vec::new(),
-            // }));
-
+            // See comments above about the relatively high cost of this logging, and our
+            // options for improving it if performance limits users who want other logging.
             self.logging.as_ref().map(|l| {
 
                 let mut messages = Vec::with_capacity(changes.len());

--- a/timely/src/progress/change_batch.rs
+++ b/timely/src/progress/change_batch.rs
@@ -201,6 +201,27 @@ impl<T:Ord> ChangeBatch<T> {
         }
     }
 
+    /// Number of compacted updates.
+    ///
+    /// This method requires mutable access to `self` because it may need to compact the
+    /// representation to determine the number of actual updates.
+    ///
+    /// # Examples
+    ///
+    ///```
+    /// use timely::progress::ChangeBatch;
+    ///
+    /// let mut batch = ChangeBatch::<usize>::new_from(17, 1);
+    /// batch.update(17, -1);
+    /// batch.update(14, -1);
+    /// assert_eq!(batch.len(), 1);
+    ///```
+    #[inline]
+    pub fn len(&mut self) -> usize {
+        self.compact();
+        self.updates.len()
+    }
+
     /// Drains `self` into `other`.
     ///
     /// This method has similar a effect to calling `other.extend(self.drain())`, but has the

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -547,6 +547,7 @@ where
     }
 
     fn set_external_summary(&mut self) {
+        self.accept_frontier();
         self.propagate_pointstamps();  // ensure propagation of input frontiers.
         self.children
             .iter_mut()

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -11,6 +11,7 @@ use std::collections::BinaryHeap;
 use std::cmp::Reverse;
 
 use crate::logging::TimelyLogger as Logger;
+use crate::logging::TimelyProgressLogger as ProgressLogger;
 
 use crate::scheduling::Schedule;
 use crate::scheduling::activate::Activations;
@@ -63,6 +64,9 @@ where
 
     /// Logging handle
     logging: Option<Logger>,
+
+    /// Progress logging handle
+    progress_logging: Option<ProgressLogger>,
 }
 
 impl<TOuter, TInner> SubgraphBuilder<TOuter, TInner>
@@ -95,6 +99,7 @@ where
         index: usize,
         mut path: Vec<usize>,
         logging: Option<Logger>,
+        progress_logging: Option<ProgressLogger>,
         name: &str,
     )
         -> SubgraphBuilder<TOuter, TInner>
@@ -114,6 +119,7 @@ where
             input_messages: Vec::new(),
             output_capabilities: Vec::new(),
             logging,
+            progress_logging,
         }
     }
 
@@ -169,7 +175,7 @@ where
 
         let (tracker, scope_summary) = builder.build();
 
-        let progcaster = Progcaster::new(worker, &self.path, self.logging.clone());
+        let progcaster = Progcaster::new(worker, &self.path, self.logging.clone(), self.progress_logging.clone());
 
         let mut incomplete = vec![true; self.children.len()];
         incomplete[0] = false;

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -570,7 +570,8 @@ impl<A: Allocate> Worker<A> {
         let dataflow_index = self.allocate_dataflow_index();
         let identifier = self.new_identifier();
 
-        let subscope = SubgraphBuilder::new_from(dataflow_index, addr, logging.clone(), name);
+        let progress_logging = self.logging.borrow_mut().get("timely/progress");
+        let subscope = SubgraphBuilder::new_from(dataflow_index, addr, logging.clone(), progress_logging.clone(), name);
         let subscope = RefCell::new(subscope);
 
         let result = {
@@ -578,6 +579,7 @@ impl<A: Allocate> Worker<A> {
                 subgraph: &subscope,
                 parent: self.clone(),
                 logging: logging.clone(),
+                progress_logging: progress_logging.clone(),
             };
             func(&mut resources, &mut builder)
         };


### PR DESCRIPTION
This PR fixes a bug that mysteriously hasn't shown up until some stress testing over in https://github.com/MaterializeInc/materialize/issues/5622.

The issue is that in set-up, a `Subgraph` will propagate pointstamp information among its operators and then schedule them for their first time. However, it would not first accept updates from the outside world, which meant that the initial calls into operator logic would not reflect "safe" frontiers, especially if an operator's input was from outside the scope (there would be no initial capability locally within the subgraph to present at it). The observed behavior was a spurious empty frontier in the first call, followed by legit frontiers after that call.

In fact, this manifests in `enterleave::enter_at` with enough panicky double-checking code (and indeed that example has an operator that consumes directly from outside the scope).

This fix is very local, but another take is that `set_external_summary` could plausibly be deleted, as the surrounding scope no longer presents a summary downwards, and initial frontiers are presented in the initial population of the `SharedProgress` struct rather than by method call.