### PR TITLE
Push filter to upstream operator

### DIFF
--- a/timely/src/dataflow/channels/pullers/counter.rs
+++ b/timely/src/dataflow/channels/pullers/counter.rs
@@ -33,10 +33,15 @@ impl<T:Ord+Clone+'static, D: Container, P: Pull<BundleCore<T, D>>> Counter<T, D,
 impl<T:Ord+Clone+'static, D, P: Pull<BundleCore<T, D>>> Counter<T, D, P> {
     /// Allocates a new `Counter` from a boxed puller.
     pub fn new(pullable: P) -> Self {
+        Self::new_with_consumed(pullable, Rc::new(RefCell::new(ChangeBatch::new())))
+    }
+
+    /// Allocates a new [Counter] from a puller and a shared consumed handle.
+    pub fn new_with_consumed(pullable: P, consumed: Rc<RefCell<ChangeBatch<T>>>) -> Self {
         Counter {
             phantom: ::std::marker::PhantomData,
             pullable,
-            consumed: Rc::new(RefCell::new(ChangeBatch::new())),
+            consumed,
         }
     }
     /// A references to shared changes in counts, for cloning or draining.

--- a/timely/src/dataflow/operators/enterleave.rs
+++ b/timely/src/dataflow/operators/enterleave.rs
@@ -99,7 +99,7 @@ impl<G: Scope, T: Timestamp+Refines<G::Timestamp>, C: Data+Container> Enter<G, T
         let input = scope.subgraph.borrow_mut().new_input(produced);
 
         let channel_id = scope.clone().new_identifier();
-        self.connect_to(input, ingress, channel_id);
+        self.connect_to(input, ingress, channel_id, |_, data, buffer| data.swap(buffer));
         StreamCore::new(Source::new(0, input.port), registrar, scope.clone())
     }
 }
@@ -131,7 +131,7 @@ impl<'a, G: Scope, D: Clone+Container, T: Timestamp+Refines<G::Timestamp>> Leave
         let output = scope.subgraph.borrow_mut().new_output();
         let (targets, registrar) = TeeCore::<G::Timestamp, D>::new();
         let channel_id = scope.clone().new_identifier();
-        self.connect_to(Target::new(0, output.port), EgressNub { targets, phantom: PhantomData }, channel_id);
+        self.connect_to(Target::new(0, output.port), EgressNub { targets, phantom: PhantomData }, channel_id, |_, data, buffer| data.swap(buffer));
 
         StreamCore::new(
             output,

--- a/timely/src/dataflow/operators/filter.rs
+++ b/timely/src/dataflow/operators/filter.rs
@@ -1,9 +1,10 @@
 //! Filters a stream by a predicate.
 
 use crate::Data;
+use crate::communication::message::RefOrMut;
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::{Stream, Scope};
-use crate::dataflow::operators::generic::operator::Operator;
+use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
 
 /// Extension trait for filtering.
 pub trait Filter<D: Data> {
@@ -24,15 +25,48 @@ pub trait Filter<D: Data> {
 
 impl<G: Scope, D: Data> Filter<D> for Stream<G, D> {
     fn filter<P: FnMut(&D)->bool+'static>(&self, mut predicate: P) -> Stream<G, D> {
-        let mut vector = Vec::new();
-        self.unary(Pipeline, "Filter", move |_,_| move |input, output| {
-            input.for_each(|time, data| {
-                data.swap(&mut vector);
-                vector.retain(|x| predicate(x));
-                if !vector.is_empty() {
-                    output.session(&time).give_vec(&mut vector);
+        let mut builder = OperatorBuilder::new("Filter".to_owned(), self.scope());
+
+        let filter = move |data: RefOrMut<Vec<D>>, buffer: &mut Vec<D>| {
+            match data {
+                RefOrMut::Ref(data) => {
+                    buffer.extend(data.into_iter().filter(|x| predicate(*x)).cloned())
+                },
+                RefOrMut::Mut(data) => {
+                    data.retain(|x| predicate(x));
+                    std::mem::swap(buffer, data);
                 }
-            });
-        })
+            }
+        };
+        let mut input = builder.new_input_filter(self, Pipeline, vec![], filter);
+        let (mut output, stream) = builder.new_output();
+        builder.set_notify(false);
+
+        builder.build(|_capabilities| {
+            let mut vector = Vec::new();
+            move |_frontiers| {
+                let mut output_handle = output.activate();
+                input.for_each(|time, data| {
+                    data.swap(&mut vector);
+                    output_handle.session(&time).give_vec(&mut vector);
+                })
+            }
+        });
+
+        stream
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::dataflow::operators::{Filter, Inspect, ToStream};
+
+    #[test]
+    fn test_filter_example() {
+        crate::example(|scope| {
+            (0..10).to_stream(scope)
+                .filter(|x| *x % 2 == 0)
+                .inspect(|x| println!("seen: {:?}", x));
+        });
     }
 }


### PR DESCRIPTION
Allow operators to push filter expressions to the upstream `Tee`.

This can reduce the amount of data copied within tees, but care needs to be taken to ensure the progress tracking invariants.

The intention is not to land this change but rather have a discussion if this is the right direction for such a change. I don't think the progress tracking wiring is particularly elegant, but seems to do the job. Maybe we could find a better abstraction here. This PR also breaks a public interface, the `Stream::connect_to` function. I'm not sure if there are any users outside of Timely that call this function.