### PR TITLE
Update versions for Github CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - run: cargo install mdbook --version 0.4.6
+      - uses: actions/checkout@v3
+      - run: cargo install mdbook --version 0.4.20
       - run: cd mdbook && mdbook build
-      - uses: JamesIves/github-pages-deploy-action@4.0.0
+      - uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: mdbook/book

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,10 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
-    - run: rustup update 1.56.1 --no-self-update && rustup default 1.56.1
+    - uses: actions/checkout@v3
+    - run: rustup update 1.60 --no-self-update && rustup default 1.60
     - run: cargo build
     - name: test mdBook
       # rustdoc doesn't build dependencies, so it needs to run after `cargo build`,


### PR DESCRIPTION
Currently, Timely fails to build in CI. Use the opportunity to upgrade
the CI integration to current versions of all dependencies.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>