### PR TITLE
Avoid spinning when workers have no dataflows

### DIFF
--- a/timely/src/execute.rs
+++ b/timely/src/execute.rs
@@ -155,7 +155,9 @@ where
     let alloc = crate::communication::allocator::thread::Thread::new();
     let mut worker = crate::worker::Worker::new(WorkerConfig::default(), alloc);
     let result = func(&mut worker);
-    while worker.step_or_park(None) { }
+    if worker.step_or_park(Some(std::time::Duration::new(0, 0))) {
+        while worker.step_or_park(None) { }
+    }
     result
 }
 
@@ -283,7 +285,9 @@ where
         }
 
         let result = func(&mut worker);
-        while worker.step_or_park(None) { }
+        if worker.step_or_park(Some(std::time::Duration::new(0, 0))) {
+            while worker.step_or_park(None) { }
+        }
         result
     })
 }
@@ -382,7 +386,9 @@ where
     initialize_from(builders, others, move |allocator| {
         let mut worker = Worker::new(worker_config.clone(), allocator);
         let result = func(&mut worker);
-        while worker.step_or_park(None) { }
+        if worker.step_or_park(Some(std::time::Duration::new(0, 0))) {
+            while worker.step_or_park(None) { }
+        }
         result
     })
 }

--- a/timely/src/execute.rs
+++ b/timely/src/execute.rs
@@ -155,8 +155,8 @@ where
     let alloc = crate::communication::allocator::thread::Thread::new();
     let mut worker = crate::worker::Worker::new(WorkerConfig::default(), alloc);
     let result = func(&mut worker);
-    if worker.step_or_park(Some(std::time::Duration::new(0, 0))) {
-        while worker.step_or_park(None) { }
+    while worker.has_dataflows() {
+        worker.step_or_park(None);
     }
     result
 }
@@ -285,8 +285,8 @@ where
         }
 
         let result = func(&mut worker);
-        if worker.step_or_park(Some(std::time::Duration::new(0, 0))) {
-            while worker.step_or_park(None) { }
+        while worker.has_dataflows() {
+            worker.step_or_park(None);
         }
         result
     })
@@ -386,8 +386,8 @@ where
     initialize_from(builders, others, move |allocator| {
         let mut worker = Worker::new(worker_config.clone(), allocator);
         let result = func(&mut worker);
-        if worker.step_or_park(Some(std::time::Duration::new(0, 0))) {
-            while worker.step_or_park(None) { }
+        while worker.has_dataflows() {
+            worker.step_or_park(None);
         }
         result
     })

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -698,6 +698,11 @@ impl<A: Allocate> Worker<A> {
         self.dataflows.borrow().keys().cloned().collect()
     }
 
+    /// True if there is at least one dataflow under management.
+    pub fn has_dataflows(&self) -> bool {
+        !self.dataflows.borrow().is_empty()
+    }
+
     // Acquire a new distinct dataflow identifier.
     fn allocate_dataflow_index(&mut self) -> usize {
         *self.dataflow_counter.borrow_mut() += 1;

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -366,7 +366,7 @@ impl<A: Allocate> Worker<A> {
             (x, y) => x.or(y),
         };
 
-        if !self.dataflows.borrow().is_empty() && delay != Some(Duration::new(0,0)) {
+        if delay != Some(Duration::new(0,0)) {
 
             // Log parking and flush log.
             if let Some(l) = self.logging().as_mut() {


### PR DESCRIPTION
Meant to address the same issue as #461, and up for discussion.

The intent here is that calling `worker.step_or_park(duration)` should not ignore the argument when `worker.dataflows` is empty. It chose to, because it our shutdown code we end up in a loop that won't break out there are no dataflows (and nothing to wake us). Some head scratching later, I deemed this to be a bug in the shutdown code: we shouldn't enter the loop if there are no dataflows, and if there are dataflows then we will exit it (as reaching zero dataflows is the test to break out of the loop).

Said differently, the code should probably have been:
```rust
while worker.has_dataflows() {
    worker.step_or_park(None);
}
```
and .. we could still do that. This PR does a similar change that is not quite as clear.