### PR TITLE
Encapsulate the operator logic in a trait

### DIFF
--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -1,27 +1,25 @@
 //! Types to build operators with general shapes.
 
-use std::rc::Rc;
 use std::cell::RefCell;
 use std::default::Default;
+use std::rc::Rc;
 
 use crate::Data;
-
-use crate::progress::{ChangeBatch, Timestamp};
-use crate::progress::operate::SharedProgress;
-use crate::progress::frontier::{Antichain, MutableAntichain};
-
-use crate::dataflow::{Stream, Scope};
-use crate::dataflow::channels::pushers::Tee;
-use crate::dataflow::channels::pushers::Counter as PushCounter;
-use crate::dataflow::channels::pushers::buffer::Buffer as PushBuffer;
+use crate::dataflow::{Scope, Stream};
 use crate::dataflow::channels::pact::ParallelizationContract;
 use crate::dataflow::channels::pullers::Counter as PullCounter;
+use crate::dataflow::channels::pushers::buffer::Buffer as PushBuffer;
+use crate::dataflow::channels::pushers::Counter as PushCounter;
+use crate::dataflow::channels::pushers::Tee;
 use crate::dataflow::operators::capability::Capability;
 use crate::dataflow::operators::capability::mint as mint_capability;
+use crate::dataflow::operators::generic::builder_raw::OperatorCoreLogic;
 use crate::dataflow::operators::generic::handles::{InputHandle, new_input_handle, OutputWrapper};
 use crate::dataflow::operators::generic::operator_info::OperatorInfo;
-
 use crate::logging::TimelyLogger as Logger;
+use crate::progress::{ChangeBatch, Timestamp};
+use crate::progress::frontier::{Antichain, MutableAntichain};
+use crate::progress::operate::SharedProgress;
 
 use super::builder_raw::OperatorBuilder as OperatorBuilderRaw;
 
@@ -131,9 +129,23 @@ impl<G: Scope> OperatorBuilder<G> {
     /// the operator is never incomplete and can be shut down at the system's
     /// discretion.
     pub fn build_reschedule<B, L>(self, constructor: B)
+        where
+            B: FnOnce(Vec<Capability<G::Timestamp>>) -> L,
+            L: FnMut(&[MutableAntichain<G::Timestamp>])->bool+'static
+    {
+        self.build_reschedule_core(constructor)
+    }
+
+    /// Creates an operator implementation from supplied logic constructor.
+    ///
+    /// Unlike `build`, the supplied closure can indicate if the operator
+    /// should be considered incomplete. The `build` method indicates that
+    /// the operator is never incomplete and can be shut down at the system's
+    /// discretion.
+    pub fn build_reschedule_core<B, L>(self, constructor: B)
     where
         B: FnOnce(Vec<Capability<G::Timestamp>>) -> L,
-        L: FnMut(&[MutableAntichain<G::Timestamp>])->bool+'static
+        L: OperatorRcLogic<G::Timestamp>+'static
     {
         // create capabilities, discard references to their creation.
         let mut capabilities = Vec::new();
@@ -144,45 +156,13 @@ impl<G: Scope> OperatorBuilder<G> {
             borrow.borrow_mut().clear();
         }
 
-        let mut logic = constructor(capabilities);
-
-        let mut self_frontier = self.frontier;
-        let self_consumed = self.consumed;
-        let self_internal = self.internal;
-        let self_produced = self.produced;
-
-        let raw_logic =
-        move |progress: &mut SharedProgress<G::Timestamp>| {
-
-            // drain frontier changes
-            for index in 0 .. progress.frontiers.len() {
-                self_frontier[index].update_iter(progress.frontiers[index].drain());
-            }
-
-            // invoke supplied logic
-            let result = logic(&self_frontier[..]);
-
-            // move batches of consumed changes.
-            for index in 0 .. progress.consumeds.len() {
-                self_consumed[index].borrow_mut().drain_into(&mut progress.consumeds[index]);
-            }
-
-            // move batches of internal changes.
-            let self_internal_borrow = self_internal.borrow_mut();
-            for index in 0 .. self_internal_borrow.len() {
-                let mut borrow = self_internal_borrow[index].borrow_mut();
-                progress.internals[index].extend(borrow.drain());
-            }
-
-            // move batches of produced changes.
-            for index in 0 .. progress.produceds.len() {
-                self_produced[index].borrow_mut().drain_into(&mut progress.produceds[index]);
-            }
-
-            result
-        };
-
-        self.builder.build(raw_logic);
+        self.builder.build_core(OperatorRawLogic {
+            frontier: self.frontier,
+            consumed: self.consumed,
+            internal: self.internal,
+            produced: self.produced,
+            logic: constructor(capabilities),
+        });
     }
 
     /// Get the identifier assigned to the operator being constructed
@@ -201,6 +181,58 @@ impl<G: Scope> OperatorBuilder<G> {
     }
 }
 
+/// Logic for an RC operator
+pub trait OperatorRcLogic<T: Timestamp> {
+    /// Notify the operator about a change in its inputs
+    fn update(&mut self, progress: &[MutableAntichain<T>]) -> bool;
+}
+
+impl<T, F> OperatorRcLogic<T> for F
+    where T: Timestamp, F: FnMut(&[MutableAntichain<T>]) -> bool {
+    fn update(&mut self, progress: &[MutableAntichain<T>]) -> bool {
+        (self)(progress)
+    }
+}
+
+struct OperatorRawLogic<T: Timestamp, L: OperatorRcLogic<T> + 'static> {
+    frontier: Vec<MutableAntichain<T>>,
+    consumed: Vec<Rc<RefCell<ChangeBatch<T>>>>,
+    internal: Rc<RefCell<Vec<Rc<RefCell<ChangeBatch<T>>>>>>,
+    produced: Vec<Rc<RefCell<ChangeBatch<T>>>>,
+    logic: L,
+}
+
+impl<T, L> OperatorCoreLogic<T> for OperatorRawLogic<T, L>
+    where T: Timestamp, L: OperatorRcLogic<T> + 'static {
+    fn update(&mut self, progress: &mut SharedProgress<T>) -> bool {
+        // drain frontier changes
+        for index in 0..progress.frontiers.len() {
+            self.frontier[index].update_iter(progress.frontiers[index].drain());
+        }
+
+        // invoke supplied logic
+        let result = self.logic.update(&self.frontier[..]);
+
+        // move batches of consumed changes.
+        for index in 0..progress.consumeds.len() {
+            self.consumed[index].borrow_mut().drain_into(&mut progress.consumeds[index]);
+        }
+
+        // move batches of internal changes.
+        let self_internal_borrow = self.internal.borrow_mut();
+        for index in 0..self_internal_borrow.len() {
+            let mut borrow = self_internal_borrow[index].borrow_mut();
+            progress.internals[index].extend(borrow.drain());
+        }
+
+        // move batches of produced changes.
+        for index in 0..progress.produceds.len() {
+            self.produced[index].borrow_mut().drain_into(&mut progress.produceds[index]);
+        }
+
+        result
+    }
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
The current implementation stores functions encapsulating the logic of
an operator. In this change, we introduce a trait that describes the
behavior of the logic, compatible to the current public interface.
The hope is that later we can extend the trait to allow operators in
different stages of the computation's life cycle, while maintaining
compatibility with the current interface for operators that do not need
a more elaborate interface.

This PR is intended to get some opinion about a change like this. I've had this in my mind for a while to see if it's possible to build this easily, but as said, I don't yet have a clear use case as to where it'll lead in the future.