### PR TITLE
Add conditional regions

### DIFF
--- a/timely/src/dataflow/operators/enterleave.rs
+++ b/timely/src/dataflow/operators/enterleave.rs
@@ -21,7 +21,7 @@
 
 use std::marker::PhantomData;
 
-use crate::dataflow::scopes::Region;
+use crate::dataflow::scopes::region::{Region, RegionSubgraph};
 use crate::progress::Timestamp;
 use crate::progress::timestamp::Refines;
 use crate::progress::{Source, Target};
@@ -31,6 +31,7 @@ use crate::communication::Push;
 use crate::dataflow::channels::pushers::{Counter, Tee};
 use crate::dataflow::channels::{Bundle, Message};
 
+use crate::scheduling::Scheduler;
 use crate::worker::AsWorker;
 use crate::dataflow::{Stream, Scope};
 use crate::dataflow::scopes::{Child, ScopeParent};
@@ -85,9 +86,6 @@ impl<G: Scope, T: Timestamp, D: Data, E: Enter<G, Product<<G as ScopeParent>::Ti
 
 impl<G: Scope, T: Timestamp+Refines<G::Timestamp>, D: Data> Enter<G, T, D> for Stream<G, D> {
     fn enter<'a>(&self, scope: &Child<'a, G, T>) -> Stream<Child<'a, G, T>, D> {
-
-        use crate::scheduling::Scheduler;
-
         let (targets, registrar) = Tee::<T, D>::new();
         let ingress = IngressNub {
             targets: Counter::new(targets),
@@ -195,6 +193,107 @@ where TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TData: Data {
             }
         }
         else { self.targets.done(); }
+    }
+}
+
+/// Extension trait to move a [`Stream`] into a child [`Region`]
+pub trait EnterRegion<G, D>
+where
+    G: Scope,
+    D: Data,
+{
+    /// Moves the [`Stream`] argument into a child [`Region`]
+    ///
+    /// # Examples
+    /// ```
+    /// use timely::dataflow::scopes::Scope;
+    /// use timely::dataflow::operators::{enterleave::{EnterRegion, LeaveRegion}, ToStream};
+    ///
+    /// timely::example(|outer| {
+    ///     let stream = (0..9).to_stream(outer);
+    ///     let output = outer.optional_region(true, |inner| {
+    ///         stream.enter_region(inner).leave_region()
+    ///     });
+    /// });
+    /// ```
+    fn enter_region<'a>(&self, region: &Region<'a, G>) -> Stream<Region<'a, G>, D>;
+}
+
+impl<G, D> EnterRegion<G, D> for Stream<G, D>
+where
+    G: Scope,
+    D: Data,
+{
+    fn enter_region<'a>(&self, region: &Region<'a, G>) -> Stream<Region<'a, G>, D> {
+        match region.subgraph {
+            RegionSubgraph::Subgraph { subgraph, .. } => {
+                let (targets, registrar) = Tee::<G::Timestamp, D>::new();
+                let ingress = IngressNub {
+                    targets: Counter::new(targets),
+                    phantom: PhantomData,
+                    activator: region.activator_for(&region.addr()),
+                    active: false,
+                };
+                let produced = ingress.targets.produced().clone();
+
+                let input = subgraph.borrow_mut().new_input(produced);
+
+                let channel_id = region.clone().new_identifier();
+                self.connect_to(input, ingress, channel_id);
+
+                Stream::new(Source::new(0, input.port), registrar, region.clone())
+            }
+
+            RegionSubgraph::Passthrough => Stream::new(*self.name(), self.ports.clone(), region.clone()),
+        }
+    }
+}
+
+/// Extension trait to move a [`Stream`] to the parent of its current [`Region`]
+pub trait LeaveRegion<G: Scope, D: Data> {
+    /// Moves a [`Stream`] to the parent of its current [`Region`]
+    ///
+    /// # Examples
+    /// ```
+    /// use timely::dataflow::scopes::Scope;
+    /// use timely::dataflow::operators::{enterleave::{EnterRegion, LeaveRegion}, ToStream};
+    ///
+    /// timely::example(|outer| {
+    ///     let stream = (0..9).to_stream(outer);
+    ///     let output = outer.optional_region(false, |inner| {
+    ///         stream.enter_region(inner).leave_region()
+    ///     });
+    /// });
+    /// ```
+    fn leave_region(&self) -> Stream<G, D>;
+}
+
+impl<'a, G: Scope, D: Data> LeaveRegion<G, D> for Stream<Region<'a, G>, D> {
+    fn leave_region(&self) -> Stream<G, D> {
+        let scope = self.scope();
+
+        match scope.subgraph {
+            RegionSubgraph::Subgraph { subgraph, .. } => {
+                let output = subgraph.borrow_mut().new_output();
+                let (targets, registrar) = Tee::<G::Timestamp, D>::new();
+                let channel_id = scope.clone().new_identifier();
+
+                self.connect_to(
+                    Target::new(0, output.port),
+                    EgressNub {
+                        targets,
+                        phantom: PhantomData,
+                    },
+                    channel_id,
+                );
+
+                Stream::new(output, registrar, scope.parent)
+            }
+
+            RegionSubgraph::Passthrough => {
+                Stream::new(*self.name(), self.ports.clone(), scope.parent)
+            }
+        }
     }
 }
 

