### PR TITLE
Exchange sort

### DIFF
--- a/timely/src/dataflow/channels/pushers/exchange.rs
+++ b/timely/src/dataflow/channels/pushers/exchange.rs
@@ -1,5 +1,6 @@
 //! The exchange pattern distributes pushed data between many target pushees.
 
+use std::mem::MaybeUninit;
 use crate::Data;
 use crate::communication::Push;
 use crate::dataflow::channels::{Bundle, Message};
@@ -11,6 +12,7 @@ pub struct Exchange<T, D, P: Push<Bundle<T, D>>, H: FnMut(&T, &D) -> u64> {
     buffers: Vec<Vec<D>>,
     current: Option<T>,
     hash_func: H,
+    sort_buffer: Vec<(usize, usize)>,
 }
 
 impl<T: Clone, D, P: Push<Bundle<T, D>>, H: FnMut(&T, &D)->u64>  Exchange<T, D, P, H> {
@@ -25,6 +27,7 @@ impl<T: Clone, D, P: Push<Bundle<T, D>>, H: FnMut(&T, &D)->u64>  Exchange<T, D, 
             hash_func: key,
             buffers,
             current: None,
+            sort_buffer: Vec::new(),
         }
     }
     #[inline]
@@ -39,8 +42,31 @@ impl<T: Clone, D, P: Push<Bundle<T, D>>, H: FnMut(&T, &D)->u64>  Exchange<T, D, 
     /// Partition data according to an index function
     #[inline(always)]
     fn partition<F: Fn(u64) -> usize>(&mut self, time: &T, data: &mut Vec<D>, func: F) {
-        for datum in data.drain(..) {
-            let index = (func)((self.hash_func)(time, &datum));
+        // move sort_buffer to avoid borrowing `mut self` twice
+        let mut sort_buffer = ::std::mem::take(&mut self.sort_buffer);
+        // Ensure that the sort buffer has as many entries as the incoming data
+        if sort_buffer.capacity() < data.len() {
+            let to_reserve = data.len() - sort_buffer.capacity();
+            sort_buffer.reserve(to_reserve);
+        }
+
+        // Calculate the (target, data_index) per datum
+        for (datum_index, datum) in data.iter().enumerate() {
+            let index = (func)((self.hash_func)(time, datum));
+            sort_buffer.push((index, datum_index));
+        }
+
+        // Sort the sort buffer by index
+        sort_buffer.sort();
+
+        // Convert the provided data such that we can move out of it and leave gaps behind
+        // This is safe because every element will be accessed exactly once.
+        let local_data = ::std::mem::take(data);
+        let mut local_data: Vec<MaybeUninit<D>> = unsafe { ::std::mem::transmute(local_data) };
+
+        for (index, offset) in sort_buffer.drain(..) {
+            // Read the element from the data vector
+            let datum = unsafe { ::std::ptr::read(local_data[offset].as_ptr()) };
 
             // Ensure allocated buffers: If the buffer's capacity is less than its default
             // capacity, increase the capacity such that it matches the default.
@@ -53,6 +79,12 @@ impl<T: Clone, D, P: Push<Bundle<T, D>>, H: FnMut(&T, &D)->u64>  Exchange<T, D, 
                 self.flush(index);
             }
         }
+
+        // Clear the local data, which is safe because it will not execute drop.
+        local_data.clear();
+        // Restore the data allocation by transmuting the cleared data back to its original allocation
+        *data = unsafe { std::mem::transmute(local_data) };
+        self.sort_buffer = sort_buffer;
     }
 }
 

--- a/timely/src/dataflow/channels/pushers/exchange.rs
+++ b/timely/src/dataflow/channels/pushers/exchange.rs
@@ -35,6 +35,25 @@ impl<T: Clone, D, P: Push<Bundle<T, D>>, H: FnMut(&T, &D)->u64>  Exchange<T, D, 
             }
         }
     }
+
+    /// Partition data according to an index function
+    #[inline(always)]
+    fn partition<F: Fn(u64) -> usize>(&mut self, time: &T, data: &mut Vec<D>, func: F) {
+        for datum in data.drain(..) {
+            let index = (func)((self.hash_func)(time, &datum));
+
+            // Ensure allocated buffers: If the buffer's capacity is less than its default
+            // capacity, increase the capacity such that it matches the default.
+            if self.buffers[index].capacity() < Message::<T, D>::default_length() {
+                let to_reserve = Message::<T, D>::default_length() - self.buffers[index].capacity();
+                self.buffers[index].reserve(to_reserve);
+            }
+            self.buffers[index].push(datum);
+            if self.buffers[index].len() == self.buffers[index].capacity() {
+                self.flush(index);
+            }
+        }
+    }
 }
 
 impl<T: Eq+Data, D: Data, P: Push<Bundle<T, D>>, H: FnMut(&T, &D)->u64> Push<Bundle<T, D>> for Exchange<T, D, P, H> {
@@ -61,44 +80,12 @@ impl<T: Eq+Data, D: Data, P: Push<Bundle<T, D>>, H: FnMut(&T, &D)->u64> Push<Bun
             // if the number of pushers is a power of two, use a mask
             if (self.pushers.len() & (self.pushers.len() - 1)) == 0 {
                 let mask = (self.pushers.len() - 1) as u64;
-                for datum in data.drain(..) {
-                    let index = (((self.hash_func)(time, &datum)) & mask) as usize;
-
-                    // Ensure allocated buffers: If the buffer's capacity is less than its default
-                    // capacity, increase the capacity such that it matches the default.
-                    if self.buffers[index].capacity() < Message::<T, D>::default_length() {
-                        let to_reserve = Message::<T, D>::default_length() - self.buffers[index].capacity();
-                        self.buffers[index].reserve(to_reserve);
-                    }
-                    self.buffers[index].push(datum);
-                    if self.buffers[index].len() == self.buffers[index].capacity() {
-                        self.flush(index);
-                    }
-
-                    // unsafe {
-                    //     self.buffers.get_unchecked_mut(index).push(datum);
-                    //     if self.buffers.get_unchecked(index).len() == self.buffers.get_unchecked(index).capacity() {
-                    //         self.flush(index);
-                    //     }
-                    // }
-
-                }
+                self.partition(time, data, move |hash| (hash & mask) as usize);
             }
             // as a last resort, use mod (%)
             else {
-                for datum in data.drain(..) {
-                    let index = (((self.hash_func)(time, &datum)) % self.pushers.len() as u64) as usize;
-                    // Ensure allocated buffers: If the buffer's capacity is less than its default
-                    // capacity, increase the capacity such that it matches the default.
-                    if self.buffers[index].capacity() < Message::<T, D>::default_length() {
-                        let to_reserve = Message::<T, D>::default_length() - self.buffers[index].capacity();
-                        self.buffers[index].reserve(to_reserve);
-                    }
-                    self.buffers[index].push(datum);
-                    if self.buffers[index].len() == self.buffers[index].capacity() {
-                        self.flush(index);
-                    }
-                }
+                let pushers = self.pushers.len() as u64;
+                self.partition(time, data, move |hash| (hash % pushers) as usize);
             }
 
         }


### PR DESCRIPTION
This is a draft to show how Timely could capture the exchange pattern, sort it, and reduce the cache misses for pushers.

Currently, this results in a significant performance regression for a low number of peers, but I'll try to test it on a machine with more workers.