### PR TITLE
nonce to prevent a split-brain communication cluster

### DIFF
--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -21,6 +21,7 @@ getopts = { version = "0.2.14", optional = true }
 bincode = { version = "1.0", optional = true }
 serde_derive = "1.0"
 serde = "1.0"
+rand = "0.8.5"
 abomonation = "0.7"
 abomonation_derive = "0.5"
 timely_bytes = { path = "../bytes", version = "0.12" }


### PR DESCRIPTION
Introduce a nonce value to ensure that all cluster members are connected to the same set of hosts.