### PR TITLE
builder_ref: first step towards ref based operator builder

### DIFF
--- a/timely/src/dataflow/operators/generic/builder_ref.rs
+++ b/timely/src/dataflow/operators/generic/builder_ref.rs
@@ -1,5 +1,229 @@
 //! Types to build operators with general shapes.
 
-// TODO: Analogue to builder_rc.rs, which instead provides wrappers that only borrow ChangeBatch<T>
-//       buffers, rather than wrapping them with Rc<RefCell<_>>. This removes dereferences from the
-//       common path of having nothing to do, and could plausibly make it a bit faster to do nothing.
+use std::rc::Rc;
+use std::cell::RefCell;
+
+use crate::Data;
+use crate::dataflow::channels::pact::ParallelizationContract;
+use crate::dataflow::channels::pushers::Tee;
+use crate::dataflow::channels::pullers::Counter as PullCounter;
+use crate::dataflow::channels::pushers::Counter as PushCounter;
+use crate::dataflow::channels::pushers::buffer::Buffer as PushBuffer;
+use crate::dataflow::operators::capability::Capability;
+use crate::dataflow::operators::generic::handles::{InputHandle, new_input_handle, OutputWrapper};
+use crate::dataflow::operators::generic::operator_info::OperatorInfo;
+use crate::dataflow::operators::generic::builder_raw::OperatorShape;
+use crate::dataflow::{Stream, Scope};
+use crate::logging::TimelyLogger as Logger;
+use crate::progress::{ChangeBatch, Timestamp};
+use crate::progress::operate::SharedProgress;
+use crate::progress::frontier::{Antichain, MutableAntichain};
+
+use super::builder_raw::OperatorBuilder as OperatorBuilderRaw;
+
+/// Builds operators with generic shape.
+#[derive(Debug)]
+pub struct OperatorBuilder<G: Scope, Inputs, Outputs> {
+    builder: OperatorBuilderRaw<G>,
+    inputs: Inputs,
+    outputs: Outputs,
+    frontier: Vec<MutableAntichain<G::Timestamp>>,
+    consumed: Vec<Rc<RefCell<ChangeBatch<G::Timestamp>>>>,
+    internal: Rc<RefCell<Vec<Rc<RefCell<ChangeBatch<G::Timestamp>>>>>>,
+    produced: Vec<Rc<RefCell<ChangeBatch<G::Timestamp>>>>,
+    logging: Option<Logger>,
+}
+
+impl<G: Scope> OperatorBuilder<G, (), ()> {
+    /// Allocates a new generic operator builder from its containing scope.
+    pub fn new(name: String, scope: G) -> Self {
+        let logging = scope.logging();
+        OperatorBuilder {
+            builder: OperatorBuilderRaw::new(name, scope),
+            inputs: (),
+            outputs: (),
+            frontier: Vec::new(),
+            consumed: Vec::new(),
+            internal: Rc::new(RefCell::new(Vec::new())),
+            produced: Vec::new(),
+            logging,
+        }
+    }
+}
+
+impl<G: Scope, Inputs: 'static, Outputs: 'static> OperatorBuilder<G, Inputs, Outputs> {
+    /// Adds a new input to a generic operator builder, returning the `Pull` implementor to use.
+    pub fn new_input<D, P>(self, stream: &Stream<G, D>, pact: P) -> OperatorBuilder<G, (InputHandle<G::Timestamp, D, P::Puller>, Inputs), Outputs>
+    where
+        P: ParallelizationContract<G::Timestamp, D>,
+        D: Data,
+    {
+        let connection = vec![Antichain::from_elem(Default::default()); self.builder.shape().outputs()];
+        self.new_input_connection(stream, pact, connection)
+    }
+
+    /// Create a new input connection
+    pub fn new_input_connection<D, P>(mut self, stream: &Stream<G, D>, pact: P, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> OperatorBuilder<G, (InputHandle<G::Timestamp, D, P::Puller>, Inputs), Outputs>
+        where
+            P: ParallelizationContract<G::Timestamp, D>,
+            D: Data,
+    {
+        let puller = self.builder.new_input_connection(stream, pact, connection);
+
+        let input = PullCounter::new(puller);
+        self.frontier.push(MutableAntichain::new());
+        self.consumed.push(input.consumed().clone());
+
+        let input_handle = new_input_handle(input, self.internal.clone(), self.logging.clone());
+
+        self.frontier.push(MutableAntichain::new());
+        OperatorBuilder {
+            builder: self.builder,
+            inputs: (input_handle, self.inputs),
+            outputs: self.outputs,
+            frontier: self.frontier,
+            consumed: self.consumed,
+            internal: self.internal,
+            produced: self.produced,
+            logging: self.logging,
+        }
+    }
+
+    /// Adds a new output to a generic operator builder, returning the `Push` implementor to use.
+    pub fn new_output<D: Data>(self) -> (OperatorBuilder<G, Inputs, (OutputWrapper<G::Timestamp, D, Tee<G::Timestamp, D>>, Outputs)>, Stream<G, D>)  {
+        let connection = vec![Antichain::from_elem(Default::default()); self.builder.shape().inputs()];
+        self.new_output_connection(connection)
+    }
+
+    /// Adds a new output with connection information to a generic operator builder, returning the `Push` implementor to use.
+    ///
+    /// The `connection` parameter contains promises made by the operator for each of the existing *inputs*, that any timestamp
+    /// appearing at the input, any output timestamp will be greater than or equal to the input timestamp subjected to a `Summary`
+    /// greater or equal to some element of the corresponding antichain in `connection`.
+    ///
+    /// Commonly the connections are either the unit summary, indicating the same timestamp might be produced as output, or an empty
+    /// antichain indicating that there is no connection from the input to the output.
+    pub fn new_output_connection<D: Data>(mut self, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> (OperatorBuilder<G, Inputs, (OutputWrapper<G::Timestamp, D, Tee<G::Timestamp, D>>, Outputs)>, Stream<G, D>)  {
+
+        let (tee, stream) = self.builder.new_output_connection(connection);
+
+        let internal = Rc::new(RefCell::new(ChangeBatch::new()));
+        self.internal.borrow_mut().push(internal.clone());
+
+        let mut buffer = PushBuffer::new(PushCounter::new(tee));
+        self.produced.push(buffer.inner().produced().clone());
+
+        let output_wrapper = OutputWrapper::new(buffer, internal);
+        let builder = OperatorBuilder {
+            builder: self.builder,
+            inputs: self.inputs,
+            outputs: (output_wrapper, self.outputs),
+            frontier: self.frontier,
+            consumed: self.consumed,
+            internal: self.internal,
+            produced: self.produced,
+            logging: self.logging,
+        };
+        (builder, stream)
+    }
+
+    /// Creates an operator implementation from supplied logic constructor.
+    pub fn build<B, L>(self, constructor: B)
+    where
+        B: FnOnce(Vec<Capability<G::Timestamp>>) -> L,
+        L: FnMut(&mut Inputs, &mut Outputs, &[MutableAntichain<G::Timestamp>]) + 'static
+    {
+        self.build_reschedule(|caps| {
+            let mut logic = constructor(caps);
+            move |inputs, outputs, frontier| { logic(inputs, outputs, frontier); false }
+        })
+    }
+
+    /// Creates an operator implementation from supplied logic constructor.
+    ///
+    /// Unlike `build`, the supplied closure can indicate if the operator
+    /// should be considered incomplete. The `build` method indicates that
+    /// the operator is never incomplete and can be shut down at the system's
+    /// discretion.
+    pub fn build_reschedule<B, L>(self, constructor: B)
+    where
+        B: FnOnce(Vec<Capability<G::Timestamp>>) -> L,
+        L: FnMut(&mut Inputs, &mut Outputs, &[MutableAntichain<G::Timestamp>]) -> bool + 'static
+    {
+        // create capabilities, discard references to their creation.
+        let mut capabilities = Vec::with_capacity(self.internal.borrow().len());
+        for batch in self.internal.borrow().iter() {
+            capabilities.push(Capability::new(G::Timestamp::minimum(), batch.clone()));
+            // Discard evidence of creation, as we are assumed to start with one.
+            batch.borrow_mut().clear();
+        }
+
+        let mut logic = constructor(capabilities);
+
+        let mut self_frontier = self.frontier;
+        let self_consumed = self.consumed;
+        let self_internal = self.internal;
+        let self_produced = self.produced;
+        let mut self_inputs = self.inputs;
+        let mut self_outputs = self.outputs;
+
+        let raw_logic =
+        move |progress: &mut SharedProgress<G::Timestamp>| {
+
+            // drain frontier changes
+            for (progress, frontier) in progress.frontiers.iter_mut().zip(self_frontier.iter_mut()) {
+                frontier.update_iter(progress.drain());
+            }
+
+            // invoke supplied logic
+            let result = logic(&mut self_inputs, &mut self_outputs, &self_frontier[..]);
+
+            // move batches of consumed changes.
+            for (progress, consumed) in progress.consumeds.iter_mut().zip(self_consumed.iter()) {
+                consumed.borrow_mut().drain_into(progress);
+            }
+
+            // move batches of internal changes.
+            let self_internal_borrow = self_internal.borrow_mut();
+            for index in 0 .. self_internal_borrow.len() {
+                let mut borrow = self_internal_borrow[index].borrow_mut();
+                progress.internals[index].extend(borrow.drain());
+            }
+
+            // move batches of produced changes.
+            for (progress, produced) in progress.produceds.iter_mut().zip(self_produced.iter()) {
+                produced.borrow_mut().drain_into(progress);
+            }
+
+            result
+        };
+
+        self.builder.build(raw_logic);
+    }
+
+
+    /// Indicates whether the operator requires frontier information.
+    pub fn set_notify(&mut self, notify: bool) {
+        self.builder.set_notify(notify);
+    }
+
+    /// Get the identifier assigned to the operator being constructed
+    pub fn index(&self) -> usize {
+        self.builder.index()
+    }
+
+    /// The operator's worker-unique identifier.
+    pub fn global(&self) -> usize {
+        self.builder.global()
+    }
+
+    /// Return a reference to the operator's shape
+    pub fn shape(&self) -> &OperatorShape {
+        self.builder.shape()
+    }
+
+    /// Creates operator info for the operator.
+    pub fn operator_info(&self) -> OperatorInfo {
+        self.builder.operator_info()
+    }
+}

--- a/timely/src/dataflow/operators/generic/mod.rs
+++ b/timely/src/dataflow/operators/generic/mod.rs
@@ -3,7 +3,7 @@
 pub mod operator;
 pub mod builder_rc;
 pub mod builder_raw;
-// pub mod builder_ref;
+pub mod builder_ref;
 mod handles;
 mod notificator;
 mod operator_info;


### PR DESCRIPTION
This commit is the first step towards building an operator builder that
doesn't rely on holding on to `Rc<RefCell<ChangeBatch<T>>`.

In order to do so `builder_ref::OperatorBuilder` encodes the current
shape of the operator in the system by consuming self and producing a
new builder type every time an input or output is added.

When the time comes to build the operator, the system requires the user
to supply a closure whose type signature matches exactly the inputs and
outputs have have been previously declared.

This PR only adds the typestate machinery to
`builder_ref::OperatorBuilder`. A subsequent PR will work on removing
all the shared refcounted change batches since they now have a single
owner. The reason this isn't included in this PR is to keep it at a
reasonable size since many auxiliary types like the handles will need to
be adjusted to work with references.