### PR TITLE
replay: work with rust streams instead of event iterators

### DIFF
--- a/kafkaesque/Cargo.toml
+++ b/kafkaesque/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 clap="*"
 abomonation="0.7"
 timely = { path = "../timely" }
+futures = "0.3"
 
 [dependencies.rdkafka]
 version = "0.23.0"

--- a/kafkaesque/src/bin/capture_recv.rs
+++ b/kafkaesque/src/bin/capture_recv.rs
@@ -1,6 +1,7 @@
 use timely::dataflow::operators::Inspect;
 use timely::dataflow::operators::capture::Replay;
 use timely::dataflow::operators::Accumulate;
+use timely::dataflow::operators::capture::event::EventIterator;
 
 use rdkafka::config::ClientConfig;
 
@@ -33,6 +34,7 @@ fn main() {
                 let topic = format!("{}-{:?}", topic, i);
                 EventConsumer::<_,u64>::new(consumer_config.clone(), topic)
             })
+            .map(|e| futures::stream::iter(e.cloned()))
             .collect::<Vec<_>>();
 
         worker.dataflow::<u64,_,_>(|scope| {

--- a/timely/examples/capture_recv.rs
+++ b/timely/examples/capture_recv.rs
@@ -3,6 +3,7 @@ extern crate timely;
 use std::net::TcpListener;
 use timely::dataflow::operators::Inspect;
 use timely::dataflow::operators::capture::{EventReader, Replay};
+use timely::dataflow::operators::capture::event::EventIterator;
 
 fn main() {
     timely::execute_from_args(std::env::args(), |worker| {
@@ -18,6 +19,7 @@ fn main() {
             .into_iter()
             .map(|l| l.incoming().next().unwrap().unwrap())
             .map(|r| EventReader::<_,u64,_>::new(r))
+            .map(|e| futures_util::stream::iter(e.cloned()))
             .collect::<Vec<_>>();
 
         worker.dataflow::<u64,_,_>(|scope| {

--- a/timely/examples/logging-recv.rs
+++ b/timely/examples/logging-recv.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use timely::dataflow::operators::Inspect;
 use timely::dataflow::operators::capture::{EventReader, Replay};
+use timely::dataflow::operators::capture::event::EventIterator;
 use timely::logging::{TimelySetup, TimelyEvent};
 
 fn main() {
@@ -21,6 +22,7 @@ fn main() {
             .into_iter()
             .map(|l| l.incoming().next().unwrap().unwrap())
             .map(|r| EventReader::<Duration,(Duration,TimelySetup,TimelyEvent),_>::new(r))
+            .map(|e| futures_util::stream::iter(e.cloned()))
             .collect::<Vec<_>>();
 
         worker.dataflow(|scope| {

--- a/timely/src/dataflow/operators/capture/capture.rs
+++ b/timely/src/dataflow/operators/capture/capture.rs
@@ -28,9 +28,11 @@ pub trait Capture<T: Timestamp, D: Data> {
     /// ```rust
     /// use std::rc::Rc;
     /// use std::sync::{Arc, Mutex};
+    /// use futures_util::stream;
     /// use timely::dataflow::Scope;
     /// use timely::dataflow::operators::{Capture, ToStream, Inspect};
     /// use timely::dataflow::operators::capture::{EventLink, Replay, Extract};
+    /// use timely::dataflow::operators::capture::event::EventIterator;
     ///
     /// // get send and recv endpoints, wrap send to share
     /// let (send, recv) = ::std::sync::mpsc::channel();
@@ -43,7 +45,7 @@ pub trait Capture<T: Timestamp, D: Data> {
     ///
     ///     // these are to capture/replay the stream.
     ///     let handle1 = Rc::new(EventLink::new());
-    ///     let handle2 = Some(handle1.clone());
+    ///     let handle2 = Some(stream::iter(handle1.clone().cloned()));
     ///
     ///     worker.dataflow::<u64,_,_>(|scope1|
     ///         (0..10).to_stream(scope1)
@@ -68,9 +70,11 @@ pub trait Capture<T: Timestamp, D: Data> {
     /// use std::rc::Rc;
     /// use std::net::{TcpListener, TcpStream};
     /// use std::sync::{Arc, Mutex};
+    /// use futures_util::stream;
     /// use timely::dataflow::Scope;
     /// use timely::dataflow::operators::{Capture, ToStream, Inspect};
     /// use timely::dataflow::operators::capture::{EventReader, EventWriter, Replay, Extract};
+    /// use timely::dataflow::operators::capture::event::EventIterator;
     ///
     /// // get send and recv endpoints, wrap send to share
     /// let (send0, recv0) = ::std::sync::mpsc::channel();
@@ -95,7 +99,7 @@ pub trait Capture<T: Timestamp, D: Data> {
     ///     );
     ///
     ///     worker.dataflow::<u64,_,_>(|scope2| {
-    ///         Some(EventReader::<_,u64,_>::new(recv))
+    ///         Some(stream::iter(EventReader::<_,u64,_>::new(recv).cloned()))
     ///             .replay_into(scope2)
     ///             .capture_into(send0)
     ///     });

--- a/timely/src/dataflow/operators/capture/event.rs
+++ b/timely/src/dataflow/operators/capture/event.rs
@@ -22,6 +22,28 @@ pub enum Event<T, D> {
 pub trait EventIterator<T, D> {
     /// Iterates over references to `Event<T, D>` elements.
     fn next(&mut self) -> Option<&Event<T, D>>;
+
+    /// Transforms an EventIterator into an Iterator by cloning all of its elements.
+    fn cloned(self) -> Cloned<T, D, Self> where Self: Sized {
+        Cloned {
+            iter: self,
+            marker: std::marker::PhantomData,
+        }
+    }
+}
+
+/// An iterator that clones the elements of an underlying event iterator.
+pub struct Cloned<T, D, I: EventIterator<T, D>> {
+    iter: I,
+    marker: std::marker::PhantomData<(T, D)>,
+}
+
+impl<T: Clone, D: Clone, I: EventIterator<T, D>> Iterator for Cloned<T, D, I> {
+    type Item = Event<T, D>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().cloned()
+    }
 }
 
 

--- a/timely/src/dataflow/operators/capture/extract.rs
+++ b/timely/src/dataflow/operators/capture/extract.rs
@@ -14,9 +14,11 @@ pub trait Extract<T: Ord, D: Ord> {
     /// ```rust
     /// use std::rc::Rc;
     /// use std::sync::{Arc, Mutex};
+    /// use futures_util::stream;
     /// use timely::dataflow::Scope;
     /// use timely::dataflow::operators::{Capture, ToStream, Inspect};
     /// use timely::dataflow::operators::capture::{EventLink, Replay, Extract};
+    /// use timely::dataflow::operators::capture::event::EventIterator;
     ///
     /// // get send and recv endpoints, wrap send to share
     /// let (send, recv) = ::std::sync::mpsc::channel();
@@ -29,7 +31,7 @@ pub trait Extract<T: Ord, D: Ord> {
     ///
     ///     // these are to capture/replay the stream.
     ///     let handle1 = Rc::new(EventLink::new());
-    ///     let handle2 = Some(handle1.clone());
+    ///     let handle2 = Some(stream::iter(handle1.clone().cloned()));
     ///
     ///     worker.dataflow::<u64,_,_>(|scope1|
     ///         (0..10).to_stream(scope1)

--- a/timely/src/dataflow/operators/capture/mod.rs
+++ b/timely/src/dataflow/operators/capture/mod.rs
@@ -20,13 +20,15 @@
 //!
 //! ```rust
 //! use std::rc::Rc;
+//! use futures_util::stream;
 //! use timely::dataflow::Scope;
 //! use timely::dataflow::operators::{Capture, ToStream, Inspect};
 //! use timely::dataflow::operators::capture::{EventLink, Replay};
+//! use timely::dataflow::operators::capture::event::EventIterator;
 //!
 //! timely::execute(timely::Config::thread(), |worker| {
 //!     let handle1 = Rc::new(EventLink::new());
-//!     let handle2 = Some(handle1.clone());
+//!     let handle2 = Some(stream::iter(handle1.clone().cloned()));
 //!
 //!     worker.dataflow::<u64,_,_>(|scope1|
 //!         (0..10).to_stream(scope1)
@@ -48,9 +50,11 @@
 //! ```
 //! use std::rc::Rc;
 //! use std::net::{TcpListener, TcpStream};
+//! use futures_util::stream;
 //! use timely::dataflow::Scope;
 //! use timely::dataflow::operators::{Capture, ToStream, Inspect};
 //! use timely::dataflow::operators::capture::{EventReader, EventWriter, Replay};
+//! use timely::dataflow::operators::capture::event::EventIterator;
 //!
 //! timely::execute(timely::Config::thread(), |worker| {
 //!     let list = TcpListener::bind("127.0.0.1:8000").unwrap();
@@ -66,7 +70,7 @@
 //!     );
 //!
 //!     worker.dataflow::<u64,_,_>(|scope2| {
-//!         Some(EventReader::<_,u64,_>::new(recv))
+//!         Some(stream::iter(EventReader::<_,u64,_>::new(recv).cloned()))
 //!             .replay_into(scope2)
 //!             .inspect(|x| println!("replayed: {:?}", x));
 //!     })


### PR DESCRIPTION
This patch makes the Replay operator accept a list of streams rather than a list of event iterators. The streams are consumed with a sync activator wrapper in a Waker in order to re-schedule the operator automatically when new data becomes available.
