### PR TITLE
Fix ability to eliminate getopts dep

### DIFF
--- a/timely/Cargo.toml
+++ b/timely/Cargo.toml
@@ -28,7 +28,7 @@ abomonation = "0.7.3"
 abomonation_derive = "0.5"
 timely_bytes = { path = "../bytes", version = "0.12" }
 timely_logging = { path = "../logging", version = "0.12" }
-timely_communication = { path = "../communication", version = "0.12" }
+timely_communication = { path = "../communication", version = "0.12", default-features = false }
 crossbeam-channel = "0.5.0"
 futures-util = "0.3"
 


### PR DESCRIPTION
Based on the use of [\[features\] getopts = \["timely_communication/getopts"\]](https://github.com/TimelyDataflow/timely-dataflow/blob/b619080c6c3d9ec249b2943d56ff4a2d8ce8e121/timely/Cargo.toml#L21) it appears that it was intended for timely_communication's "getopts" feature to be only conditionally enabled. However ["getopts" is a **default** feature of timely_communication](https://github.com/TimelyDataflow/timely-dataflow/blob/b619080c6c3d9ec249b2943d56ff4a2d8ce8e121/communication/Cargo.toml#L17).

In order for a crate that depends on `timely` to be able to avoid the `getopts` dependency when it has no need for `timely::execute_from_args`, timely must not unconditionally enable timely_communication's default features.

PR tested with a crate that depends on timely with default-features=false, using `cargo check` to confirm it's able to build and `cargo tree` to confirm the getopts transitive dependency is now correctly eliminated.