### PR TITLE
update rustc in CI to 1.64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    - run: rustup update 1.60 --no-self-update && rustup default 1.60
+    - run: rustup update 1.64 --no-self-update && rustup default 1.64
     - run: cargo build
     - name: test mdBook
       # rustdoc doesn't build dependencies, so it needs to run after `cargo build`,


### PR DESCRIPTION
Tests for the kafkaesque example started failing because it depends on `clap` which now requires rustc `1.64`. We could change the deps of the example but updating rustc seems like a good anything anyway.