### PR TITLE
Worked on Capability egronomics

### DIFF
--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -17,7 +17,6 @@ use crate::dataflow::channels::pushers::buffer::Buffer as PushBuffer;
 use crate::dataflow::channels::pact::ParallelizationContract;
 use crate::dataflow::channels::pullers::Counter as PullCounter;
 use crate::dataflow::operators::capability::Capability;
-use crate::dataflow::operators::capability::mint as mint_capability;
 use crate::dataflow::operators::generic::handles::{InputHandle, new_input_handle, OutputWrapper};
 use crate::dataflow::operators::generic::operator_info::OperatorInfo;
 
@@ -138,7 +137,7 @@ impl<G: Scope> OperatorBuilder<G> {
         // create capabilities, discard references to their creation.
         let mut capabilities = Vec::with_capacity(self.internal.borrow().len());
         for batch in self.internal.borrow().iter() {
-            capabilities.push(mint_capability(G::Timestamp::minimum(), batch.clone()));
+            capabilities.push(Capability::new(G::Timestamp::minimum(), batch.clone()));
             // Discard evidence of creation, as we are assumed to start with one.
             batch.borrow_mut().clear();
         }

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -18,7 +18,6 @@ use crate::communication::{Push, Pull, message::RefOrMut};
 use crate::logging::TimelyLogger as Logger;
 
 use crate::dataflow::operators::CapabilityRef;
-use crate::dataflow::operators::capability::mint_ref as mint_capability_ref;
 use crate::dataflow::operators::capability::CapabilityTrait;
 
 /// Handle to an operator's input stream.
@@ -47,10 +46,10 @@ impl<'a, T: Timestamp, D: Data, P: Pull<Bundle<T, D>>> InputHandle<T, D, P> {
         self.pull_counter.next().map(|bundle| {
             match bundle.as_ref_or_mut() {
                 RefOrMut::Ref(bundle) => {
-                    (mint_capability_ref(&bundle.time, internal.clone()), RefOrMut::Ref(&bundle.data))
+                    (CapabilityRef::new(&bundle.time, internal.clone()), RefOrMut::Ref(&bundle.data))
                 },
                 RefOrMut::Mut(bundle) => {
-                    (mint_capability_ref(&bundle.time, internal.clone()), RefOrMut::Mut(&mut bundle.data))
+                    (CapabilityRef::new(&bundle.time, internal.clone()), RefOrMut::Mut(&mut bundle.data))
                 },
             }
         })
@@ -81,10 +80,10 @@ impl<'a, T: Timestamp, D: Data, P: Pull<Bundle<T, D>>> InputHandle<T, D, P> {
         while let Some((cap, data)) = self.pull_counter.next().map(|bundle| {
             match bundle.as_ref_or_mut() {
                 RefOrMut::Ref(bundle) => {
-                    (mint_capability_ref(&bundle.time, internal.clone()), RefOrMut::Ref(&bundle.data))
+                    (CapabilityRef::new(&bundle.time, internal.clone()), RefOrMut::Ref(&bundle.data))
                 },
                 RefOrMut::Mut(bundle) => {
-                    (mint_capability_ref(&bundle.time, internal.clone()), RefOrMut::Mut(&mut bundle.data))
+                    (CapabilityRef::new(&bundle.time, internal.clone()), RefOrMut::Mut(&mut bundle.data))
                 },
             }
         }) {

--- a/timely/src/dataflow/operators/generic/notificator.rs
+++ b/timely/src/dataflow/operators/generic/notificator.rs
@@ -109,11 +109,11 @@ fn notificator_delivers_notifications_in_topo_order() {
     use crate::progress::ChangeBatch;
     use crate::progress::frontier::MutableAntichain;
     use crate::order::Product;
-    use crate::dataflow::operators::capability::mint as mint_capability;
+    use crate::dataflow::operators::capability::Capability;
 
     let mut frontier = MutableAntichain::new_bottom(Product::new(0, 0));
 
-    let root_capability = mint_capability(Product::new(0,0), Rc::new(RefCell::new(ChangeBatch::new())));
+    let root_capability = Capability::new(Product::new(0,0), Rc::new(RefCell::new(ChangeBatch::new())));
 
     let logging = None;//::logging::new_inactive_logger();
 

--- a/timely/src/dataflow/operators/unordered_input.rs
+++ b/timely/src/dataflow/operators/unordered_input.rs
@@ -14,8 +14,7 @@ use crate::Data;
 use crate::dataflow::channels::pushers::{Tee, Counter as PushCounter};
 use crate::dataflow::channels::pushers::buffer::{Buffer as PushBuffer, AutoflushSession};
 
-use crate::dataflow::operators::ActivateCapability;
-use crate::dataflow::operators::capability::mint as mint_capability;
+use crate::dataflow::operators::{ActivateCapability, Capability};
 
 use crate::dataflow::{Stream, Scope};
 
@@ -84,7 +83,7 @@ impl<G: Scope> UnorderedInput<G> for G {
         let (output, registrar) = Tee::<G::Timestamp, D>::new();
         let internal = Rc::new(RefCell::new(ChangeBatch::new()));
         // let produced = Rc::new(RefCell::new(ChangeBatch::new()));
-        let cap = mint_capability(G::Timestamp::minimum(), internal.clone());
+        let cap = Capability::new(G::Timestamp::minimum(), internal.clone());
         let counter = PushCounter::new(output);
         let produced = counter.produced().clone();
         let peers = self.peers();
@@ -93,7 +92,7 @@ impl<G: Scope> UnorderedInput<G> for G {
         let mut address = self.addr();
         address.push(index);
 
-        let cap = ActivateCapability::new(cap, &address[..], self.activations().clone());
+        let cap = ActivateCapability::new(cap, &address, self.activations());
 
         let helper = UnorderedHandle::new(counter);
 

--- a/timely/src/order.rs
+++ b/timely/src/order.rs
@@ -29,8 +29,8 @@ macro_rules! implement_partial {
     ($($index_type:ty,)*) => (
         $(
             impl PartialOrder for $index_type {
-                #[inline] fn less_than(&self, other: &Self) -> bool { self < other }
-                #[inline] fn less_equal(&self, other: &Self) -> bool { self <= other }
+                fn less_than(&self, other: &Self) -> bool { self < other }
+                fn less_equal(&self, other: &Self) -> bool { self <= other }
             }
         )*
     )

--- a/timely/src/order.rs
+++ b/timely/src/order.rs
@@ -29,8 +29,8 @@ macro_rules! implement_partial {
     ($($index_type:ty,)*) => (
         $(
             impl PartialOrder for $index_type {
-                fn less_than(&self, other: &Self) -> bool { self < other }
-                fn less_equal(&self, other: &Self) -> bool { self <= other }
+                #[inline] fn less_than(&self, other: &Self) -> bool { self < other }
+                #[inline] fn less_equal(&self, other: &Self) -> bool { self <= other }
             }
         )*
     )

--- a/timely/src/scheduling/activate.rs
+++ b/timely/src/scheduling/activate.rs
@@ -37,6 +37,7 @@ impl Scheduler for Box<dyn Scheduler> {
 }
 
 /// Allocation-free activation tracker.
+#[derive(Debug)]
 pub struct Activations {
     clean: usize,
     /// `(offset, length)`

--- a/timely/src/scheduling/mod.rs
+++ b/timely/src/scheduling/mod.rs
@@ -24,11 +24,12 @@ pub trait Schedule {
 pub trait Scheduler {
     /// Provides a shared handle to the activation scheduler.
     fn activations(&self) -> Rc<RefCell<Activations>>;
+
     /// Constructs an `Activator` tied to the specified operator address.
     fn activator_for(&self, path: &[usize]) -> Activator {
-        let activations = self.activations().clone();
-        Activator::new(path, activations)
+        Activator::new(path, self.activations())
     }
+
     /// Constructs a `SyncActivator` tied to the specified operator address.
     fn sync_activator_for(&self, path: &[usize]) -> SyncActivator {
         let sync_activations = self.activations().borrow().sync();


### PR DESCRIPTION
* Removed the `mint()` and `mint_ref()` methods in favor of `pub(crate)` `new()` constructors
* Implemented `Debug` for `ActivateCapability` & `Activations`
* Added `.try_{delayed, downgrade}` methods to allow fallibly performing delays/downgrades. Good for debugging code and for applications that can't tolerate panicking
* Worked on the panics used within `.delayed()` & `.downgrade()` with the aim of reducing their code bloat as much as possible, thereby making the compiler eagerly inline the actual function's body without including all the panicking/formatting/generic machinery within it
* Removed `#[inline]` attributes from many frequently-called functions. This aims to counteract code bloat, as the `#[inline]` attribute has large compile time costs ([reference](https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute), [rust core team member](https://internals.rust-lang.org/t/when-should-i-use-inline/598/3?u=wisagan))