### PR TITLE
logging: Store logger in Rc

### DIFF
--- a/timely/examples/logging-send.rs
+++ b/timely/examples/logging-send.rs
@@ -79,7 +79,7 @@ fn main() {
                 input.send(i);
             }
             input.advance_to(round);
-            input_logger.log(());
+            input_logger.borrow().log(());
 
             while probe.less_than(input.time()) {
                 worker.step();

--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -33,7 +33,7 @@ pub struct OperatorBuilder<G: Scope> {
     consumed: Vec<Rc<RefCell<ChangeBatch<G::Timestamp>>>>,
     internal: Rc<RefCell<Vec<Rc<RefCell<ChangeBatch<G::Timestamp>>>>>>,
     produced: Vec<Rc<RefCell<ChangeBatch<G::Timestamp>>>>,
-    logging: Option<Logger>,
+    logging: Option<Rc<RefCell<Logger>>>,
 }
 
 impl<G: Scope> OperatorBuilder<G> {

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -24,7 +24,7 @@ use crate::dataflow::operators::capability::CapabilityTrait;
 pub struct InputHandle<T: Timestamp, D, P: Pull<Bundle<T, D>>> {
     pull_counter: PullCounter<T, D, P>,
     internal: Rc<RefCell<Vec<Rc<RefCell<ChangeBatch<T>>>>>>,
-    logging: Option<Logger>,
+    logging: Option<Rc<RefCell<Logger>>>,
 }
 
 /// Handle to an operator's input stream and frontier.
@@ -87,9 +87,9 @@ impl<'a, T: Timestamp, D: Data, P: Pull<Bundle<T, D>>> InputHandle<T, D, P> {
                 },
             }
         }) {
-            self.logging.as_mut().map(|l| l.log(crate::logging::GuardedMessageEvent { is_start: true }));
+            self.logging.as_mut().map(|l| l.borrow().log(crate::logging::GuardedMessageEvent { is_start: true }));
             logic(cap, data);
-            self.logging.as_mut().map(|l| l.log(crate::logging::GuardedMessageEvent { is_start: false }));
+            self.logging.as_mut().map(|l| l.borrow().log(crate::logging::GuardedMessageEvent { is_start: false }));
         }
     }
 
@@ -148,7 +148,7 @@ pub fn _access_pull_counter<T: Timestamp, D, P: Pull<Bundle<T, D>>>(input: &mut 
 
 /// Constructs an input handle.
 /// Declared separately so that it can be kept private when `InputHandle` is re-exported.
-pub fn new_input_handle<T: Timestamp, D, P: Pull<Bundle<T, D>>>(pull_counter: PullCounter<T, D, P>, internal: Rc<RefCell<Vec<Rc<RefCell<ChangeBatch<T>>>>>>, logging: Option<Logger>) -> InputHandle<T, D, P> {
+pub fn new_input_handle<T: Timestamp, D, P: Pull<Bundle<T, D>>>(pull_counter: PullCounter<T, D, P>, internal: Rc<RefCell<Vec<Rc<RefCell<ChangeBatch<T>>>>>>, logging: Option<Rc<RefCell<Logger>>>) -> InputHandle<T, D, P> {
     InputHandle {
         pull_counter,
         internal,

--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -32,9 +32,9 @@ where
     /// A copy of the child's parent scope.
     pub parent:   G,
     /// The log writer for this scope.
-    pub logging:  Option<Logger>,
+    pub logging:  Option<Rc<RefCell<Logger>>>,
     /// The progress log writer for this scope.
-    pub progress_logging:  Option<ProgressLogger>,
+    pub progress_logging:  Option<Rc<RefCell<ProgressLogger>>>,
 }
 
 impl<'a, G, T> Child<'a, G, T>

--- a/timely/src/dataflow/stream.rs
+++ b/timely/src/dataflow/stream.rs
@@ -36,7 +36,7 @@ impl<S: Scope, D> Stream<S, D> {
     pub fn connect_to<P: Push<Bundle<S::Timestamp, D>>+'static>(&self, target: Target, pusher: P, identifier: usize) {
 
         let mut logging = self.scope().logging();
-        logging.as_mut().map(|l| l.log(crate::logging::ChannelsEvent {
+        logging.as_mut().map(|l| l.borrow().log(crate::logging::ChannelsEvent {
             id: identifier,
             scope_addr: self.scope.addr(),
             source: (self.name.node, self.name.port),

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -1,5 +1,9 @@
 //! Traits, implementations, and macros related to logging timely events.
 
+use std::time::Duration;
+
+use crate::dataflow::operators::capture::{Event, EventPusher};
+
 /// Type alias for logging timely events.
 pub type WorkerIdentifier = usize;
 /// Logger type for worker-local logging.
@@ -8,9 +12,6 @@ pub type Logger<Event> = crate::logging_core::Logger<Event, WorkerIdentifier>;
 pub type TimelyLogger = Logger<TimelyEvent>;
 /// Logger for timely dataflow progress events (the "timely/progress" log stream).
 pub type TimelyProgressLogger = Logger<TimelyProgressEvent>;
-
-use std::time::Duration;
-use crate::dataflow::operators::capture::{Event, EventPusher};
 
 /// Logs events as a timely stream, with progress statements.
 pub struct BatchLogger<T, E, P> where P: EventPusher<Duration, (Duration, E, T)> {

--- a/timely/src/progress/reachability.rs
+++ b/timely/src/progress/reachability.rs
@@ -832,23 +832,26 @@ fn summarize_outputs<T: Timestamp>(
 /// Logging types for reachability tracking events.
 pub mod logging {
 
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
     use crate::logging::{Logger, ProgressEventTimestampVec};
 
     /// A logger with additional identifying information about the tracker.
     pub struct TrackerLogger {
         path: Vec<usize>,
-        logger: Logger<TrackerEvent>,
+        logger: Rc<RefCell<Logger<TrackerEvent>>>,
     }
 
     impl TrackerLogger {
         /// Create a new tracker logger from its fields.
-        pub fn new(path: Vec<usize>, logger: Logger<TrackerEvent>) -> Self {
+        pub fn new(path: Vec<usize>, logger: Rc<RefCell<Logger<TrackerEvent>>>) -> Self {
             Self { path, logger }
         }
 
         /// Log source update events with additional identifying information.
         pub fn log_source_updates(&mut self, updates: Box<dyn ProgressEventTimestampVec>) {
-            self.logger.log({
+            self.logger.borrow().log({
                 SourceUpdate {
                     tracker_id: self.path.clone(),
                     updates,
@@ -857,7 +860,7 @@ pub mod logging {
         }
         /// Log target update events with additional identifying information.
         pub fn log_target_updates(&mut self, updates: Box<dyn ProgressEventTimestampVec>) {
-            self.logger.log({
+            self.logger.borrow().log({
                 TargetUpdate {
                     tracker_id: self.path.clone(),
                     updates,


### PR DESCRIPTION
The idea of this PR is to reduce the size of various structs that contain `Logger`s. For example, the size of `LogPusher` drops from 120 bytes to 64 bytes, which can lead to a noticeable reduction in memory with large dataflows and many workers.

On the other hand, this change introduces API-incompatibilities due to the change of the logging type from `Logger` to `Rc<RefCell<Logger>>`.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>