### PR TITLE
Use `Antichain` for `MutableAntichain::frontier`.

### DIFF
--- a/timely/src/dataflow/operators/capability.rs
+++ b/timely/src/dataflow/operators/capability.rs
@@ -407,7 +407,7 @@ impl<T: Timestamp> CapabilitySet<T> {
     ///             let mut cap = CapabilitySet::from_elem(default_cap);
     ///             let mut vector = Vec::new();
     ///             move |input, output| {
-    ///                 cap.downgrade(&input.frontier().frontier());
+    ///                 cap.downgrade(input.frontier().frontier());
     ///                 while let Some((time, data)) = input.next() {
     ///                     data.swap(&mut vector);
     ///                 }

--- a/timely/src/dataflow/operators/generic/notificator.rs
+++ b/timely/src/dataflow/operators/generic/notificator.rs
@@ -1,4 +1,4 @@
-use crate::progress::frontier::{AntichainRef, MutableAntichain};
+use crate::progress::frontier::{Antichain, MutableAntichain};
 use crate::progress::Timestamp;
 use crate::dataflow::operators::Capability;
 use crate::logging::TimelyLogger as Logger;
@@ -40,7 +40,7 @@ impl<'a, T: Timestamp> Notificator<'a, T> {
     }
 
     /// Reveals the elements in the frontier of the indicated input.
-    pub fn frontier(&self, input: usize) -> AntichainRef<T> {
+    pub fn frontier(&self, input: usize) -> &Antichain<T> {
         self.frontiers[input].frontier()
     }
 

--- a/timely/src/dataflow/operators/inspect.rs
+++ b/timely/src/dataflow/operators/inspect.rs
@@ -140,7 +140,7 @@ impl<G: Scope, C: Container> InspectCore<G, C> for StreamCore<G, C> {
         let mut frontier = crate::progress::Antichain::from_elem(G::Timestamp::minimum());
         let mut vector = Default::default();
         self.unary_frontier(Pipeline, "InspectBatch", move |_,_| move |input, output| {
-            if input.frontier.frontier() != frontier.borrow() {
+            if input.frontier.frontier() != &frontier {
                 frontier.clear();
                 frontier.extend(input.frontier.frontier().iter().cloned());
                 func(Err(frontier.elements()));

--- a/timely/src/dataflow/operators/probe.rs
+++ b/timely/src/dataflow/operators/probe.rs
@@ -167,7 +167,7 @@ impl<T: Timestamp> Handle<T> {
     /// ```
     #[inline]
     pub fn with_frontier<R, F: FnMut(AntichainRef<T>)->R>(&self, mut function: F) -> R {
-        function(self.frontier.borrow().frontier())
+        function(self.frontier.borrow().frontier().borrow())
     }
 }
 


### PR DESCRIPTION
This PR converts `MutableAntichain::frontier` from a `Vec<T>` to an `Antichain<T>`. In addition to a bit more code reuse, this allows `MutableAntichain` to expose a `&Antichain<T>` type rather than an `AntichainRef<T>`, which can be annoying to relate back to antichains (e.g. to `join` with, say). One can always go from an `&Antichain<T>` to an `AntichainRef<T>` with the `borrow()` method, but not the other way around.

The downside to scrutinize is the moment where we update `frontier` rebuilding the antichain. To my eyes, we do almost the same linear work per element, except that we additionally consider evicting elements that we know we wont have to evict. I'm ok losing that performance for the type clarity, or perhaps adding some `from_ordered_iter` to `Antichain`.

cc: @jkosh44