### PR TITLE
Reachability logging

### DIFF
--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -178,7 +178,7 @@ where
         let reachability_logging =
         worker.log_register()
             .get::<reachability::logging::TrackerEvent>("timely/reachability")
-            .map(|logger| (path, logger));
+            .map(|logger| reachability::logging::TrackerLogger::new(path, logger));
         let (tracker, scope_summary) = builder.build(reachability_logging);
 
         let progcaster = Progcaster::new(worker, &self.path, self.logging.clone(), self.progress_logging.clone());

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -173,7 +173,13 @@ where
             builder.add_edge(source, target);
         }
 
-        let (tracker, scope_summary) = builder.build();
+        // The `None` argument is optional logging infrastructure.
+        let path = self.path.clone();
+        let reachability_logging =
+        worker.log_register()
+            .get::<reachability::logging::TrackerEvent>("timely/reachability")
+            .map(|logger| (path, logger));
+        let (tracker, scope_summary) = builder.build(reachability_logging);
 
         let progcaster = Progcaster::new(worker, &self.path, self.logging.clone(), self.progress_logging.clone());
 


### PR DESCRIPTION
This PR is an attempt at replicating #321 with some firm isolation between existing logging machinery and any new logging machinery. It has some opinions about where and how frequently we should log things (in batch, after consolidation), and it uses the abstraction of #352 to allow timestamps to be recovered via `dyn Any` downcasting.

cc @utaal for any thoughts, but I should be able to move this forward even without any particular comments. I think if I extend it to capture the topology as well as the events it pretty closely resembles the intent of #321.