### PR TITLE
Extend RefOrMut to cover owned data.

### DIFF
--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -24,5 +24,6 @@ serde = "1.0"
 abomonation = "0.7"
 abomonation_derive = "0.5"
 timely_bytes = { path = "../bytes", version = "0.12" }
+timely_container = { path = "../container", version = "0.12" }
 timely_logging = { path = "../logging", version = "0.12" }
 crossbeam-channel = "0.5.0"

--- a/communication/src/lib.rs
+++ b/communication/src/lib.rs
@@ -88,6 +88,12 @@ extern crate abomonation;
 extern crate timely_bytes as bytes;
 extern crate timely_logging as logging_core;
 
+/// Re-export [timely_container].
+pub mod container {
+    pub use timely_container::*;
+}
+pub use timely_container::Container;
+
 pub mod allocator;
 pub mod networking;
 pub mod initialize;

--- a/communication/src/message.rs
+++ b/communication/src/message.rs
@@ -5,61 +5,8 @@ use bytes::arc::Bytes;
 use abomonation;
 use crate::Data;
 
-/// Either an immutable or mutable reference.
-pub enum RefOrMut<'a, T> where T: 'a {
-    /// An immutable reference.
-    Ref(&'a T),
-    /// A mutable reference.
-    Mut(&'a mut T),
-}
-
-impl<'a, T: 'a> ::std::ops::Deref for RefOrMut<'a, T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        match self {
-            RefOrMut::Ref(reference) => reference,
-            RefOrMut::Mut(reference) => reference,
-        }
-    }
-}
-
-impl<'a, T: 'a> ::std::borrow::Borrow<T> for RefOrMut<'a, T> {
-    fn borrow(&self) -> &T {
-        match self {
-            RefOrMut::Ref(reference) => reference,
-            RefOrMut::Mut(reference) => reference,
-        }
-    }
-}
-
-impl<'a, T: Clone+'a> RefOrMut<'a, T> {
-    /// Extracts the contents of `self`, either by cloning or swapping.
-    ///
-    /// This consumes `self` because its contents are now in an unknown state.
-    pub fn swap<'b>(self, element: &'b mut T) {
-        match self {
-            RefOrMut::Ref(reference) => element.clone_from(reference),
-            RefOrMut::Mut(reference) => ::std::mem::swap(reference, element),
-        };
-    }
-    /// Extracts the contents of `self`, either by cloning or swapping.
-    ///
-    /// This consumes `self` because its contents are now in an unknown state.
-    pub fn replace(self, mut element: T) -> T {
-        self.swap(&mut element);
-        element
-    }
-
-    /// Extracts the contents of `self`, either by cloning, or swapping and leaving a default
-    /// element in place.
-    ///
-    /// This consumes `self` because its contents are now in an unknown state.
-    pub fn take(self) -> T where T: Default {
-        let mut element = Default::default();
-        self.swap(&mut element);
-        element
-    }
-}
+/// Re-export [crate::container::RefOrMut] for backwards compatibility.
+pub use crate::container::RefOrMut;
 
 /// A wrapped message which may be either typed or binary data.
 pub struct Message<T> {

--- a/container/src/lib.rs
+++ b/container/src/lib.rs
@@ -3,6 +3,8 @@
 #![forbid(missing_docs)]
 
 pub mod columnation;
+mod refs;
+pub use refs::RefOrMut;
 
 /// A container transferring data through dataflow edges
 ///

--- a/container/src/refs.rs
+++ b/container/src/refs.rs
@@ -1,0 +1,60 @@
+/// Either an immutable or mutable reference.
+pub enum RefOrMut<'a, T> {
+    /// An immutable reference.
+    Ref(&'a T),
+    /// A mutable reference.
+    Mut(&'a mut T),
+    /// An owned type.
+    Owned(T),
+}
+
+impl<T> ::std::ops::Deref for RefOrMut<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            RefOrMut::Ref(reference) => reference,
+            RefOrMut::Mut(reference) => reference,
+            RefOrMut::Owned(owned) => owned,
+        }
+    }
+}
+
+impl<T> ::std::borrow::Borrow<T> for RefOrMut<'_, T> {
+    fn borrow(&self) -> &T {
+        match self {
+            RefOrMut::Ref(reference) => reference,
+            RefOrMut::Mut(reference) => reference,
+            RefOrMut::Owned(owned) => owned,
+        }
+    }
+}
+
+impl<T: Clone> RefOrMut<'_, T> {
+    /// Extracts the contents of `self`, either by cloning or swapping.
+    ///
+    /// This consumes `self` because its contents are now in an unknown state.
+    pub fn swap<'b>(self, element: &'b mut T) {
+        match self {
+            RefOrMut::Ref(reference) => element.clone_from(reference),
+            RefOrMut::Mut(reference) => ::std::mem::swap(reference, element),
+            RefOrMut::Owned(owned) => *element = owned,
+        };
+    }
+    /// Extracts the contents of `self`, either by cloning or swapping.
+    ///
+    /// This consumes `self` because its contents are now in an unknown state.
+    pub fn replace(self, mut element: T) -> T {
+        self.swap(&mut element);
+        element
+    }
+
+    /// Extracts the contents of `self`, either by cloning, or swapping and leaving a default
+    /// element in place.
+    ///
+    /// This consumes `self` because its contents are now in an unknown state.
+    pub fn take(self) -> T where T: Default {
+        let mut element = Default::default();
+        self.swap(&mut element);
+        element
+    }
+}

