### PR TITLE
exchange: remove one layer of boxing

### DIFF
--- a/timely/src/dataflow/channels/pact.rs
+++ b/timely/src/dataflow/channels/pact.rs
@@ -15,7 +15,7 @@ use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
 use crate::Container;
 
 use crate::worker::AsWorker;
-use crate::dataflow::channels::pushers::Exchange as ExchangePusher;
+use crate::dataflow::channels::pushers::{Exchange as ExchangePusher, DataHasher};
 use super::{BundleCore, Message};
 
 use crate::logging::{TimelyLogger as Logger, MessagesEvent};
@@ -73,14 +73,13 @@ impl<T: Timestamp, C, D: Data+Clone, F: FnMut(&D)->u64+'static> ParallelizationC
 where
     C: Data + Container + PushPartitioned<Item=D>,
 {
-    // TODO: The closure in the type prevents us from naming it.
-    //       Could specialize `ExchangePusher` to a time-free version.
-    type Pusher = Box<dyn Push<BundleCore<T, C>>>;
-    type Puller = Box<dyn Pull<BundleCore<T, C>>>;
-    fn connect<A: AsWorker>(mut self, allocator: &mut A, identifier: usize, address: &[usize], logging: Option<Logger>) -> (Self::Pusher, Self::Puller) {
+    type Pusher = ExchangePusher<T, C, D, LogPusher<T, C, Box<dyn Push<BundleCore<T, C>>>>, DataHasher<F>>;
+    type Puller = LogPuller<T, C, Box<dyn Pull<BundleCore<T, C>>>>;
+
+    fn connect<A: AsWorker>(self, allocator: &mut A, identifier: usize, address: &[usize], logging: Option<Logger>) -> (Self::Pusher, Self::Puller) {
         let (senders, receiver) = allocator.allocate::<Message<T, C>>(identifier, address);
         let senders = senders.into_iter().enumerate().map(|(i,x)| LogPusher::new(x, allocator.index(), i, identifier, logging.clone())).collect::<Vec<_>>();
-        (Box::new(ExchangePusher::new(senders, move |_, d| (self.hash_func)(d))), Box::new(LogPuller::new(receiver, allocator.index(), identifier, logging.clone())))
+        (ExchangePusher::new(senders, DataHasher::new(self.hash_func)), LogPuller::new(receiver, allocator.index(), identifier, logging.clone()))
     }
 }
 

--- a/timely/src/dataflow/channels/pushers/exchange.rs
+++ b/timely/src/dataflow/channels/pushers/exchange.rs
@@ -5,37 +5,9 @@ use crate::{Container, Data};
 use crate::communication::Push;
 use crate::dataflow::channels::{BundleCore, Message};
 
-/// Hashes a pair of time and data in order to distribute records
-pub trait ParallelizationHasher<T, D> {
-    /// Computes the distribution function
-    fn hash(&mut self, time: &T, data: &D) -> u64;
-}
-
-impl<T, D, F: FnMut(&T, &D) -> u64> ParallelizationHasher<T, D> for F {
-    fn hash(&mut self, time: &T, data: &D) -> u64 {
-        (self)(time, data)
-    }
-}
-
-/// A ParallizationContract hasher that only consideres the data
-pub struct DataHasher<F>(F);
-
-impl<T, D, F: FnMut(&D) -> u64> ParallelizationHasher<T, D> for DataHasher<F> {
-    fn hash(&mut self, _time: &T, data: &D) -> u64 {
-        (self.0)(data)
-    }
-}
-
-impl<F> DataHasher<F> {
-    /// Construct a new data hasher with the given function
-    pub fn new(hash_func: F) -> Self {
-        Self(hash_func)
-    }
-}
-
 // TODO : Software write combining
 /// Distributes records among target pushees according to a distribution function.
-pub struct Exchange<T, C: Container, D, P: Push<BundleCore<T, C>>, H: ParallelizationHasher<T, D>> {
+pub struct Exchange<T, C: Container, D, P: Push<BundleCore<T, C>>, H: FnMut(&D) -> u64> {
     pushers: Vec<P>,
     buffers: Vec<C>,
     current: Option<T>,
@@ -43,7 +15,7 @@ pub struct Exchange<T, C: Container, D, P: Push<BundleCore<T, C>>, H: Paralleliz
     phantom: std::marker::PhantomData<D>,
 }
 
-impl<T: Clone, C: Container, D: Data, P: Push<BundleCore<T, C>>, H: ParallelizationHasher<T, D>>  Exchange<T, C, D, P, H> {
+impl<T: Clone, C: Container, D: Data, P: Push<BundleCore<T, C>>, H: FnMut(&D) -> u64>  Exchange<T, C, D, P, H> {
     /// Allocates a new `Exchange` from a supplied set of pushers and a distribution function.
     pub fn new(pushers: Vec<P>, key: H) -> Exchange<T, C, D, P, H> {
         let mut buffers = vec![];
@@ -68,7 +40,7 @@ impl<T: Clone, C: Container, D: Data, P: Push<BundleCore<T, C>>, H: Parallelizat
     }
 }
 
-impl<T: Eq+Data, C: Container, D: Data, P: Push<BundleCore<T, C>>, H: ParallelizationHasher<T, D>> Push<BundleCore<T, C>> for Exchange<T, C, D, P, H>
+impl<T: Eq+Data, C: Container, D: Data, P: Push<BundleCore<T, C>>, H: FnMut(&D) -> u64> Push<BundleCore<T, C>> for Exchange<T, C, D, P, H>
 where
     C: PushPartitioned<Item=D>
 {
@@ -100,7 +72,7 @@ where
                 let pushers = &mut self.pushers;
                 data.push_partitioned(
                     &mut self.buffers,
-                    move |datum| (hash_func.hash(time, datum) & mask) as usize,
+                    move |datum| ((hash_func)(datum) & mask) as usize,
                     |index, buffer| {
                             Message::push_at(buffer, time.clone(), &mut pushers[index]);
                     }
@@ -112,7 +84,7 @@ where
                 let pushers = &mut self.pushers;
                 data.push_partitioned(
                     &mut self.buffers,
-                    move |datum| (hash_func.hash(time, datum) % num_pushers) as usize,
+                    move |datum| ((hash_func)(datum) % num_pushers) as usize,
                     |index, buffer| {
                         Message::push_at(buffer, time.clone(), &mut pushers[index]);
                     }

--- a/timely/src/dataflow/channels/pushers/mod.rs
+++ b/timely/src/dataflow/channels/pushers/mod.rs
@@ -1,5 +1,5 @@
 pub use self::tee::{Tee, TeeCore, TeeHelper};
-pub use self::exchange::Exchange;
+pub use self::exchange::{Exchange, DataHasher};
 pub use self::counter::{Counter, CounterCore};
 
 pub mod tee;

--- a/timely/src/dataflow/channels/pushers/mod.rs
+++ b/timely/src/dataflow/channels/pushers/mod.rs
@@ -1,5 +1,5 @@
 pub use self::tee::{Tee, TeeCore, TeeHelper};
-pub use self::exchange::{Exchange, DataHasher};
+pub use self::exchange::Exchange;
 pub use self::counter::{Counter, CounterCore};
 
 pub mod tee;


### PR DESCRIPTION
We were previously forced to use a boxed trait object because we were unable to name the type of the constructed closure.

~~This patch fixes it by introducing a custom `ParallelizationHasher` trait that the `ParallelizationContractCore` expects with a blanket implementation for all closures taking two arguments. This is to maintain backwards compatibility with any code thatpasses a closure directly to `ExchangeCore::new`.~~

~~Then a wrapper type `DataHasher<F>` is introduced that allows us to both specialize the `ParallelizationHasher` implementation for single argument closures and at the same time name the type which is what we need to remove one layer of boxed trait objects.~~

UPDATE: After discussion with @frankmcsherry and @antiguru it turns out that we'd rather remove the ability to distribute records based on time, which makes it even easier to remove the box. This PR is now changed to reflect that.

