### PR TITLE
Silence dead code/unused unsafe warnings with bincode

### DIFF
--- a/communication/src/allocator/zero_copy/push_pull.rs
+++ b/communication/src/allocator/zero_copy/push_pull.rs
@@ -85,6 +85,7 @@ impl<T:Data> Puller<T> {
 
 impl<T:Data> Pull<Message<T>> for Puller<T> {
     #[inline]
+    #[cfg_attr(feature = "bincode", allow(unused_unsafe))]
     fn pull(&mut self) -> &mut Option<Message<T>> {
         self.current =
         self.receiver
@@ -123,6 +124,7 @@ impl<T:Data> PullerInner<T> {
 
 impl<T:Data> Pull<Message<T>> for PullerInner<T> {
     #[inline]
+    #[cfg_attr(feature = "bincode", allow(unused_unsafe))]
     fn pull(&mut self) -> &mut Option<Message<T>> {
 
         let inner = self.inner.pull();

--- a/communication/src/message.rs
+++ b/communication/src/message.rs
@@ -50,6 +50,7 @@ pub struct Message<T> {
 /// Possible returned representations from a channel.
 enum MessageContents<T> {
     /// Binary representation. Only available as a reference.
+    #[cfg_attr(feature = "bincode", allow(dead_code))]
     Binary(abomonation::abomonated::Abomonated<T, Bytes>),
     /// Rust typed instance. Available for ownership.
     Owned(T),


### PR DESCRIPTION
The bincode feature swaps some code with variants that don't require unsafe
or don't construct all enum variants. Ignore this specific warning when
the bincode feature is enabled.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>