### PR TITLE
publicly expose the `capability` module

### DIFF
--- a/timely/src/dataflow/operators/capability.rs
+++ b/timely/src/dataflow/operators/capability.rs
@@ -34,9 +34,10 @@ use crate::scheduling::Activations;
 use crate::dataflow::channels::pullers::counter::ConsumedGuard;
 
 /// An internal trait expressing the capability to send messages with a given timestamp.
-pub trait CapabilityTrait<T: Timestamp> {
+pub trait CapabilityTrait<T: Timestamp>: private::Sealed {
     /// The timestamp associated with the capability.
     fn time(&self) -> &T;
+    /// Checks if this capability is valid for the output port associated with `query_buffer`
     fn valid_for_output(&self, query_buffer: &Rc<RefCell<ChangeBatch<T>>>) -> bool;
 }
 
@@ -51,6 +52,18 @@ impl<'a, T: Timestamp, C: CapabilityTrait<T>> CapabilityTrait<T> for &'a mut C {
     fn valid_for_output(&self, query_buffer: &Rc<RefCell<ChangeBatch<T>>>) -> bool {
         (**self).valid_for_output(query_buffer)
     }
+}
+
+mod private {
+    use crate::progress::Timestamp;
+
+    pub trait Sealed {}
+
+    impl<'a, C: Sealed> Sealed for &'a C { }
+    impl<'a, C: Sealed> Sealed for &'a mut C { }
+    impl<T: Timestamp> Sealed for super::Capability<T> { }
+    impl<T: Timestamp> Sealed for super::InputCapability<T> { }
+    impl<T: Timestamp> Sealed for super::ActivateCapability<T> { }
 }
 
 /// The capability to send data with a certain timestamp on a dataflow edge.

--- a/timely/src/dataflow/operators/mod.rs
+++ b/timely/src/dataflow/operators/mod.rs
@@ -60,6 +60,5 @@ pub mod generic;
 pub mod reclock;
 pub mod count;
 
-// keep "mint" module-private
-mod capability;
+pub mod capability;
 pub use self::capability::{ActivateCapability, Capability, InputCapability, CapabilitySet, DowngradeError};


### PR DESCRIPTION
The `CapabilityTrait` trait is part of the public API of `timely` (e.g `OutputHandle::session` expects one), but the trait itself is not publicly accessible.

This is because implementing this trait would circumvent the safety properties of capabilities. However, not exposing it also prevents safe wrapping of handles to provide additional functionality on top of them.

This PR offers a solution by making the `capability` module public and using the [sealed trait
pattern](https://rust-lang.github.io/api-guidelines/future-proofing.html) to prevent any foreign crate from implementing `CapabilityTrait`.