### PR TITLE
Allow exchange operator to take FnMut

### DIFF
--- a/timely/src/dataflow/operators/exchange.rs
+++ b/timely/src/dataflow/operators/exchange.rs
@@ -22,12 +22,12 @@ pub trait Exchange<T, D: ExchangeData> {
     ///            .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn exchange(&self, route: impl Fn(&D)->u64+'static) -> Self;
+    fn exchange(&self, route: impl FnMut(&D)->u64+'static) -> Self;
 }
 
 // impl<T: Timestamp, G: Scope<Timestamp=T>, D: ExchangeData> Exchange<T, D> for Stream<G, D> {
 impl<G: Scope, D: ExchangeData> Exchange<G::Timestamp, D> for Stream<G, D> {
-    fn exchange(&self, route: impl Fn(&D)->u64+'static) -> Stream<G, D> {
+    fn exchange(&self, route: impl FnMut(&D)->u64+'static) -> Stream<G, D> {
         let mut vector = Default::default();
         self.unary(ExchangePact::new(route), "Exchange", move |_,_| move |input, output| {
             input.for_each(|time, data| {


### PR DESCRIPTION
Since the underlying `channels::pact::Exchange` already can store an `FnMut` as the hash function, it seems like the exchange operator should be able to support taking one as well. I'm still getting my bearings with Timely and Rust, so if there's a reason for the mismatch, I'd love to learn about why.

FWIW, my use case: for reasons unrelated to Timely, I have a limit on how many workers can gather input from the previous system, so I'd like to round-robin exchange right away with a counter, so additional workers have things to chew on in the early part of the dataflow. I know I could hash the input or generate random numbers currently, but this seemed like it could be supported as well.

Thanks!