### PR TITLE
Usability and performance tweaks

### DIFF
--- a/timely/src/dataflow/channels/pact.rs
+++ b/timely/src/dataflow/channels/pact.rs
@@ -38,7 +38,7 @@ impl<T: 'static, D: 'static> ParallelizationContract<T, D> for Pipeline {
         // // ignore `&mut A` and use thread allocator
         // let (pusher, puller) = Thread::new::<Bundle<T, D>>();
         (LogPusher::new(pusher, allocator.index(), allocator.index(), identifier, logging.clone()),
-         LogPuller::new(puller, allocator.index(), identifier, logging.clone()))
+         LogPuller::new(puller, allocator.index(), identifier, logging))
     }
 }
 

--- a/timely/src/dataflow/channels/pushers/buffer.rs
+++ b/timely/src/dataflow/channels/pushers/buffer.rs
@@ -113,7 +113,7 @@ impl<'a, T, D, P: Push<Bundle<T, D>>+'a> Session<'a, T, D, P>  where T: Eq+Clone
     /// new backing memory.
     #[inline]
     pub fn give_vec(&mut self, message: &mut Vec<D>) {
-        if message.len() > 0 {
+        if !message.is_empty() {
             self.buffer.give_vec(message);
         }
     }
@@ -144,7 +144,7 @@ impl<'a, T: Timestamp, D, P: Push<Bundle<T, D>>+'a> AutoflushSession<'a, T, D, P
     /// Transmits a pre-packed batch of data.
     #[inline]
     pub fn give_content(&mut self, message: &mut Vec<D>) {
-        if message.len() > 0 {
+        if !message.is_empty() {
             self.buffer.give_vec(message);
         }
     }

--- a/timely/src/dataflow/operators/capability.rs
+++ b/timely/src/dataflow/operators/capability.rs
@@ -385,10 +385,16 @@ impl<T: Timestamp> CapabilitySet<T> {
     }
 }
 
+impl<T: Timestamp> Default for CapabilitySet<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T: Timestamp> Deref for CapabilitySet<T> {
     type Target=[Capability<T>];
 
     fn deref(&self) -> &[Capability<T>] {
-        &self.elements[..]
+        &self.elements
     }
 }

--- a/timely/src/dataflow/operators/enterleave.rs
+++ b/timely/src/dataflow/operators/enterleave.rs
@@ -136,7 +136,7 @@ impl<'a, G: Scope, D: Data, T: Timestamp+Refines<G::Timestamp>> Leave<G, D> for 
         Stream::new(
             output,
             registrar,
-            scope.parent.clone()
+            scope.parent,
         )
     }
 }
