### PR TITLE
Implemented Debug for Stream and fixed a few clippy lints

### DIFF
--- a/timely/src/dataflow/stream.rs
+++ b/timely/src/dataflow/stream.rs
@@ -10,6 +10,7 @@ use crate::communication::Push;
 use crate::dataflow::Scope;
 use crate::dataflow::channels::pushers::tee::TeeHelper;
 use crate::dataflow::channels::Bundle;
+use std::fmt;
 
 // use dataflow::scopes::root::loggers::CHANNELS_Q;
 
@@ -53,4 +54,16 @@ impl<S: Scope, D> Stream<S, D> {
     pub fn name(&self) -> &Source { &self.name }
     /// The scope immediately containing the stream.
     pub fn scope(&self) -> S { self.scope.clone() }
+}
+
+impl<S, D> fmt::Debug for Stream<S, D>
+where
+    S: Scope,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Stream")
+            .field("source", &self.name)
+            // TODO: Use `.finish_non_exhaustive()` after rust/#67364 lands
+            .finish()
+    }
 }


### PR DESCRIPTION
* Implemented `Debug` for `Stream` (and will implement `Debug` for `Arranged` and `Collection` after this lands), this allows for unwrapping on items that hold streams, as an example `Vec<Stream>::try_into().unwrap()` would previously error and force you to use `.unwrap_or_else(|_| panic!())`, this allows it to happen seamlessly. Just a nice little quality of life tweak
* Fixed a few clippy lints, there seems to be quite a lot so if it's ok with you I can make a follow-up that fixes more of them