### PR TITLE
allow worker without dataflows to sleep

### DIFF
--- a/communication/examples/comm_hello.rs
+++ b/communication/examples/comm_hello.rs
@@ -7,7 +7,7 @@ fn main() {
 
     // extract the configuration from user-supplied arguments, initialize the computation.
     let config = timely_communication::Config::from_args(std::env::args()).unwrap();
-    let guards = timely_communication::initialize(config, |mut allocator| {
+    let guards = timely_communication::initialize(config, |mut allocator, _kill_switch| {
 
         println!("worker {} of {} started", allocator.index(), allocator.peers());
 

--- a/communication/src/lib.rs
+++ b/communication/src/lib.rs
@@ -22,7 +22,7 @@
 //! let config = timely_communication::Config::Process(2);
 //!
 //! // initializes communication, spawns workers
-//! let guards = timely_communication::initialize(config, |mut allocator| {
+//! let guards = timely_communication::initialize(config, |mut allocator, _kill_switch| {
 //!     println!("worker {} started", allocator.index());
 //!
 //!     // allocates a pair of senders list and one receiver.

--- a/timely/examples/threadless.rs
+++ b/timely/examples/threadless.rs
@@ -1,5 +1,7 @@
 extern crate timely;
 
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use timely::dataflow::{InputHandle, ProbeHandle};
 use timely::dataflow::operators::{Inspect, Probe};
 use timely::WorkerConfig;
@@ -8,7 +10,8 @@ fn main() {
 
     // create a naked single-threaded worker.
     let allocator = timely::communication::allocator::Thread::new();
-    let mut worker = timely::worker::Worker::new(WorkerConfig::default(), allocator);
+    let kill_switch = Arc::new(AtomicBool::new(false));
+    let mut worker = timely::worker::Worker::new(WorkerConfig::default(), allocator, kill_switch);
 
     // create input and probe handles.
     let mut input = InputHandle::new();


### PR DESCRIPTION
As of now, a worker without any dataflows present will sit in a busy waiting loop. The thread will never park, as in `worker.rs` the thread parks only if the dataflow is not empty. 

This commit allows worker threads to `park` if no dataflow is installed. We unpark the thread if the `WorkerGuard` is dropped. But this introduces a race, as the unpark might be called before the thread is run. Thus, we introduce a per worker atomic bool `kill_switch` that gets set before we unpark the worker thread. The worker thread must now obey this flag: It must not park when the `kill_switch` is set.

This behavior is implemented in `worker.rs`. Clients of timely communication must obey this rule, and it breaks existing client code of communication, because the worker closure receives the `kill_switch` as additional argument. 