### PR TITLE
channels: add `Distribute` pact

### DIFF
--- a/timely/Cargo.toml
+++ b/timely/Cargo.toml
@@ -21,6 +21,7 @@ bincode= ["timely_communication/bincode"]
 getopts = ["getopts-dep", "timely_communication/getopts"]
 
 [dependencies]
+fnv="1.0.2"
 getopts-dep = { package = "getopts", version = "0.2.14", optional = true }
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
This PR adds the `Distribute` pact that aims to evenly distribute data among all workers by routing each container to a randomly selected worker.

Traditionally this "defensive distribution" could be implemented using an `Exchange` pact whose key function round-robined the records or randomly distributed them in some other way. While this works it has couple of downsides:
* The key function is calculated once per record, instead of once per container
* Each record must be copied out of the original container into a per-worker container depending on the key function

The `Distribute` pact streamlines this pattern by avoiding copying each record to a separate container and immediately pushing each container to a random worker.

### Future work

A potential future improvement is to circulate in-band statistics over the channel about how many messages each workers has seen. This would allow each worker to estimate the current skew and only leap into action once things are bad enough.