### PR TITLE
Make TCP communication fabric generic over network protocol

### DIFF
--- a/communication/src/allocator/zero_copy/initialize.rs
+++ b/communication/src/allocator/zero_copy/initialize.rs
@@ -6,6 +6,7 @@ use crate::allocator::process::ProcessBuilder;
 use crate::networking::create_sockets;
 use super::tcp::{send_loop, recv_loop};
 use super::allocator::{TcpBuilder, new_vector};
+use super::stream::Stream;
 
 /// Join handles for send and receive threads.
 ///
@@ -52,8 +53,8 @@ pub fn initialize_networking(
 ///
 /// It is important that the `sockets` argument contain sockets for each remote process, in order, and
 /// with position `my_index` set to `None`.
-pub fn initialize_networking_from_sockets(
-    mut sockets: Vec<Option<std::net::TcpStream>>,
+pub fn initialize_networking_from_sockets<S: Stream + 'static>(
+    mut sockets: Vec<Option<S>>,
     my_index: usize,
     threads: usize,
     log_sender: Box<dyn Fn(CommunicationSetup)->Option<Logger<CommunicationEvent, CommunicationSetup>>+Send+Sync>)

--- a/communication/src/allocator/zero_copy/mod.rs
+++ b/communication/src/allocator/zero_copy/mod.rs
@@ -11,3 +11,4 @@ pub mod allocator;
 pub mod allocator_process;
 pub mod initialize;
 pub mod push_pull;
+pub mod stream;

--- a/communication/src/allocator/zero_copy/stream.rs
+++ b/communication/src/allocator/zero_copy/stream.rs
@@ -1,0 +1,47 @@
+//! Abstractions over network streams.
+
+use std::io;
+use std::net::{TcpStream, Shutdown};
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
+
+/// An abstraction over network streams.
+pub trait Stream: Sized + Send + Sync + io::Read + io::Write {
+    /// Creates a new independently owned handle to the underlying stream.
+    fn try_clone(&self) -> io::Result<Self>;
+
+    /// Moves this stream into or out of nonblocking mode.
+    fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()>;
+
+    /// Shuts down the read, write, or both halves of this connection.
+    fn shutdown(&self, how: Shutdown) -> io::Result<()>;
+}
+
+impl Stream for TcpStream {
+    fn try_clone(&self) -> io::Result<Self> {
+        self.try_clone()
+    }
+
+    fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
+        self.set_nonblocking(nonblocking)
+    }
+
+    fn shutdown(&self, how: Shutdown) -> io::Result<()> {
+        self.shutdown(how)
+    }
+}
+
+#[cfg(unix)]
+impl Stream for UnixStream {
+    fn try_clone(&self) -> io::Result<Self> {
+        self.try_clone()
+    }
+
+    fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
+        self.set_nonblocking(nonblocking)
+    }
+
+    fn shutdown(&self, how: Shutdown) -> io::Result<()> {
+        self.shutdown(how)
+    }
+}


### PR DESCRIPTION
This commit makes the communication fabric that was previously specific to TCP generic over the network protocol. Most practically this allows executing a timely computation over Unix domain sockets, which is useful in development, but in theory any network protocol that satisfies the new `Stream` trait could be used.