### PR TITLE
Disable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ members = [
 opt-level = 3
 debug = true
 rpath = false
-lto = true
+# Disable LTO because it causes erratic behavior in Rust 1.53
+#lto = true
 debug-assertions = false


### PR DESCRIPTION
Disable LTO for timely-dataflow because it causes erratic runtime performance, at least in Rust 1.53.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>