--- a/timely/src/dataflow/operators/enterleave.rs
+++ b/timely/src/dataflow/operators/enterleave.rs
@@ -21,6 +21,7 @@
 
 use std::marker::PhantomData;
 
+use crate::dataflow::scopes::Region;
 use crate::progress::Timestamp;
 use crate::progress::timestamp::Refines;
 use crate::progress::{Source, Target};
@@ -51,7 +52,7 @@ pub trait Enter<G: Scope, T: Timestamp+Refines<G::Timestamp>, D: Data> {
     ///     });
     /// });
     /// ```
-    fn enter<'a>(&self, _: &Child<'a, G, T>) -> Stream<Child<'a, G, T>, D>;
+    fn enter<'a>(&self, child: &Child<'a, G, T>) -> Stream<Child<'a, G, T>, D>;
 }
 
 use crate::dataflow::scopes::child::Iterative;

--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -139,7 +139,7 @@ where
 
     fn optional_region_named<R, F>(&mut self, name: &str, enabled: bool, func: F) -> R
     where
-        F: FnOnce(&mut Region<Self, T>) -> R,
+        F: FnOnce(&mut Region<Self>) -> R,
     {
         // If the region is enabled then build the child dataflow graph, otherwise
         // create a passthrough region

--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -5,6 +5,7 @@ use std::cell::RefCell;
 
 use crate::communication::{Data, Push, Pull};
 use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
+use crate::dataflow::scopes::region::RegionSubgraph;
 use crate::scheduling::Scheduler;
 use crate::scheduling::activate::Activations;
 use crate::progress::{Timestamp, Operate, SubgraphBuilder};
@@ -15,6 +16,7 @@ use crate::logging::TimelyLogger as Logger;
 use crate::logging::TimelyProgressLogger as ProgressLogger;
 use crate::worker::{AsWorker, Config};
 
+use super::Region;
 use super::{ScopeParent, Scope};
 
 /// Type alias for iterative child scope.
@@ -131,6 +133,54 @@ where
         let subscope = subscope.into_inner().build(self);
 
         self.add_operator_with_index(Box::new(subscope), index);
+
+        result
+    }
+
+    fn optional_region_named<R, F>(&mut self, name: &str, enabled: bool, func: F) -> R
+    where
+        F: FnOnce(&mut Region<Self, T>) -> R,
+    {
+        // If the region is enabled then build the child dataflow graph, otherwise
+        // create a passthrough region
+        let region = if enabled {
+            let index = self.subgraph.borrow_mut().allocate_child_id();
+            let path = self.subgraph.borrow().path.clone();
+
+            let subscope = RefCell::new(SubgraphBuilder::<T, T>::new_from(
+                index,
+                path,
+                self.logging(),
+                self.progress_logging.clone(),
+                name,
+            ));
+
+            Some((subscope, index))
+        } else {
+            None
+        };
+
+        let result = {
+            let region = region
+                .as_ref()
+                .map_or(RegionSubgraph::Passthrough, |(scope, idx)| {
+                    RegionSubgraph::subgraph(scope, *idx)
+                });
+
+            let mut builder = Region {
+                subgraph: region,
+                parent: self.clone(),
+                logging: self.logging.clone(),
+                progress_logging: self.progress_logging.clone(),
+            };
+            func(&mut builder)
+        };
+
+        // If the region is enabled then build and add the sub-scope to the dataflow graph
+        if let Some((subscope, index)) = region {
+            let subscope = subscope.into_inner().build(self);
+            self.add_operator_with_index(Box::new(subscope), index);
+        }
 
         result
     }