@@ -206,7 +206,7 @@ mod test {
     fn test_nested() {
 
         use crate::dataflow::{InputHandle, ProbeHandle};
-        use crate::dataflow::operators::{Input, Exchange, Inspect, Probe};
+        use crate::dataflow::operators::{Input, Inspect, Probe};
 
         use crate::dataflow::Scope;
         use crate::dataflow::operators::{Enter, Leave};

--- a/timely/src/dataflow/operators/filter.rs
+++ b/timely/src/dataflow/operators/filter.rs
@@ -29,7 +29,7 @@ impl<G: Scope, D: Data> Filter<D> for Stream<G, D> {
             input.for_each(|time, data| {
                 data.swap(&mut vector);
                 vector.retain(|x| predicate(x));
-                if vector.len() > 0 {
+                if !vector.is_empty() {
                     output.session(&time).give_vec(&mut vector);
                 }
             });

--- a/timely/src/dataflow/operators/generic/builder_raw.rs
+++ b/timely/src/dataflow/operators/generic/builder_raw.rs
@@ -163,7 +163,7 @@ impl<G: Scope> OperatorBuilder<G> {
         let operator = OperatorCore {
             shape: self.shape,
             address: self.address,
-            activations: self.scope.activations().clone(),
+            activations: self.scope.activations(),
             logic,
             shared_progress: Rc::new(RefCell::new(SharedProgress::new(inputs, outputs))),
             summary: self.summary,

--- a/timely/src/dataflow/operators/generic/notificator.rs
+++ b/timely/src/dataflow/operators/generic/notificator.rs
@@ -282,7 +282,7 @@ impl<T: Timestamp> FrontierNotificator<T> {
     /// });
     /// ```
     #[inline]
-    pub fn notify_at<'a>(&mut self, cap: Capability<T>) {
+    pub fn notify_at(&mut self, cap: Capability<T>) {
         self.pending.push((cap,1));
     }
 
@@ -398,7 +398,7 @@ impl<T: Timestamp> FrontierNotificator<T> {
     ///            });
     /// });
     /// ```
-    pub fn pending<'a>(&'a self) -> ::std::slice::Iter<'a, (Capability<T>, u64)> {
+    pub fn pending(&self) -> ::std::slice::Iter<'_, (Capability<T>, u64)> {
         self.pending.iter()
     }
 }

--- a/timely/src/dataflow/operators/input.rs
+++ b/timely/src/dataflow/operators/input.rs
@@ -369,6 +369,12 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
     }
 }
 
+impl<T: Timestamp, D: Data> Default for Handle<T, D> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T:Timestamp, D: Data> Drop for Handle<T, D> {
     fn drop(&mut self) {
         self.close_epoch();

--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -118,7 +118,7 @@ where
         let index = self.subgraph.borrow_mut().allocate_child_id();
         let path = self.subgraph.borrow().path.clone();
 
-        let subscope = RefCell::new(SubgraphBuilder::new_from(index, path, self.logging().clone(), self.progress_logging.clone(), name));
+        let subscope = RefCell::new(SubgraphBuilder::new_from(index, path, self.logging(), self.progress_logging.clone(), name));
         let result = {
             let mut builder = Child {
                 subgraph: &subscope,

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -30,16 +30,16 @@ impl<T, E, P> BatchLogger<T, E, P> where P: EventPusher<Duration, (Duration, E, 
         }
     }
     /// Publishes a batch of logged events and advances the capability.
-    pub fn publish_batch(&mut self, time: &Duration, data: &mut Vec<(Duration, E, T)>) {
+    pub fn publish_batch(&mut self, &time: &Duration, data: &mut Vec<(Duration, E, T)>) {
         if !data.is_empty() {
             self.event_pusher.push(Event::Messages(self.time, data.drain(..).collect()));
         }
-        if &self.time < time {
-            let new_frontier = time.clone();
-            let old_frontier = self.time.clone();
+        if self.time < time {
+            let new_frontier = time;
+            let old_frontier = self.time;
             self.event_pusher.push(Event::Progress(vec![(new_frontier, 1), (old_frontier, -1)]));
         }
-        self.time = time.clone();
+        self.time = time;
     }
 }
 impl<T, E, P> Drop for BatchLogger<T, E, P> where P: EventPusher<Duration, (Duration, E, T)> {

--- a/timely/src/progress/broadcast.rs
+++ b/timely/src/progress/broadcast.rs
@@ -154,8 +154,8 @@ impl<T:Timestamp+Send> Progcaster<T> {
                     seq_no: counter,
                     channel,
                     addr: addr.clone(),
-                    messages: messages,
-                    internal: internal,
+                    messages,
+                    internal,
                 });
             });
 

--- a/timely/src/progress/mod.rs
+++ b/timely/src/progress/mod.rs
@@ -33,9 +33,9 @@ impl Location {
         Location { node, port: Port::Source(port) }
     }
     /// If the location is a target.
-    pub fn is_target(&self) -> bool { if let Port::Target(_) = self.port { true } else { false } }
+    pub fn is_target(&self) -> bool { matches!(self.port, Port::Target(_)) }
     /// If the location is a source.
-    pub fn is_source(&self) -> bool { if let Port::Source(_) = self.port { true } else { false } }
+    pub fn is_source(&self) -> bool { matches!(self.port, Port::Source(_)) }
 }
 
 impl From<Target> for Location {


### PR DESCRIPTION
* Added some `Default` implementations to types where possible
* Removed some redundant clones
* Addressed a few minor lints
* Swapped from indexing to iteration where possible
* Added methods to `Antichain` & `ChangeBatch` that allow pre-allocating space within them
* Made `summarize_outputs()` do as much pre-allocation as possible instead of just repeatedly pushing, should help to cut down the number of alloc calls it makes
* Moved trait bounds on `Antichain`, `MutableAntichain` & `ChangeBatch` from the type declaration to the methods that need it, this is really nice from a user perspective because it means you can use these types within your own structs without having to add trait bounds *everywhere*
* Made `MutableAntichain::update_iter()` use [`Iterator::size_hint()`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.size_hint) to pre-allocate space for the new elements