### PR TITLE
Remove Abomonation for encoding MessageHeader

### DIFF
--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -19,6 +19,7 @@ default = ["getopts"]
 [dependencies]
 getopts = { version = "0.2.14", optional = true }
 bincode = { version = "1.0", optional = true }
+byteorder = "1.5"
 serde_derive = "1.0"
 serde = "1.0"
 abomonation = "0.7"


### PR DESCRIPTION
While this does not remove the dependency on Abomonation, it ensures that
reading and writing MessageHeader structs from the network does not use
Abomonation.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>