### PR TITLE
Base message default length off element size

### DIFF
--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -123,7 +123,7 @@ impl<T, E: Clone> Logger<T, E> {
             time,
             offset,
             action: action,
-            buffer: Vec::with_capacity(1024),
+            buffer: Vec::new(),
         };
         let inner = Rc::new(RefCell::new(inner));
         Logger { inner }
@@ -168,6 +168,25 @@ impl<T, E: Clone> Logger<T, E> {
 }
 
 impl<T, E: Clone, A: ?Sized + FnMut(&Duration, &mut Vec<(Duration, E, T)>)> LoggerInner<T, E, A> {
+
+    /// The upper limit for buffers to allocate, size in bytes. [Self::buffer_capacity] converts
+    /// this to size in elements.
+    const BUFFER_SIZE_BYTES: usize = 1 << 13;
+
+    /// The maximum buffer capacity in elements. Returns a number between [Self::BUFFER_SIZE_BYTES]
+    /// and 1, inclusively.
+    // TODO: This fn is not const because it cannot depend on non-Sized generic parameters
+    fn buffer_capacity() -> usize {
+        let size =  ::std::mem::size_of::<(Duration, E, T)>();
+        if size == 0 {
+            Self::BUFFER_SIZE_BYTES
+        } else if size <= Self::BUFFER_SIZE_BYTES {
+            Self::BUFFER_SIZE_BYTES / size
+        } else {
+            1
+        }
+    }
+
     pub fn log_many<I>(&mut self, events: I)
         where I: IntoIterator, I::Item: Into<T>
     {
@@ -181,7 +200,7 @@ impl<T, E: Clone, A: ?Sized + FnMut(&Duration, &mut Vec<(Duration, E, T)>)> Logg
                 // to do in-place updates without forcing them to take ownership.
                 self.buffer.clear();
                 let buffer_capacity = self.buffer.capacity();
-                if buffer_capacity < 1024 {
+                if buffer_capacity < Self::buffer_capacity() {
                     self.buffer.reserve((buffer_capacity+1).next_power_of_two());
                 }
             }

--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -122,8 +122,8 @@ impl<T, E: Clone> Logger<T, E> {
             id,
             time,
             offset,
-            action: action,
-            buffer: Vec::new(),
+            action,
+            buffer: Vec::with_capacity(LoggerInner::<T, E, F>::buffer_capacity()),
         };
         let inner = Rc::new(RefCell::new(inner));
         Logger { inner }

--- a/timely/src/dataflow/channels/mod.rs
+++ b/timely/src/dataflow/channels/mod.rs
@@ -28,7 +28,14 @@ pub struct Message<T, D> {
 impl<T, D> Message<T, D> {
     /// Default buffer size.
     pub fn default_length() -> usize {
-        1024
+        const MESSAGE_BUFFER_SIZE: usize = 1 << 13;
+        match std::mem::size_of::<D>() {
+            // We could use usize::MAX here, but to avoid overflows we limit the default length
+            // for zero-byte types.
+            0 => MESSAGE_BUFFER_SIZE,
+            size @ 1..=MESSAGE_BUFFER_SIZE => MESSAGE_BUFFER_SIZE / size,
+            _ => 1,
+        }
     }
 
     /// Creates a new message instance from arguments.

--- a/timely/src/dataflow/channels/mod.rs
+++ b/timely/src/dataflow/channels/mod.rs
@@ -29,12 +29,15 @@ impl<T, D> Message<T, D> {
     /// Default buffer size.
     pub fn default_length() -> usize {
         const MESSAGE_BUFFER_SIZE: usize = 1 << 13;
-        match std::mem::size_of::<D>() {
-            // We could use usize::MAX here, but to avoid overflows we limit the default length
-            // for zero-byte types.
-            0 => MESSAGE_BUFFER_SIZE,
-            size @ 1..=MESSAGE_BUFFER_SIZE => MESSAGE_BUFFER_SIZE / size,
-            _ => 1,
+        let size = std::mem::size_of::<D>();
+        if size == 0 {
+            // We could use usize::MAX here, but to avoid overflows we
+            // limit the default length for zero-byte types.
+            MESSAGE_BUFFER_SIZE
+        } else if size <= MESSAGE_BUFFER_SIZE {
+            MESSAGE_BUFFER_SIZE / size
+        } else {
+            1
         }
     }
 


### PR DESCRIPTION
Instead of defaulting to 1024 elements, use the size in memory of the data
type to determine the default length. With this change, the number of
elements is based off a buffer of 8KiB to match the current behavior for
1024 8-byte elements.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>