### PR TITLE
enterleave should not depend on command line args

### DIFF
--- a/timely/src/dataflow/operators/enterleave.rs
+++ b/timely/src/dataflow/operators/enterleave.rs
@@ -212,7 +212,7 @@ mod test {
         use crate::dataflow::operators::{Enter, Leave};
 
         // initializes and runs a timely dataflow.
-        crate::execute_from_args(std::env::args(), |worker| {
+        crate::execute(crate::Config::process(3), |worker| {
 
             let index = worker.index();
             let mut input = InputHandle::new();


### PR DESCRIPTION
The test depends on the command line args, which is probably not what we want. The test binary only allows its own parameters, so we cannot supply Timely-specific parameters here. Also, passing legitimate parameters to the test binary causes the test to fail because Timely doesn't understand the parameters.

This PR changes the test to a fixed configuration of three worker threads.