### PR TITLE
Open the Inspect trait for more stream kinds

### DIFF
--- a/timely/src/dataflow/operators/generic/operator.rs
+++ b/timely/src/dataflow/operators/generic/operator.rs
@@ -594,7 +594,7 @@ where
 /// timely::example(|scope| {
 ///
 ///
-///     empty(scope)     // type required in this example
+///     empty::<_, Vec<_>>(scope)     // type required in this example
 ///         .inspect(|()| panic!("never called"));
 ///
 /// });


### PR DESCRIPTION
Instead of only supporting vector-backed streams, permit TimelyStack and
Rc streams.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>