### PR TITLE
Exchange, input, tee: Only allocate buffers as needed

### DIFF
--- a/timely/src/dataflow/channels/mod.rs
+++ b/timely/src/dataflow/channels/mod.rs
@@ -53,5 +53,10 @@ impl<T, D> Message<T, D> {
                 buffer.clear();
             }
         }
+
+        // Avoid memory leaks by buffers growing out of bounds
+        if buffer.capacity() > Self::default_length() {
+            *buffer = Vec::with_capacity(Self::default_length());
+        }
     }
 }

--- a/timely/src/dataflow/channels/mod.rs
+++ b/timely/src/dataflow/channels/mod.rs
@@ -31,6 +31,11 @@ impl<T, D> Message<T, D> {
         1024
     }
 
+    /// Minimal buffer size, >= 1
+    pub fn minimal_length() -> usize {
+        8
+    }
+
     /// Creates a new message instance from arguments.
     pub fn new(time: T, data: Vec<D>, from: usize, seq: usize) -> Self {
         Message { time, data, from, seq }

--- a/timely/src/dataflow/channels/mod.rs
+++ b/timely/src/dataflow/channels/mod.rs
@@ -31,17 +31,13 @@ impl<T, D> Message<T, D> {
         1024
     }
 
-    /// Minimal buffer size, >= 1
-    pub fn minimal_length() -> usize {
-        8
-    }
-
     /// Creates a new message instance from arguments.
     pub fn new(time: T, data: Vec<D>, from: usize, seq: usize) -> Self {
         Message { time, data, from, seq }
     }
 
-    /// Forms a message, and pushes contents at `pusher`.
+    /// Forms a message, and pushes contents at `pusher`. Replaces `buffer` with what the pusher
+    /// leaves in place, or a new empty `Vec`.
     #[inline]
     pub fn push_at<P: Push<Bundle<T, D>>>(buffer: &mut Vec<D>, time: T, pusher: &mut P) {
 
@@ -57,9 +53,5 @@ impl<T, D> Message<T, D> {
                 buffer.clear();
             }
         }
-
-        // TODO: Unclear we always want this here.
-        if buffer.capacity() != Self::default_length() {
-            *buffer = Vec::with_capacity(Self::default_length());
-        }
-    }}
+    }
+}