--- a/timely/src/dataflow/scopes/mod.rs
+++ b/timely/src/dataflow/scopes/mod.rs
@@ -1,5 +1,6 @@
 //! Hierarchical organization of timely dataflow graphs.
 
+use std::panic::Location;
 use crate::progress::{Timestamp, Operate, Source, Target};
 use crate::order::Product;
 use crate::progress::timestamp::Refines;
@@ -7,8 +8,10 @@ use crate::communication::Allocate;
 use crate::worker::AsWorker;
 
 pub mod child;
+pub mod region;
 
 pub use self::child::Child;
+pub use region::Region;
 
 /// The information a child scope needs from its parent.
 pub trait ScopeParent: AsWorker+Clone {
@@ -187,4 +190,73 @@ pub trait Scope: ScopeParent {
         self.scoped::<<Self as ScopeParent>::Timestamp,R,F>(name, func)
     }
 
+    /// Creates an optional dataflow region with the same timestamp as the outer scope.
+    ///
+    /// If `enabled` is true then this acts like [`Scope::region()`] and if `enabled`
+    /// is false it's a no-op and produces no change in the dataflow graph.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use timely::dataflow::Scope;
+    /// use timely::dataflow::operators::{Input, Enter, Leave};
+    ///
+    /// timely::execute_from_args(std::env::args(), |worker| {
+    ///     // must specify types as nothing else drives inference.
+    ///     let input = worker.dataflow::<u64,_,_>(|child1| {
+    ///         let (input, stream) = child1.new_input::<String>();
+    ///         let output = child1.optional_region(true, |child2| {
+    ///             stream.enter(child2).leave()
+    ///         });
+    ///
+    ///         input
+    ///     });
+    /// });
+    /// ```
+    ///
+    #[track_caller]
+    fn optional_region<R, F>(&mut self, enabled: bool, func: F) -> R
+    where
+        F: FnOnce(&mut Region<Self, Self::Timestamp>) -> R,
+    {
+        let caller = Location::caller();
+        let name = format!(
+            "OptionalRegion @ {}:{}:{}",
+            caller.file(),
+            caller.line(),
+            caller.column(),
+        );
+
+        self.optional_region_named(&name, enabled, func)
+    }
+
+    /// Creates an optional dataflow region with the same timestamp as the outer scope.
+    ///
+    /// If `enabled` is true then this acts like [`Scope::region()`] and if `enabled`
+    /// is false it's a no-op and produces no change in the dataflow graph.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use timely::dataflow::Scope;
+    /// use timely::dataflow::operators::{Input, Enter, Leave};
+    ///
+    /// timely::execute_from_args(std::env::args(), |worker| {
+    ///     // must specify types as nothing else drives inference.
+    ///     let input = worker.dataflow::<u64,_,_>(|child1| {
+    ///         let (input, stream) = child1.new_input::<String>();
+    ///         let output = child1.optional_region_named(
+    ///             "This is my region",
+    ///             false,
+    ///             |child2| stream.enter(child2).leave(),
+    ///         );
+    ///
+    ///         input
+    ///     });
+    /// });
+    /// ```
+    ///
+    fn optional_region_named<R, F>(&mut self, name: &str, enabled: bool, func: F) -> R
+    where
+        F: FnOnce(&mut Region<Self, Self::Timestamp>) -> R;
 }

