### PR TITLE
Inline give for Buffer

### DIFF
--- a/timely/src/dataflow/channels/pushers/buffer.rs
+++ b/timely/src/dataflow/channels/pushers/buffer.rs
@@ -81,6 +81,7 @@ impl<T, C: Container, P: Push<BundleCore<T, C>>> BufferCore<T, C, P> where T: Eq
 
 impl<T, D: Data, P: Push<Bundle<T, D>>> Buffer<T, D, P> where T: Eq+Clone {
     // internal method for use by `Session`.
+    #[inline]
     fn give(&mut self, data: D) {
         if self.buffer.capacity() < crate::container::buffer::default_capacity::<D>() {
             let to_reserve = crate::container::buffer::default_capacity::<D>() - self.buffer.capacity();


### PR DESCRIPTION
This fixes a regression introduced by #426 where BufferCore::give now lacked the inline annotation. In pingpong, this changes the runtime as follows:

Without inline:
```
target/release/examples/pingpong 1 500000000 -w1  2.45s user 0.00s system 99% cpu 2.446 total
```

With inline:
```
target/release/examples/pingpong 1 500000000 -w1  1.75s user 0.00s system 99% cpu 1.755 total
```