### PR TITLE
Avoid preallocating buffers in buffer, tee

### DIFF
--- a/timely/src/dataflow/channels/mod.rs
+++ b/timely/src/dataflow/channels/mod.rs
@@ -47,25 +47,12 @@ impl<T, D> Message<T, D> {
     }
 
     /// Forms a message, and pushes contents at `pusher`. Replaces `buffer` with what the pusher
-    /// leaves in place, or a new `Vec`. Note that the returned vector is always initialized with
-    /// a capacity of [Self::default_length] elements.
+    /// leaves in place, or a new `Vec`. If the returned vector has a different capacity than the
+    /// default, it will be replaced with an empty vector.
+    ///
+    /// Clients are responsible to ensure that their buffers are allocated before reusing them.
     #[inline]
     pub fn push_at<P: Push<Bundle<T, D>>>(buffer: &mut Vec<D>, time: T, pusher: &mut P) {
-
-        Self::push_at_no_allocation(buffer, time, pusher);
-
-        // Allocate a default buffer to avoid oddly sized or empty buffers
-        if buffer.capacity() != Self::default_length() {
-            *buffer = Vec::with_capacity(Self::default_length());
-        }
-    }
-
-    /// Forms a message, and pushes contents at `pusher`. Replaces `buffer` with what the pusher
-    /// leaves in place, or a new empty `Vec`. If the pusher leaves a vector with a capacity larger
-    /// than [Self::default_length], the vector is initialized with a new vector with
-    /// [Self::default_length] capacity.
-    #[inline]
-    pub fn push_at_no_allocation<P: Push<Bundle<T, D>>>(buffer: &mut Vec<D>, time: T, pusher: &mut P) {
 
         let data = ::std::mem::take(buffer);
         let message = Message::new(time, data, 0, 0);
@@ -80,9 +67,9 @@ impl<T, D> Message<T, D> {
             }
         }
 
-        // Avoid memory leaks by buffers growing out of bounds
-        if buffer.capacity() > Self::default_length() {
-            *buffer = Vec::with_capacity(Self::default_length());
+        // Avoid oddly-sized buffers
+        if std::mem::size_of::<D>() > 0 && buffer.capacity() != Self::default_length() {
+            *buffer = Default::default();
         }
     }
 }

--- a/timely/src/dataflow/channels/pushers/buffer.rs
+++ b/timely/src/dataflow/channels/pushers/buffer.rs
@@ -23,7 +23,7 @@ impl<T, D, P: Push<Bundle<T, D>>> Buffer<T, D, P> where T: Eq+Clone {
     pub fn new(pusher: P) -> Buffer<T, D, P> {
         Buffer {
             time: None,
-            buffer: Vec::with_capacity(Message::<T, D>::default_length()),
+            buffer: Default::default(),
             pusher,
         }
     }
@@ -65,8 +65,12 @@ impl<T, D, P: Push<Bundle<T, D>>> Buffer<T, D, P> where T: Eq+Clone {
 
     // internal method for use by `Session`.
     fn give(&mut self, data: D) {
+        // Ensure default capacity
+        if self.buffer.capacity() < Message::<T, D>::default_length() {
+            let to_reserve = Message::<T, D>::default_length() - self.buffer.capacity();
+            self.buffer.reserve(to_reserve);
+        }
         self.buffer.push(data);
-        // assert!(self.buffer.capacity() == Message::<O::Data>::default_length());
         if self.buffer.len() == self.buffer.capacity() {
             self.flush();
         }

--- a/timely/src/dataflow/channels/pushers/exchange.rs
+++ b/timely/src/dataflow/channels/pushers/exchange.rs
@@ -31,7 +31,7 @@ impl<T: Clone, D, P: Push<Bundle<T, D>>, H: FnMut(&T, &D)->u64>  Exchange<T, D, 
     fn flush(&mut self, index: usize) {
         if !self.buffers[index].is_empty() {
             if let Some(ref time) = self.current {
-                Message::push_at_no_allocation(&mut self.buffers[index], time.clone(), &mut self.pushers[index]);
+                Message::push_at(&mut self.buffers[index], time.clone(), &mut self.pushers[index]);
             }
         }
     }

--- a/timely/src/dataflow/channels/pushers/tee.rs
+++ b/timely/src/dataflow/channels/pushers/tee.rs
@@ -23,6 +23,10 @@ impl<T: Data, D: Data> Push<Bundle<T, D>> for Tee<T, D> {
         let mut pushers = self.shared.borrow_mut();
         if let Some(message) = message {
             for index in 1..pushers.len() {
+                // Ensure default capacity
+                if self.buffer.capacity() != Message::<T, D>::default_length() {
+                    self.buffer = Vec::with_capacity(Message::<T, D>::default_length());
+                }
                 self.buffer.extend_from_slice(&message.data);
                 Message::push_at(&mut self.buffer, message.time.clone(), &mut pushers[index-1]);
             }
@@ -44,7 +48,7 @@ impl<T, D> Tee<T, D> {
     pub fn new() -> (Tee<T, D>, TeeHelper<T, D>) {
         let shared = Rc::new(RefCell::new(Vec::new()));
         let port = Tee {
-            buffer: Vec::with_capacity(Message::<T, D>::default_length()),
+            buffer: Default::default(),
             shared: shared.clone(),
         };
 
@@ -55,7 +59,7 @@ impl<T, D> Tee<T, D> {
 impl<T, D> Clone for Tee<T, D> {
     fn clone(&self) -> Tee<T, D> {
         Tee {
-            buffer: Vec::with_capacity(self.buffer.capacity()),
+            buffer: Default::default(),
             shared: self.shared.clone(),
         }
     }


### PR DESCRIPTION
Instead of allocating buffers at construction time, allocate buffers
before pushing or cloning. This adds additional instructions on the fast
path for input/buffer/exchange/tee, but seems to be justified by the
memory savings.

We expect a linear amount of memory savings per operator in the number of workers. For non-serializing allocators, this memory saving will persist during the lifetime of the instance, for returning (serializing) allocators, the memory savings will remain until the first data is sent.

The exchange benchmark does not report a change in performance.

The main question that we'd need to answer is whether we're comfortable with `Message::push_at` not ensuring that the returned object is allocated. With current Timely, this moves the burden of ensuring allocations to clients of `push_at`, which is not great. Considering #426, this problem would disappear (somewhat) because containers would be responsible for their own buffer management. We could delay this PR until after #426 lands