--- a/timely/src/dataflow/scopes/mod.rs
+++ b/timely/src/dataflow/scopes/mod.rs
@@ -199,14 +199,14 @@ pub trait Scope: ScopeParent {
     ///
     /// ```
     /// use timely::dataflow::Scope;
-    /// use timely::dataflow::operators::{Input, Enter, Leave};
+    /// use timely::dataflow::operators::{Input, enterleave::{EnterRegion, LeaveRegion}};
     ///
     /// timely::execute_from_args(std::env::args(), |worker| {
     ///     // must specify types as nothing else drives inference.
-    ///     let input = worker.dataflow::<u64,_,_>(|child1| {
-    ///         let (input, stream) = child1.new_input::<String>();
-    ///         let output = child1.optional_region(true, |child2| {
-    ///             stream.enter(child2).leave()
+    ///     let input = worker.dataflow::<u64,_,_>(|scope| {
+    ///         let (input, stream) = scope.new_input::<String>();
+    ///         let output = scope.optional_region(true, |region| {
+    ///             stream.enter_region(region).leave_region()
     ///         });
     ///
     ///         input
@@ -217,7 +217,7 @@ pub trait Scope: ScopeParent {
     #[track_caller]
     fn optional_region<R, F>(&mut self, enabled: bool, func: F) -> R
     where
-        F: FnOnce(&mut Region<Self, Self::Timestamp>) -> R,
+        F: FnOnce(&mut Region<Self>) -> R,
     {
         let caller = Location::caller();
         let name = format!(
@@ -239,16 +239,16 @@ pub trait Scope: ScopeParent {
     ///
     /// ```
     /// use timely::dataflow::Scope;
-    /// use timely::dataflow::operators::{Input, Enter, Leave};
+    /// use timely::dataflow::operators::{Input, enterleave::{EnterRegion, LeaveRegion}};
     ///
     /// timely::execute_from_args(std::env::args(), |worker| {
     ///     // must specify types as nothing else drives inference.
-    ///     let input = worker.dataflow::<u64,_,_>(|child1| {
-    ///         let (input, stream) = child1.new_input::<String>();
-    ///         let output = child1.optional_region_named(
+    ///     let input = worker.dataflow::<u64,_,_>(|scope| {
+    ///         let (input, stream) = scope.new_input::<String>();
+    ///         let output = scope.optional_region_named(
     ///             "This is my region",
     ///             false,
-    ///             |child2| stream.enter(child2).leave(),
+    ///             |region| stream.enter_region(region).leave_region(),
     ///         );
     ///
     ///         input
@@ -258,5 +258,5 @@ pub trait Scope: ScopeParent {
     ///
     fn optional_region_named<R, F>(&mut self, name: &str, enabled: bool, func: F) -> R
     where
-        F: FnOnce(&mut Region<Self, Self::Timestamp>) -> R;
+        F: FnOnce(&mut Region<Self>) -> R;
 }

--- a/timely/src/dataflow/scopes/region.rs
+++ b/timely/src/dataflow/scopes/region.rs
@@ -1,0 +1,311 @@
+//! A child dataflow scope used to build optional dataflow regions.
+
+use crate::{
+    communication::{
+        allocator::thread::{ThreadPuller, ThreadPusher},
+        Data, Pull, Push,
+    },
+    dataflow::{scopes::Child, Scope, ScopeParent},
+    logging::{TimelyLogger as Logger, TimelyProgressLogger as ProgressLogger, WorkerIdentifier},
+    logging_core::Registry,
+    progress::{timestamp::Refines, Operate, Source, SubgraphBuilder, Target, Timestamp},
+    scheduling::{Activations, Scheduler},
+    worker::{AsWorker, Config},
+};
+use std::{
+    cell::{RefCell, RefMut},
+    rc::Rc,
+};
+use timely_communication::Message;
+
+type AllocatedChannels<D> = (Vec<Box<dyn Push<Message<D>>>>, Box<dyn Pull<Message<D>>>);
+
+/// A nested dataflow region, can either be a subgraph equivalent to [`Scope::region()`]
+/// or a no-op that has no affect on the dataflow graph
+pub struct Region<'a, G, T>
+where
+    G: Scope<Timestamp = T>,
+    T: Timestamp,
+{
+    /// The subgraph under construction
+    pub subgraph: RegionSubgraph<'a, G, T>,
+    /// A copy of the child's parent scope.
+    pub parent: G,
+    /// The log writer for this scope.
+    pub logging: Option<Logger>,
+    /// The progress log writer for this scope.
+    pub progress_logging: Option<ProgressLogger>,
+}
+
+impl<'a, G, T> Region<'a, G, T>
+where
+    G: Scope<Timestamp = T>,
+    T: Timestamp,
+{
+    fn allocate_child_id(&mut self) -> usize {
+        match self.subgraph {
+            RegionSubgraph::Subgraph { subgraph, .. } => subgraph.borrow_mut().allocate_child_id(),
+            RegionSubgraph::Passthrough => self.parent.allocate_operator_index(),
+        }
+    }
+
+    fn path(&self) -> Vec<usize> {
+        match self.subgraph {
+            RegionSubgraph::Subgraph { subgraph, .. } => subgraph.borrow().path.clone(),
+            RegionSubgraph::Passthrough => self.parent.addr(),
+        }
+    }
+
+    fn create_child_subscope<TOuter, TInner>(
+        &mut self,
+        name: &str,
+    ) -> RefCell<SubgraphBuilder<TOuter, TInner>>
+    where
+        TOuter: Timestamp,
+        TInner: Timestamp + Refines<TOuter>,
+    {
+        let index = self.allocate_child_id();
+        let path = self.path();
+
+        RefCell::new(SubgraphBuilder::new_from(
+            index,
+            path,
+            self.logging(),
+            self.progress_logging.clone(),
+            name,
+        ))
+    }
+}
+
+impl<'a, G, T> AsWorker for Region<'a, G, T>
+where
+    G: Scope<Timestamp = T>,
+    T: Timestamp,
+{
+    fn config(&self) -> &Config {
+        self.parent.config()
+    }
+
+    fn index(&self) -> usize {
+        self.parent.index()
+    }
+
+    fn peers(&self) -> usize {
+        self.parent.peers()
+    }
+
+    fn allocate<D: Data>(&mut self, identifier: usize, address: &[usize]) -> AllocatedChannels<D> {
+        self.parent.allocate(identifier, address)
+    }
+
+    fn pipeline<D: 'static>(
+        &mut self,
+        identifier: usize,
+        address: &[usize],
+    ) -> (ThreadPusher<Message<D>>, ThreadPuller<Message<D>>) {
+        self.parent.pipeline(identifier, address)
+    }
+
+    fn new_identifier(&mut self) -> usize {
+        self.parent.new_identifier()
+    }
+
+    fn log_register(&self) -> RefMut<Registry<WorkerIdentifier>> {
+        self.parent.log_register()
+    }
+}
+
+impl<'a, G, T> Scheduler for Region<'a, G, T>
+where
+    G: Scope<Timestamp = T>,
+    T: Timestamp,
+{
+    fn activations(&self) -> Rc<RefCell<Activations>> {
+        self.parent.activations()
+    }
+}
+
+impl<'a, G, T> ScopeParent for Region<'a, G, T>
+where
+    G: Scope<Timestamp = T>,
+    T: Timestamp,
+{
+    type Timestamp = T;
+}
+
+impl<'a, G, T> Scope for Region<'a, G, T>
+where
+    G: Scope<Timestamp = T>,
+    T: Timestamp + Refines<G::Timestamp>,
+{
+    fn name(&self) -> String {
+        todo!()
+    }
+
+    fn addr(&self) -> Vec<usize> {
+        todo!()
+    }
+
+    fn add_edge(&self, source: Source, target: Target) {
+        match self.subgraph {
+            RegionSubgraph::Subgraph { subgraph, .. } => {
+                subgraph.borrow_mut().connect(source, target);
+            }
+            RegionSubgraph::Passthrough => self.parent.add_edge(source, target),
+        }
+    }
+
+    fn allocate_operator_index(&mut self) -> usize {
+        match self.subgraph {
+            RegionSubgraph::Subgraph { subgraph, .. } => subgraph.borrow_mut().allocate_child_id(),
+            RegionSubgraph::Passthrough => self.parent.allocate_operator_index(),
+        }
+    }
+
+    fn add_operator_with_indices(
+        &mut self,
+        operator: Box<dyn Operate<Self::Timestamp>>,
+        local: usize,
+        global: usize,
+    ) {
+        match self.subgraph {
+            RegionSubgraph::Subgraph { subgraph, .. } => {
+                subgraph.borrow_mut().add_child(operator, local, global);
+            }
+            RegionSubgraph::Passthrough => self
+                .parent
+                .add_operator_with_indices(operator, local, global),
+        }
+    }
+
+    fn scoped<T2, R, F>(&mut self, name: &str, func: F) -> R
+    where
+        T2: Timestamp + Refines<Self::Timestamp>,
+        F: FnOnce(&mut Child<Self, T2>) -> R,
+    {
+        let subscope = self.create_child_subscope(name);
+        let index = subscope.borrow().index();
+
+        let result = {
+            let mut builder = Child {
+                subgraph: &subscope,
+                parent: self.clone(),
+                logging: self.logging.clone(),
+                progress_logging: self.progress_logging.clone(),
+            };
+            func(&mut builder)
+        };
+
+        let subscope = subscope.into_inner().build(self);
+        self.add_operator_with_index(Box::new(subscope), index);
+
+        result
+    }
+
+    fn optional_region_named<R, F>(&mut self, name: &str, enabled: bool, func: F) -> R
+    where
+        F: FnOnce(&mut Region<Self, Self::Timestamp>) -> R,
+    {
+        // If the region is enabled then build the child dataflow graph, otherwise
+        // create a passthrough region
+        let region = if enabled {
+            Some(self.create_child_subscope(name))
+        } else {
+            None
+        };
+
+        let result = {
+            let region = region
+                .as_ref()
+                .map_or(RegionSubgraph::Passthrough, |subscope| {
+                    let index = subscope.borrow().index();
+                    RegionSubgraph::subgraph(subscope, index)
+                });
+
+            let mut builder = Region {
+                subgraph: region,
+                parent: self.clone(),
+                logging: self.logging.clone(),
+                progress_logging: self.progress_logging.clone(),
+            };
+            func(&mut builder)
+        };
+
+        // If the region is enabled then build and add the sub-scope to the dataflow graph
+        if let Some(subscope) = region {
+            let index = subscope.borrow().index();
+            let subscope = subscope.into_inner().build(self);
+
+            self.add_operator_with_index(Box::new(subscope), index);
+        }
+
+        result
+    }
+}
+
+impl<'a, G, T> Clone for Region<'a, G, T>
+where
+    G: Scope<Timestamp = T>,
+    T: Timestamp,
+{
+    fn clone(&self) -> Self {
+        Self {
+            subgraph: self.subgraph,
+            parent: self.parent.clone(),
+            logging: self.logging.clone(),
+            progress_logging: self.progress_logging.clone(),
+        }
+    }
+}
+
+/// The kind of region to build, can either be a subgraph equivalent to [`Scope::region()`]
+/// or a no-op that has no affect on the dataflow graph
+pub enum RegionSubgraph<'a, G, T>
+where
+    G: ScopeParent,
+    T: Timestamp,
+{
+    /// A region that will be rendered as a nested dataflow scope
+    Subgraph {
+        /// The inner dataflow scope
+        subgraph: &'a RefCell<SubgraphBuilder<G::Timestamp, T>>,
+        /// The subgraph's operator index
+        index: usize,
+    },
+    /// A region that will be a no-op in the dataflow graph
+    Passthrough,
+}
+
+impl<'a, G, T> RegionSubgraph<'a, G, T>
+where
+    G: ScopeParent,
+    T: Timestamp,
+{
+    /// Create a new region subgraph
+    pub(crate) fn subgraph(
+        subgraph: &'a RefCell<SubgraphBuilder<G::Timestamp, T>>,
+        index: usize,
+    ) -> Self {
+        Self::Subgraph { subgraph, index }
+    }
+}
+
+impl<'a, G, T> Clone for RegionSubgraph<'a, G, T>
+where
+    G: ScopeParent,
+    T: Timestamp,
+{
+    fn clone(&self) -> Self {
+        match *self {
+            Self::Subgraph { subgraph, index } => Self::Subgraph { subgraph, index },
+            Self::Passthrough => Self::Passthrough,
+        }
+    }
+}
+
+impl<'a, G, T> Copy for RegionSubgraph<'a, G, T>
+where
+    G: ScopeParent,
+    T: Timestamp,
+{
+}

--- a/timely/src/dataflow/stream.rs
+++ b/timely/src/dataflow/stream.rs
@@ -25,7 +25,7 @@ pub struct Stream<S: Scope, D> {
     /// The `Scope` containing the stream.
     scope: S,
     /// Maintains a list of Push<Bundle<T, D>> interested in the stream's output.
-    ports: TeeHelper<S::Timestamp, D>,
+    pub(crate) ports: TeeHelper<S::Timestamp, D>,
 }
 
 impl<S: Scope, D> Stream<S, D> {

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -215,6 +215,11 @@ where
             progress_mode: worker.config().progress_mode,
         }
     }
+
+    /// Get the subgraph builder's index.
+    pub fn index(&self) -> usize {
+        self.index
+    }
 }
 
 


### PR DESCRIPTION
Allows the making and using of optional regions, regions that either act like `Scope::region()` or like nothing at all depending on the parameters given to it, allowing for applications to ~~have their cake and eat it too~~ use regions for dataflow debugging when necessary while still being able to disable them to avoid the overhead incurred by them

Closes #392, unblocks [differential-datalog/#990](https://github.com/vmware/differential-datalog/issues/990)