--- a/timely/Cargo.toml
+++ b/timely/Cargo.toml
@@ -29,7 +29,6 @@ abomonation_derive = "0.5"
 timely_bytes = { path = "../bytes", version = "0.12" }
 timely_logging = { path = "../logging", version = "0.12" }
 timely_communication = { path = "../communication", version = "0.12", default-features = false }
-timely_container = { path = "../container", version = "0.12" }
 crossbeam-channel = "0.5.0"
 futures-util = "0.3"
 

--- a/timely/src/dataflow/channels/pact.rs
+++ b/timely/src/dataflow/channels/pact.rs
@@ -8,11 +8,11 @@
 //! The progress tracking logic assumes that this number is independent of the pact used.
 
 use std::{fmt::{self, Debug}, marker::PhantomData};
-use timely_container::PushPartitioned;
 
 use crate::communication::{Push, Pull, Data};
 use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
 use crate::Container;
+use crate::container::PushPartitioned;
 
 use crate::worker::AsWorker;
 use crate::dataflow::channels::pushers::Exchange as ExchangePusher;

--- a/timely/src/dataflow/channels/pushers/exchange.rs
+++ b/timely/src/dataflow/channels/pushers/exchange.rs
@@ -1,8 +1,8 @@
 //! The exchange pattern distributes pushed data between many target pushees.
 
-use timely_container::PushPartitioned;
 use crate::{Container, Data};
 use crate::communication::Push;
+use crate::container::PushPartitioned;
 use crate::dataflow::channels::{BundleCore, Message};
 
 // TODO : Software write combining

--- a/timely/src/dataflow/operators/inspect.rs
+++ b/timely/src/dataflow/operators/inspect.rs
@@ -1,9 +1,8 @@
 //! Extension trait and implementation for observing and action on streamed data.
 
 use std::rc::Rc;
-use timely_container::columnation::{Columnation, TimelyStack};
-use crate::Container;
-use crate::Data;
+use crate::{Container, Data};
+use crate::container::columnation::{Columnation, TimelyStack};
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::{Scope, StreamCore};
 use crate::dataflow::operators::generic::Operator;

--- a/timely/src/lib.rs
+++ b/timely/src/lib.rs
@@ -76,10 +76,10 @@ pub use timely_communication::Config as CommunicationConfig;
 pub use worker::Config as WorkerConfig;
 pub use execute::Config as Config;
 
-pub use timely_container::Container;
+pub use timely_communication::Container;
 /// Re-export of the `timely_container` crate.
 pub mod container {
-    pub use timely_container::*;
+    pub use timely_communication::container::*;
 }
 
 /// Re-export of the `timely_communication` crate.


### PR DESCRIPTION
The RefOrMut type previously covered immutable and mutable references to
data. We extend it to cover owned data in addition to the previous variants
to more clearly communicate that the sender doesn't want to hold on to the
data and also cannot accept an allocation instead.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>