--- a/timely/src/dataflow/channels/pushers/buffer.rs
+++ b/timely/src/dataflow/channels/pushers/buffer.rs
@@ -23,7 +23,7 @@ impl<T, D, P: Push<Bundle<T, D>>> Buffer<T, D, P> where T: Eq+Clone {
     pub fn new(pusher: P) -> Buffer<T, D, P> {
         Buffer {
             time: None,
-            buffer: Vec::with_capacity(Message::<T, D>::default_length()),
+            buffer: Vec::new(),
             pusher,
         }
     }
@@ -65,6 +65,9 @@ impl<T, D, P: Push<Bundle<T, D>>> Buffer<T, D, P> where T: Eq+Clone {
 
     // internal method for use by `Session`.
     fn give(&mut self, data: D) {
+        if self.buffer.capacity() < Message::<T, D>::default_length() {
+            self.buffer.reserve(Message::<T, D>::default_length());
+        }
         self.buffer.push(data);
         // assert!(self.buffer.capacity() == Message::<O::Data>::default_length());
         if self.buffer.len() == self.buffer.capacity() {

--- a/timely/src/dataflow/channels/pushers/buffer.rs
+++ b/timely/src/dataflow/channels/pushers/buffer.rs
@@ -30,13 +30,13 @@ impl<T, D, P: Push<Bundle<T, D>>> Buffer<T, D, P> where T: Eq+Clone {
 
     /// Returns a `Session`, which accepts data to send at the associated time
     pub fn session(&mut self, time: &T) -> Session<T, D, P> {
-        if let Some(true) = self.time.as_ref().map(|x| x != time) { self.flush(true); }
+        if let Some(true) = self.time.as_ref().map(|x| x != time) { self.flush(); }
         self.time = Some(time.clone());
         Session { buffer: self }
     }
     /// Allocates a new `AutoflushSession` which flushes itself on drop.
     pub fn autoflush_session(&mut self, cap: Capability<T>) -> AutoflushSession<T, D, P> where T: Timestamp {
-        if let Some(true) = self.time.as_ref().map(|x| x != cap.time()) { self.flush(true); }
+        if let Some(true) = self.time.as_ref().map(|x| x != cap.time()) { self.flush(); }
         self.time = Some(cap.time().clone());
         AutoflushSession {
             buffer: self,
@@ -51,19 +51,15 @@ impl<T, D, P: Push<Bundle<T, D>>> Buffer<T, D, P> where T: Eq+Clone {
 
     /// Flushes all data and pushes a `None` to `self.pusher`, indicating a flush.
     pub fn cease(&mut self) {
-        self.flush(false);
+        self.flush();
         self.pusher.push(&mut None);
     }
 
     /// moves the contents of
-    fn flush(&mut self, reserve: bool) {
+    fn flush(&mut self) {
         if !self.buffer.is_empty() {
             let time = self.time.as_ref().unwrap().clone();
             Message::push_at(&mut self.buffer, time, &mut self.pusher);
-            if reserve && self.buffer.capacity() < Message::<T, D>::default_length() {
-                let to_reserve =  Message::<T, D>::default_length() - self.buffer.capacity();
-                self.buffer.reserve(to_reserve);
-            }
         }
     }
 
@@ -75,7 +71,11 @@ impl<T, D, P: Push<Bundle<T, D>>> Buffer<T, D, P> where T: Eq+Clone {
             if self.buffer.capacity() < Message::<T, D>::default_length() {
                 self.buffer.reserve(Message::<T, D>::default_length());
             } else {
-                self.flush(true);
+                self.flush();
+                if self.buffer.capacity() < Message::<T, D>::default_length() {
+                    let to_reserve =  Message::<T, D>::default_length() - self.buffer.capacity();
+                    self.buffer.reserve(to_reserve);
+                }
             }
         }
     }
@@ -84,7 +84,7 @@ impl<T, D, P: Push<Bundle<T, D>>> Buffer<T, D, P> where T: Eq+Clone {
     fn give_vec(&mut self, vector: &mut Vec<D>) {
         // flush to ensure fifo-ness
         if !self.buffer.is_empty() {
-            self.flush(false);
+            self.flush();
         }
 
         let time = self.time.as_ref().expect("Buffer::give_vec(): time is None.").clone();

--- a/timely/src/dataflow/channels/pushers/exchange.rs
+++ b/timely/src/dataflow/channels/pushers/exchange.rs
@@ -9,7 +9,6 @@ use crate::dataflow::channels::{Bundle, Message};
 pub struct Exchange<T, D, P: Push<Bundle<T, D>>, H: FnMut(&T, &D) -> u64> {
     pushers: Vec<P>,
     buffers: Vec<Vec<D>>,
-    max_len: Vec<usize>,
     current: Option<T>,
     hash_func: H,
 }
@@ -17,33 +16,19 @@ pub struct Exchange<T, D, P: Push<Bundle<T, D>>, H: FnMut(&T, &D) -> u64> {
 impl<T: Clone, D, P: Push<Bundle<T, D>>, H: FnMut(&T, &D)->u64>  Exchange<T, D, P, H> {
     /// Allocates a new `Exchange` from a supplied set of pushers and a distribution function.
     pub fn new(pushers: Vec<P>, key: H) -> Exchange<T, D, P, H> {
-        let mut buffers = vec![];
-        for _ in 0..pushers.len() {
-            buffers.push(Vec::with_capacity(Message::<T, D>::minimal_length()));
-        }
+        let buffers = (0..pushers.len()).map(|_| vec![]).collect();
         Exchange {
             pushers,
             hash_func: key,
-            max_len: vec![0; buffers.len()],
             buffers,
             current: None,
         }
     }
     #[inline]
-    fn flush(&mut self, index: usize, maybe_shrink: bool) {
+    fn flush(&mut self, index: usize) {
         if !self.buffers[index].is_empty() {
-            let old_len = self.buffers[index].len();
             if let Some(ref time) = self.current {
                 Message::push_at(&mut self.buffers[index], time.clone(), &mut self.pushers[index]);
-            }
-            if maybe_shrink {
-                if self.buffers[index].capacity() > 2 * self.max_len[index] &&
-                    self.buffers[index].capacity() > Message::<T, D>::minimal_length() {
-                    self.buffers[index] = Vec::with_capacity(Message::<T, D>::minimal_length());
-                }
-                self.max_len[index] = 0;
-            } else {
-                self.max_len[index] = std::cmp::max(self.max_len[index], old_len);
             }
         }
     }
@@ -51,16 +36,6 @@ impl<T: Clone, D, P: Push<Bundle<T, D>>, H: FnMut(&T, &D)->u64>  Exchange<T, D, 
 
 impl<T: Eq+Data, D: Data, P: Push<Bundle<T, D>>, H: FnMut(&T, &D)->u64> Push<Bundle<T, D>> for Exchange<T, D, P, H> {
     fn push(&mut self, message: &mut Option<Bundle<T, D>>) {
-        let push_at = |this: &mut Exchange<_, _, _, _>, index: usize, datum| {
-            this.buffers[index].push(datum);
-            if this.buffers[index].len() == this.buffers[index].capacity() {
-                this.flush(index, false);
-                if this.buffers[index].len() < Message::<T, D>::default_length() {
-                    let len = this.buffers[index].len();
-                    this.buffers[index].reserve(len);
-                }
-            }
-        };
         // if only one pusher, no exchange
         if self.pushers.len() == 1 {
             self.pushers[0].push(message);
@@ -72,7 +47,7 @@ impl<T: Eq+Data, D: Data, P: Push<Bundle<T, D>>, H: FnMut(&T, &D)->u64> Push<Bun
             // if the time isn't right, flush everything.
             if self.current.as_ref().map_or(false, |x| x != time) {
                 for index in 0..self.pushers.len() {
-                    self.flush(index, false);
+                    self.flush(index);
                 }
             }
             self.current = Some(time.clone());
@@ -82,19 +57,31 @@ impl<T: Eq+Data, D: Data, P: Push<Bundle<T, D>>, H: FnMut(&T, &D)->u64> Push<Bun
                 let mask = (self.pushers.len() - 1) as u64;
                 for datum in data.drain(..) {
                     let index = (((self.hash_func)(time, &datum)) & mask) as usize;
-                    push_at(self, index, datum);
+                    if self.buffers[index].capacity() == 0 {
+                        self.buffers[index].reserve(Message::<T, D>::default_length());
+                    }
+                    self.buffers[index].push(datum);
+                    if self.buffers[index].len() == self.buffers[index].capacity() {
+                        self.flush(index);
+                    }
                 }
             } else {
                 // as a last resort, use mod (%)
                 for datum in data.drain(..) {
                     let index = (((self.hash_func)(time, &datum)) % self.pushers.len() as u64) as usize;
-                    push_at(self, index, datum);
+                    if self.buffers[index].capacity() == 0 {
+                        self.buffers[index].reserve(Message::<T, D>::default_length());
+                    }
+                    self.buffers[index].push(datum);
+                    if self.buffers[index].len() == self.buffers[index].capacity() {
+                        self.flush(index);
+                    }
                 }
             }
         } else {
             // flush
             for index in 0..self.pushers.len() {
-                self.flush(index, true);
+                self.flush(index);
                 self.pushers[index].push(&mut None);
             }
         }

--- a/timely/src/dataflow/channels/pushers/tee.rs
+++ b/timely/src/dataflow/channels/pushers/tee.rs
@@ -44,7 +44,7 @@ impl<T, D> Tee<T, D> {
     pub fn new() -> (Tee<T, D>, TeeHelper<T, D>) {
         let shared = Rc::new(RefCell::new(Vec::new()));
         let port = Tee {
-            buffer: Vec::with_capacity(Message::<T, D>::default_length()),
+            buffer: Vec::new(),
             shared: shared.clone(),
         };
 
@@ -55,7 +55,7 @@ impl<T, D> Tee<T, D> {
 impl<T, D> Clone for Tee<T, D> {
     fn clone(&self) -> Tee<T, D> {
         Tee {
-            buffer: Vec::with_capacity(self.buffer.capacity()),
+            buffer: Vec::new(),
             shared: self.shared.clone(),
         }
     }

--- a/timely/src/dataflow/operators/input.rs
+++ b/timely/src/dataflow/operators/input.rs
@@ -212,8 +212,8 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
             activate: Vec::new(),
             progress: Vec::new(),
             pushers: Vec::new(),
-            buffer1: Vec::with_capacity(Message::<T, D>::default_length()),
-            buffer2: Vec::with_capacity(Message::<T, D>::default_length()),
+            buffer1: Vec::new(),
+            buffer2: Vec::new(),
             now_at: T::minimum(),
         }
     }
@@ -304,7 +304,9 @@ impl<T:Timestamp, D: Data> Handle<T, D> {
     #[inline]
     /// Sends one record into the corresponding timely dataflow `Stream`, at the current epoch.
     pub fn send(&mut self, data: D) {
-        // assert!(self.buffer1.capacity() == Message::<T, D>::default_length());
+        if self.buffer1.capacity() < Message::<T, D>::default_length() {
+            self.buffer1.reserve(Message::<T, D>::default_length());
+        }
         self.buffer1.push(data);
         if self.buffer1.len() == self.buffer1.capacity() {
             self.flush();


### PR DESCRIPTION
Instead of pre-allocating relatively large buffers for each pusher,
only allocate small buffers and grow them as needed. This can lead
to more allocations, but by doubling the buffer size we hope to
amortize some of the cost.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>