### PR TITLE
MapCore for containers

### DIFF
--- a/container/src/columnation.rs
+++ b/container/src/columnation.rs
@@ -272,7 +272,7 @@ mod serde {
 }
 
 mod container {
-    use crate::{Container, PushPartitioned};
+    use crate::{Container, MonotonicContainer, PushPartitioned};
 
     use crate::columnation::{Columnation, TimelyStack};
 
@@ -294,6 +294,10 @@ mod container {
         fn clear(&mut self) {
             TimelyStack::clear(self)
         }
+    }
+
+    impl<T: Columnation + 'static, O: Columnation + 'static> MonotonicContainer<O> for TimelyStack<T> {
+        type Output = TimelyStack<O>;
     }
 
     impl<T: Columnation + 'static> PushPartitioned for TimelyStack<T> {

--- a/timely/src/dataflow/operators/mod.rs
+++ b/timely/src/dataflow/operators/mod.rs
@@ -14,7 +14,7 @@ pub use self::unordered_input::{UnorderedInput, UnorderedInputCore};
 pub use self::feedback::{Feedback, LoopVariable, ConnectLoop};
 pub use self::concat::{Concat, Concatenate};
 pub use self::partition::Partition;
-pub use self::map::Map;
+pub use self::map::{Map, MapCore};
 pub use self::inspect::{Inspect, InspectCore};
 pub use self::filter::Filter;
 pub use self::delay::Delay;


### PR DESCRIPTION
An idea on how we could provide a generic map function for containers, where the client's interface does not need to know the specifics of the container type.

This includes a draft on how we could provide a `flat_map` operator, but it is unclear to me whether the recycling of allocations is desirable here.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>