### PR TITLE
timely: unconstrained lifetime for `CapabilityRef`

### DIFF
--- a/timely/src/dataflow/channels/pullers/counter.rs
+++ b/timely/src/dataflow/channels/pullers/counter.rs
@@ -16,15 +16,23 @@ pub struct Counter<T: Ord+Clone+'static, D, P: Pull<BundleCore<T, D>>> {
 }
 
 /// A guard type that updates the change batch counts on drop
-pub struct ConsumedGuard<'a, T: Ord + Clone + 'static> {
-    consumed: &'a Rc<RefCell<ChangeBatch<T>>>,
+pub struct ConsumedGuard<T: Ord + Clone + 'static> {
+    consumed: Rc<RefCell<ChangeBatch<T>>>,
     time: Option<T>,
     len: usize,
 }
 
-impl<'a, T:Ord+Clone+'static> Drop for ConsumedGuard<'a, T> {
+impl<T:Ord+Clone+'static> ConsumedGuard<T> {
+    pub(crate) fn time(&self) -> &T {
+        &self.time.as_ref().unwrap()
+    }
+}
+
+impl<T:Ord+Clone+'static> Drop for ConsumedGuard<T> {
     fn drop(&mut self) {
-        self.consumed.borrow_mut().update(self.time.take().unwrap(), self.len as i64);
+        // SAFETY: we're in a Drop impl, so this runs at most once
+        let time = self.time.take().unwrap();
+        self.consumed.borrow_mut().update(time, self.len as i64);
     }
 }
 
@@ -36,11 +44,11 @@ impl<T:Ord+Clone+'static, D: Container, P: Pull<BundleCore<T, D>>> Counter<T, D,
     }
 
     #[inline]
-    pub(crate) fn next_guarded(&mut self) -> Option<(ConsumedGuard<'_, T>, &mut BundleCore<T, D>)> {
+    pub(crate) fn next_guarded(&mut self) -> Option<(ConsumedGuard<T>, &mut BundleCore<T, D>)> {
         if let Some(message) = self.pullable.pull() {
             if message.data.len() > 0 {
                 let guard = ConsumedGuard {
-                    consumed: &self.consumed,
+                    consumed: Rc::clone(&self.consumed),
                     time: Some(message.time.clone()),
                     len: message.data.len(),
                 };

--- a/timely/src/dataflow/operators/mod.rs
+++ b/timely/src/dataflow/operators/mod.rs
@@ -62,4 +62,4 @@ pub mod count;
 
 // keep "mint" module-private
 mod capability;
-pub use self::capability::{ActivateCapability, Capability, CapabilityRef, CapabilitySet, DowngradeError};
+pub use self::capability::{ActivateCapability, Capability, InputCapability, CapabilitySet, DowngradeError};


### PR DESCRIPTION
Since the merge of https://github.com/TimelyDataflow/timely-dataflow/pull/429, `CapabilityRef`s have been made safe to hold onto across operator invocations because that PR made sure that they only decremented their progress counts on `Drop`. While this allowed `async`/`await` based operators to freely hold on to them, it was still very difficult for synchronous based operators to do the same thing, due to the lifetime attached to the `CapabilityRef`.

We can observe that the lifetime no longer provides any benefits, which means it can be removed and turn `CapabilityRef`s into fully owned values. This allows any style of operator to easily hold on to them. The benefit of that isn't just performance (by avoiding the `retain()` dance), but also about deferring the decision of the output port a given input should flow to to a later time.

After making this change, the name `CapabilityRef` felt wrong, since there is no reference to anything anymore. Instead, the main distinction between `CapabilityRef`s and `Capabilities` are that the former is associated with an input port and the latter is associated with an output port.

As such, I have renamed `CapabilityRef` to `InputCapability` to signal to users that holding onto one of them represents holding onto a timestamp at the input for which we have not yet determined the output port that it should flow to. This nicely ties up the semantics of the `InputCapability::retain_for_output` and `InputCapability::delayed_for_output` methods, which make it clear by their name and signature that this is what "transfers" the capability from input ports to output ports.