### PR TITLE
Avoid always flushing logs in worker

### DIFF
--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -406,7 +406,6 @@ impl<A: Allocate> Worker<A> {
         }
 
         // Clean up, indicate if dataflows remain.
-        self.logging.borrow_mut().flush();
         self.allocator.borrow_mut().release();
         !self.dataflows.borrow().is_empty()
     }


### PR DESCRIPTION
Currently, we flush on Park and after the `step_or_park` finishes. With
this change, we only explicitly flush on Park.

Note that this might delay some log messages for long park intervals.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>