### PR TITLE
Accept frontier changes in subgraph set-up

### DIFF
--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -547,6 +547,7 @@ where
     }
 
     fn set_external_summary(&mut self) {
+        self.accept_frontier();
         self.propagate_pointstamps();  // ensure propagation of input frontiers.
         self.children
             .iter_mut()


### PR DESCRIPTION
This PR fixes a bug that mysteriously hasn't shown up until some stress testing over in MaterializeInc/materialize#5622.

The issue is that in set-up, a Subgraph will propagate pointstamp information among its operators and then schedule them for their first time. However, it would not first accept updates from the outside world, which meant that the initial calls into operator logic would not reflect "safe" frontiers, especially if an operator's input was from outside the scope (there would be no initial capability locally within the subgraph to present at it). The observed behavior was a spurious empty frontier in the first call, followed by legit frontiers after that call.

In fact, this manifests in the doctest for `enterleave::enter_at` with enough panicky double-checking code (and indeed that example has an operator that consumes directly from outside the scope).

This fix is very local, but another take is that `set_external_summary` could plausibly be deleted, as the surrounding scope no longer presents a summary downwards, and initial frontiers are presented in the initial population of the SharedProgress struct rather than by method call.