### PR TITLE
Fixed bug in Subgraph::get_internal_summary()

### DIFF
--- a/timely/src/progress/frontier.rs
+++ b/timely/src/progress/frontier.rs
@@ -43,6 +43,11 @@ impl<T: PartialOrder> Antichain<T> {
         }
     }
 
+    /// Reserves capacity for at least additional more elements to be inserted in the given `Antichain`
+    pub fn reserve(&mut self, additional: usize) {
+        self.elements.reserve(additional);
+    }
+
     /// Performs a sequence of insertion and return true iff any insertion does.
     ///
     /// # Examples

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -637,8 +637,17 @@ impl<T: Timestamp> PerOperatorState<T> {
 
         let (internal_summary, shared_progress) = scope.get_internal_summary();
 
-        assert_eq!(internal_summary.len(), inputs);
-        assert!(!internal_summary.iter().any(|x| x.len() != outputs));
+        assert_eq!(
+            internal_summary.len(),
+            inputs,
+            "operator summary has {} inputs when {} were expected",
+            internal_summary.len(),
+            inputs,
+        );
+        assert!(
+            !internal_summary.iter().any(|x| x.len() != outputs),
+            "operator summary had too few outputs",
+        );
 
         PerOperatorState {
             name:               scope.name().to_owned(),

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -533,10 +533,7 @@ where
         // Note that we need to have `self.inputs()` elements in the summary
         // with each element containing `self.outputs()` antichains regardless
         // of how long `self.scope_summary` is
-        let mut internal_summary: Vec<Vec<_>> = (0..self.inputs())
-            .map(|_| (0..self.outputs()).map(|_| Antichain::new()).collect())
-            .collect();
-
+        let mut internal_summary = vec![vec![Antichain::new(); self.outputs()]; self.inputs()];
         for (input_idx, input) in self.scope_summary.iter().enumerate() {
             for (output_idx, output) in input.iter().enumerate() {
                 let antichain = &mut internal_summary[input_idx][output_idx];

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -548,6 +548,16 @@ where
             }
         }
 
+        debug_assert_eq!(
+            internal_summary.len(),
+            self.inputs(),
+            "the internal summary should have as many elements as there are inputs",
+        );
+        debug_assert!(
+            internal_summary.iter().all(|summary| summary.len() == self.outputs()),
+            "each element of the internal summary should have as many elements as there are outputs",
+        );
+
         // Each child has expressed initial capabilities (their `shared_progress.internals`).
         // We introduce these into the progress tracker to determine the scope's initial
         // internal capabilities.

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -530,6 +530,9 @@ where
         assert_eq!(self.children[0].outputs, self.inputs());
         assert_eq!(self.children[0].inputs, self.outputs());
 
+        // Note that we need to have `self.inputs()` elements in the summary
+        // with each element containing `self.outputs()` antichains regardless
+        // of how long `self.scope_summary` is
         let mut internal_summary: Vec<Vec<_>> = (0..self.inputs())
             .map(|_| (0..self.outputs()).map(|_| Antichain::new()).collect())
             .collect();

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -537,17 +537,11 @@ where
             .map(|_| (0..self.outputs()).map(|_| Antichain::new()).collect())
             .collect();
 
-        for (summary, internal_summary) in
-            self.scope_summary.iter().zip(internal_summary.iter_mut())
-        {
-            internal_summary.reserve(summary.len());
-
-            for (output, antichain) in summary.iter().zip(internal_summary) {
+        for (input_idx, input) in self.scope_summary.iter().enumerate() {
+            for (output_idx, output) in input.iter().enumerate() {
+                let antichain = &mut internal_summary[input_idx][output_idx];
                 antichain.reserve(output.elements().len());
-
-                for path_summary in output.elements() {
-                    antichain.insert(TInner::summarize(path_summary.clone()));
-                }
+                antichain.extend(output.elements().iter().cloned().map(TInner::summarize));
             }
         }
 


### PR DESCRIPTION
Fixes a bug introduced in #379 that caused too few elements/sub-elements being added to the internal summary