### PR TITLE
Add a tuple timestamp

### DIFF
--- a/timely/src/order.rs
+++ b/timely/src/order.rs
@@ -25,6 +25,15 @@ pub trait PartialOrder : Eq {
 /// and other sanity-maintaining operations.
 pub trait TotalOrder : PartialOrder { }
 
+/// A type that does not affect total orderedness.
+///
+/// This trait is not useful, but must be made public and documented or else Rust
+/// complains about its existence in the constraints on the implementation of
+/// public traits for public types.
+pub trait Empty : PartialOrder { }
+
+impl Empty for () { }
+
 macro_rules! implement_partial {
     ($($index_type:ty,)*) => (
         $(
@@ -47,93 +56,132 @@ macro_rules! implement_total {
 implement_partial!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize, (), ::std::time::Duration,);
 implement_total!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize, (), ::std::time::Duration,);
 
-
-use std::fmt::{Formatter, Error, Debug};
-
-use crate::progress::Timestamp;
-use crate::progress::timestamp::Refines;
-
-impl<TOuter: Timestamp, TInner: Timestamp> Refines<TOuter> for Product<TOuter, TInner> {
-    fn to_inner(other: TOuter) -> Self {
-        Product::new(other, TInner::minimum())
+pub use product::Product;
+/// A pair of timestamps, partially ordered by the product order.
+mod product {
+    /// A nested pair of timestamps, one outer and one inner.
+    ///
+    /// We use `Product` rather than `(TOuter, TInner)` so that we can derive our own `PartialOrder`,
+    /// because Rust just uses the lexicographic total order.
+    #[derive(Abomonation, Copy, Clone, Hash, Eq, PartialEq, Default, Ord, PartialOrd, Serialize, Deserialize)]
+    pub struct Product<TOuter, TInner> {
+        /// Outer timestamp.
+        pub outer: TOuter,
+        /// Inner timestamp.
+        pub inner: TInner,
     }
-    fn to_outer(self: Product<TOuter, TInner>) -> TOuter {
-        self.outer
-    }
-    fn summarize(path: <Self as Timestamp>::Summary) -> <TOuter as Timestamp>::Summary {
-        path.outer
-    }
-}
 
-/// A nested pair of timestamps, one outer and one inner.
-///
-/// We use `Product` rather than `(TOuter, TInner)` so that we can derive our own `PartialOrd`,
-/// because Rust just uses the lexicographic total order.
-#[derive(Abomonation, Copy, Clone, Hash, Eq, PartialEq, Default, Ord, PartialOrd, Serialize, Deserialize)]
-pub struct Product<TOuter, TInner> {
-    /// Outer timestamp.
-    pub outer: TOuter,
-    /// Inner timestamp.
-    pub inner: TInner,
-}
-
-impl<TOuter, TInner> Product<TOuter, TInner> {
-    /// Creates a new product from outer and inner coordinates.
-    pub fn new(outer: TOuter, inner: TInner) -> Product<TOuter, TInner> {
-        Product {
-            outer,
-            inner,
+    impl<TOuter, TInner> Product<TOuter, TInner> {
+        /// Creates a new product from outer and inner coordinates.
+        pub fn new(outer: TOuter, inner: TInner) -> Self {
+            Product {
+                outer,
+                inner,
+            }
         }
     }
-}
 
-/// Debug implementation to avoid seeing fully qualified path names.
-impl<TOuter: Debug, TInner: Debug> Debug for Product<TOuter, TInner> {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        f.write_str(&format!("({:?}, {:?})", self.outer, self.inner))
+    // Debug implementation to avoid seeing fully qualified path names.
+    use std::fmt::{Formatter, Error, Debug};
+    impl<TOuter: Debug, TInner: Debug> Debug for Product<TOuter, TInner> {
+        fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+            f.write_str(&format!("({:?}, {:?})", self.outer, self.inner))
+        }
     }
-}
 
-impl<TOuter: PartialOrder, TInner: PartialOrder> PartialOrder for Product<TOuter, TInner> {
-    #[inline]
-    fn less_equal(&self, other: &Self) -> bool {
-        self.outer.less_equal(&other.outer) && self.inner.less_equal(&other.inner)
+    use super::PartialOrder;
+    impl<TOuter: PartialOrder, TInner: PartialOrder> PartialOrder for Product<TOuter, TInner> {
+        #[inline]
+        fn less_equal(&self, other: &Self) -> bool {
+            self.outer.less_equal(&other.outer) && self.inner.less_equal(&other.inner)
+        }
     }
-}
 
-impl<TOuter: Timestamp, TInner: Timestamp> Timestamp for Product<TOuter, TInner> {
-    type Summary = Product<TOuter::Summary, TInner::Summary>;
-    fn minimum() -> Self { Product { outer: TOuter::minimum(), inner: TInner::minimum() }}
-}
-
-use crate::progress::timestamp::PathSummary;
-impl<TOuter: Timestamp, TInner: Timestamp> PathSummary<Product<TOuter, TInner>> for Product<TOuter::Summary, TInner::Summary> {
-    #[inline]
-    fn results_in(&self, product: &Product<TOuter, TInner>) -> Option<Product<TOuter, TInner>> {
-        self.outer.results_in(&product.outer)
-            .and_then(|outer|
-                self.inner.results_in(&product.inner)
-                    .map(|inner| Product::new(outer, inner))
-            )
+    use crate::progress::Timestamp;
+    impl<TOuter: Timestamp, TInner: Timestamp> Timestamp for Product<TOuter, TInner> {
+        type Summary = Product<TOuter::Summary, TInner::Summary>;
+        fn minimum() -> Self { Self { outer: TOuter::minimum(), inner: TInner::minimum() }}
     }
-    #[inline]
-    fn followed_by(&self, other: &Product<TOuter::Summary, TInner::Summary>) -> Option<Product<TOuter::Summary, TInner::Summary>> {
-        self.outer.followed_by(&other.outer)
-            .and_then(|outer|
-                self.inner.followed_by(&other.inner)
-                    .map(|inner| Product::new(outer, inner))
-            )
+
+    use crate::progress::timestamp::PathSummary;
+    impl<TOuter: Timestamp, TInner: Timestamp> PathSummary<Product<TOuter, TInner>> for Product<TOuter::Summary, TInner::Summary> {
+        #[inline]
+        fn results_in(&self, product: &Product<TOuter, TInner>) -> Option<Product<TOuter, TInner>> {
+            self.outer.results_in(&product.outer)
+                .and_then(|outer|
+                    self.inner.results_in(&product.inner)
+                        .map(|inner| Product::new(outer, inner))
+                )
+        }
+        #[inline]
+        fn followed_by(&self, other: &Self) -> Option<Self> {
+            self.outer.followed_by(&other.outer)
+                .and_then(|outer|
+                    self.inner.followed_by(&other.inner)
+                        .map(|inner| Product::new(outer, inner))
+                )
+        }
     }
+
+    use crate::progress::timestamp::Refines;
+    impl<TOuter: Timestamp, TInner: Timestamp> Refines<TOuter> for Product<TOuter, TInner> {
+        fn to_inner(other: TOuter) -> Self {
+            Product::new(other, TInner::minimum())
+        }
+        fn to_outer(self: Product<TOuter, TInner>) -> TOuter {
+            self.outer
+        }
+        fn summarize(path: <Self as Timestamp>::Summary) -> <TOuter as Timestamp>::Summary {
+            path.outer
+        }
+    }
+
+    use super::{Empty, TotalOrder};
+    impl<T1: Empty, T2: Empty> Empty for Product<T1, T2> { }
+    impl<T1, T2> TotalOrder for Product<T1, T2> where T1: Empty, T2: TotalOrder { }
 }
 
-/// A type that does not affect total orderedness.
-///
-/// This trait is not useful, but must be made public and documented or else Rust
-/// complains about its existence in the constraints on the implementation of
-/// public traits for public types.
-pub trait Empty : PartialOrder { }
+/// Rust tuple ordered by the lexicographic order.
+mod tuple {
 
-impl Empty for () { }
-impl<T1: Empty, T2: Empty> Empty for Product<T1, T2> { }
+    use super::PartialOrder;
+    impl<TOuter: PartialOrder, TInner: PartialOrder> PartialOrder for (TOuter, TInner) {
+        #[inline]
+        fn less_equal(&self, other: &Self) -> bool {
+            // We avoid Rust's `PartialOrd` implementation, for reasons of correctness.
+            self.0.less_than(&other.0) || (self.0.eq(&other.0) && self.1.less_equal(&other.1))
+        }
+    }
 
-impl<T1, T2> TotalOrder for Product<T1, T2> where T1: Empty, T2: TotalOrder { }
+    use super::TotalOrder;
+    impl<T1, T2> TotalOrder for (T1, T2) where T1: TotalOrder, T2: TotalOrder { }
+
+    use crate::progress::Timestamp;
+    impl<TOuter: Timestamp, TInner: Timestamp> Timestamp for (TOuter, TInner) {
+        type Summary = (TOuter::Summary, TInner::Summary);
+        fn minimum() -> Self { (TOuter::minimum(), TInner::minimum()) }
+    }
+
+    use crate::progress::timestamp::PathSummary;
+    impl<TOuter: Timestamp, TInner: Timestamp> PathSummary<(TOuter, TInner)> for (TOuter::Summary, TInner::Summary) {
+        #[inline]
+        fn results_in(&self, (outer, inner): &(TOuter, TInner)) -> Option<(TOuter, TInner)> {
+            self.0.results_in(outer)
+                .and_then(|outer|
+                    self.1.results_in(inner)
+                        .map(|inner| (outer, inner))
+                )
+        }
+        #[inline]
+        fn followed_by(&self, (outer, inner): &(TOuter::Summary, TInner::Summary)) -> Option<(TOuter::Summary, TInner::Summary)> {
+            self.0.followed_by(outer)
+                .and_then(|outer|
+                    self.1.followed_by(inner)
+                        .map(|inner| (outer, inner))
+                )
+        }
+    }
+
+    use super::Empty;
+    impl<T1: Empty, T2: Empty> Empty for (T1, T2) { }
+}


### PR DESCRIPTION
This PR adds a `Timestamp` implementation for `(T1, T2)`, following Rust's lead that this is a lexicographically ordered sequence, rather than a partially ordered product (use `order::Product` for that).

I think the path summary representation is .. pessimistic, but not incorrect. It allows summaries to both coordinates, which are both applied. In principle, advancing the outer coordinator could *zero* the inner coordinate, so `(summ1, summ2)` could be "if `summ1` is non-zero apply `summ1` and set the second coordinate to `T2::minimum()` subjected to `summ2`".

I didn't do that, and just applied the summaries to each coordinate, promising more of an advance than is strictly required.

In writing this up, I took the opportunity to relayout `order.rs` which, not having a second implementation, lacked for organization.