### PR TITLE
Remove core

### DIFF
--- a/kafkaesque/src/bin/capture_recv.rs
+++ b/kafkaesque/src/bin/capture_recv.rs
@@ -3,7 +3,6 @@ use timely::dataflow::operators::capture::Replay;
 use timely::dataflow::operators::Accumulate;
 
 use rdkafka::config::ClientConfig;
-
 use kafkaesque::EventConsumer;
 
 fn main() {
@@ -31,7 +30,7 @@ fn main() {
             .filter(|i| i % worker.peers() == worker.index())
             .map(|i| {
                 let topic = format!("{}-{:?}", topic, i);
-                EventConsumer::<_,u64>::new(consumer_config.clone(), topic)
+                EventConsumer::<_, Vec<u64>>::new(consumer_config.clone(), topic)
             })
             .collect::<Vec<_>>();
 

--- a/kafkaesque/src/bin/capture_send.rs
+++ b/kafkaesque/src/bin/capture_send.rs
@@ -2,7 +2,6 @@ use timely::dataflow::operators::ToStream;
 use timely::dataflow::operators::capture::Capture;
 
 use rdkafka::config::ClientConfig;
-
 use kafkaesque::EventProducer;
 
 fn main() {
@@ -20,7 +19,7 @@ fn main() {
             .set("bootstrap.servers", brokers);
 
         let topic = format!("{}-{:?}", topic, worker.index());
-        let producer = EventProducer::new(producer_config, topic);
+        let producer = EventProducer::<u64, Vec<u64>>::new(producer_config, topic);
 
         worker.dataflow::<u64,_,_>(|scope|
             (0 .. count)

--- a/kafkaesque/src/kafka_source.rs
+++ b/kafkaesque/src/kafka_source.rs
@@ -1,11 +1,11 @@
 use timely::Data;
 use timely::dataflow::{Scope, Stream};
 use timely::dataflow::operators::Capability;
-use timely::dataflow::operators::generic::OutputHandle;
 use timely::dataflow::channels::pushers::Tee;
 
 use rdkafka::Message;
 use rdkafka::consumer::{ConsumerContext, BaseConsumer};
+use timely::dataflow::operators::generic::OutputHandleCore;
 
 /// Constructs a stream of data from a Kafka consumer.
 ///
@@ -96,7 +96,7 @@ where
     D: Data,
     L: Fn(&[u8],
           &mut Capability<G::Timestamp>,
-          &mut OutputHandle<G::Timestamp, D, Tee<G::Timestamp, D>>) -> bool+'static,
+          &mut OutputHandleCore<G::Timestamp, Vec<D>, Tee<G::Timestamp, D>>) -> bool+'static,
 {
     use timely::dataflow::operators::generic::source;
     source(scope, name, move |capability, info| {

--- a/kafkaesque/src/kafka_source.rs
+++ b/kafkaesque/src/kafka_source.rs
@@ -1,5 +1,5 @@
 use timely::Data;
-use timely::dataflow::{Scope, Stream};
+use timely::dataflow::{Scope, StreamCore};
 use timely::dataflow::operators::Capability;
 use timely::dataflow::operators::generic::OutputHandle;
 use timely::dataflow::channels::pushers::Tee;
@@ -89,7 +89,7 @@ pub fn kafka_source<C, G, D, L>(
     name: &str,
     consumer: BaseConsumer<C>,
     logic: L
-) -> Stream<G, D>
+) -> StreamCore<G, Vec<D>>
 where
     C: ConsumerContext+'static,
     G: Scope,

--- a/kafkaesque/src/kafka_source.rs
+++ b/kafkaesque/src/kafka_source.rs
@@ -1,5 +1,5 @@
 use timely::Data;
-use timely::dataflow::{Scope, StreamCore};
+use timely::dataflow::{Scope, Stream};
 use timely::dataflow::operators::Capability;
 use timely::dataflow::operators::generic::OutputHandle;
 use timely::dataflow::channels::pushers::Tee;
@@ -89,7 +89,7 @@ pub fn kafka_source<C, G, D, L>(
     name: &str,
     consumer: BaseConsumer<C>,
     logic: L
-) -> StreamCore<G, Vec<D>>
+) -> Stream<G, Vec<D>>
 where
     C: ConsumerContext+'static,
     G: Scope,

--- a/kafkaesque/src/kafka_source.rs
+++ b/kafkaesque/src/kafka_source.rs
@@ -3,7 +3,7 @@ use timely::dataflow::{Scope, Stream};
 use timely::dataflow::operators::Capability;
 use rdkafka::Message;
 use rdkafka::consumer::{ConsumerContext, BaseConsumer};
-use timely::dataflow::channels::pushers::TeeCore;
+use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::generic::OutputHandle;
 
 /// Constructs a stream of data from a Kafka consumer.
@@ -95,7 +95,7 @@ where
     D: Data,
     L: Fn(&[u8],
           &mut Capability<G::Timestamp>,
-          &mut OutputHandle<G::Timestamp, Vec<D>, TeeCore<G::Timestamp, Vec<D>>>) -> bool+'static,
+          &mut OutputHandle<G::Timestamp, Vec<D>, Tee<G::Timestamp, Vec<D>>>) -> bool+'static,
 {
     use timely::dataflow::operators::generic::source;
     source(scope, name, move |capability, info| {

--- a/kafkaesque/src/kafka_source.rs
+++ b/kafkaesque/src/kafka_source.rs
@@ -1,10 +1,9 @@
 use timely::Data;
 use timely::dataflow::{Scope, Stream};
 use timely::dataflow::operators::Capability;
-use timely::dataflow::channels::pushers::Tee;
-
 use rdkafka::Message;
 use rdkafka::consumer::{ConsumerContext, BaseConsumer};
+use timely::dataflow::channels::pushers::TeeCore;
 use timely::dataflow::operators::generic::OutputHandle;
 
 /// Constructs a stream of data from a Kafka consumer.
@@ -96,7 +95,7 @@ where
     D: Data,
     L: Fn(&[u8],
           &mut Capability<G::Timestamp>,
-          &mut OutputHandle<G::Timestamp, Vec<D>, Tee<G::Timestamp, D>>) -> bool+'static,
+          &mut OutputHandle<G::Timestamp, Vec<D>, TeeCore<G::Timestamp, Vec<D>>>) -> bool+'static,
 {
     use timely::dataflow::operators::generic::source;
     source(scope, name, move |capability, info| {

--- a/kafkaesque/src/kafka_source.rs
+++ b/kafkaesque/src/kafka_source.rs
@@ -5,7 +5,7 @@ use timely::dataflow::channels::pushers::Tee;
 
 use rdkafka::Message;
 use rdkafka::consumer::{ConsumerContext, BaseConsumer};
-use timely::dataflow::operators::generic::OutputHandleCore;
+use timely::dataflow::operators::generic::OutputHandle;
 
 /// Constructs a stream of data from a Kafka consumer.
 ///
@@ -96,7 +96,7 @@ where
     D: Data,
     L: Fn(&[u8],
           &mut Capability<G::Timestamp>,
-          &mut OutputHandleCore<G::Timestamp, Vec<D>, Tee<G::Timestamp, D>>) -> bool+'static,
+          &mut OutputHandle<G::Timestamp, Vec<D>, Tee<G::Timestamp, D>>) -> bool+'static,
 {
     use timely::dataflow::operators::generic::source;
     source(scope, name, move |capability, info| {

--- a/kafkaesque/src/lib.rs
+++ b/kafkaesque/src/lib.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicIsize, Ordering};
 
 use abomonation::Abomonation;
-use timely::dataflow::operators::capture::event::{EventCore, EventPusherCore, EventIteratorCore};
+use timely::dataflow::operators::capture::event::{EventCore, EventPusher, EventIteratorCore};
 
 use rdkafka::Message;
 use rdkafka::client::ClientContext;
@@ -62,7 +62,7 @@ impl<T, D> EventProducer<T, D> {
     }
 }
 
-impl<T: Abomonation, D: Abomonation> EventPusherCore<T, D> for EventProducer<T, D> {
+impl<T: Abomonation, D: Abomonation> EventPusher<T, D> for EventProducer<T, D> {
     fn push(&mut self, event: EventCore<T, D>) {
         unsafe { ::abomonation::encode(&event, &mut self.buffer).expect("Encode failure"); }
         // println!("sending {:?} bytes", self.buffer.len());

--- a/kafkaesque/src/lib.rs
+++ b/kafkaesque/src/lib.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicIsize, Ordering};
 
 use abomonation::Abomonation;
-use timely::dataflow::operators::capture::event::{Event, EventPusher, EventIteratorCore};
+use timely::dataflow::operators::capture::event::{Event, EventPusher, EventIterator};
 
 use rdkafka::Message;
 use rdkafka::client::ClientContext;
@@ -102,7 +102,7 @@ impl<T, D> EventConsumer<T, D> {
     }
 }
 
-impl<T: Abomonation, D: Abomonation> EventIteratorCore<T, D> for EventConsumer<T, D> {
+impl<T: Abomonation, D: Abomonation> EventIterator<T, D> for EventConsumer<T, D> {
     fn next(&mut self) -> Option<&Event<T, D>> {
         if let Some(result) = self.consumer.poll(std::time::Duration::from_millis(0)) {
             match result {

--- a/kafkaesque/src/lib.rs
+++ b/kafkaesque/src/lib.rs
@@ -82,16 +82,13 @@ impl<T, D> Drop for EventProducer<T, D> {
 }
 
 /// A Wrapper for `R: Read` implementing `EventIterator<T, D>`.
-pub struct EventConsumerCore<T, D> {
+pub struct EventConsumer<T, D> {
     consumer: BaseConsumer<DefaultConsumerContext>,
     buffer: Vec<u8>,
     phant: ::std::marker::PhantomData<(T,D)>,
 }
 
-/// [EventConsumerCore] specialized to vector-based containers.
-pub type EventConsumer<T, D> = EventConsumerCore<T, Vec<D>>;
-
-impl<T, D> EventConsumerCore<T, D> {
+impl<T, D> EventConsumer<T, D> {
     /// Allocates a new `EventReader` wrapping a supplied reader.
     pub fn new(config: ClientConfig, topic: String) -> Self {
         println!("allocating consumer for topic {:?}", topic);
@@ -105,7 +102,7 @@ impl<T, D> EventConsumerCore<T, D> {
     }
 }
 
-impl<T: Abomonation, D: Abomonation> EventIteratorCore<T, D> for EventConsumerCore<T, D> {
+impl<T: Abomonation, D: Abomonation> EventIteratorCore<T, D> for EventConsumer<T, D> {
     fn next(&mut self) -> Option<&Event<T, D>> {
         if let Some(result) = self.consumer.poll(std::time::Duration::from_millis(0)) {
             match result {

--- a/mdbook/src/chapter_2/chapter_2_1.md
+++ b/mdbook/src/chapter_2/chapter_2_1.md
@@ -16,7 +16,7 @@ fn main() {
     // initializes and runs a timely dataflow.
     timely::execute_from_args(std::env::args(), |worker| {
 
-        let mut input = InputHandle::<(), String>::new();
+        let mut input = InputHandle::<(), Vec<String>>::new();
 
         // define a new dataflow
         worker.dataflow(|scope| {

--- a/mdbook/src/chapter_4/chapter_4_4.md
+++ b/mdbook/src/chapter_4/chapter_4_4.md
@@ -52,7 +52,7 @@ One nice aspect of `capture_into` is that it really does reveal everything that 
 At *its* core, `replay_into` takes some sequence of `Event<T, D>` items and reproduces the stream, as it was recorded. It is also fairly simple, and we can just look at its implementation as well:
 
 ```rust,ignore
-    fn replay_into<S: Scope<Timestamp=T>>(self, scope: &mut S) -> Stream<S, D>{
+    fn replay_into<S: Scope<Timestamp=T>>(self, scope: &mut S) -> StreamCore<S, Vec<D>>{
 
         let mut builder = OperatorBuilder::new("Replay".to_owned(), scope.clone());
         let (targets, stream) = builder.new_output();

--- a/mdbook/src/chapter_4/chapter_4_4.md
+++ b/mdbook/src/chapter_4/chapter_4_4.md
@@ -52,7 +52,7 @@ One nice aspect of `capture_into` is that it really does reveal everything that 
 At *its* core, `replay_into` takes some sequence of `Event<T, D>` items and reproduces the stream, as it was recorded. It is also fairly simple, and we can just look at its implementation as well:
 
 ```rust,ignore
-    fn replay_into<S: Scope<Timestamp=T>>(self, scope: &mut S) -> StreamCore<S, Vec<D>>{
+    fn replay_into<S: Scope<Timestamp=T>>(self, scope: &mut S) -> Stream<S, Vec<D>>{
 
         let mut builder = OperatorBuilder::new("Replay".to_owned(), scope.clone());
         let (targets, stream) = builder.new_output();

--- a/mdbook/src/chapter_5/chapter_5_3.md
+++ b/mdbook/src/chapter_5/chapter_5_3.md
@@ -8,15 +8,10 @@ Many parts of Timely assume that data is organized into `Vec<T>`, i.e., batches 
 This abstractions works well for many cases but precludes some advanced techniques, such as transferring translated or columnar data between operators.
 With the container abstraction, Timely specifies a minimal interface it requires tracking progress and provide data to operators.
 
-## Core operators
-
-In Timely, we provide a set of `Core` operators that are generic on the container type they can handle.
-In most cases, the `Core` operators are a immediate generalization of their non-core variant, providing the semantically equivalent functionality.
-
 ## Limitations
 
 A challenge when genericizing Timely operators is that all interfaces need to be declared independent of a concrete type, for example as part of a trait.
-For this reason, Timely doesn't currently support operators that require knowledge of the elements of a container or how to partition a container, with the only exception being the `Vec` type.
+For this reason, Timely doesn't currently support operators that require knowledge of the elements of a container, with the only exception being the `Vec` type.
 
 ## A custom container
 

--- a/timely/examples/barrier.rs
+++ b/timely/examples/barrier.rs
@@ -11,7 +11,7 @@ fn main() {
     timely::execute_from_args(std::env::args().skip(2), move |worker| {
 
         worker.dataflow(move |scope| {
-            let (handle, stream) = scope.feedback::<usize>(1);
+            let (handle, stream) = scope.feedback::<Vec<usize>>(1);
             stream.unary_notify(
                 Pipeline,
                 "Barrier",

--- a/timely/examples/bfs.rs
+++ b/timely/examples/bfs.rs
@@ -44,7 +44,7 @@ fn main() {
                 .to_stream(scope);
 
             // define a loop variable, for the (node, worker) pairs.
-            let (handle, stream) = scope.feedback(1usize);
+            let (handle, stream) = scope.feedback::<Vec<_>>(1usize);
 
             // use the stream of edges
             graph.binary_notify(
@@ -58,7 +58,7 @@ fn main() {
                     // receive edges, start to sort them
                     input1.for_each(|time, data| {
                         notify.notify_at(time.retain());
-                        edge_list.push(data.replace(Vec::new()));
+                        edge_list.push(data.take());
                     });
 
                     // receive (node, worker) pairs, note any new ones.
@@ -68,7 +68,7 @@ fn main() {
                                       notify.notify_at(time.retain());
                                       Vec::new()
                                   })
-                                  .push(data.replace(Vec::new()));
+                                  .push(data.take());
                     });
 
                     notify.for_each(|time, _num, _notify| {

--- a/timely/examples/capture_recv.rs
+++ b/timely/examples/capture_recv.rs
@@ -17,7 +17,7 @@ fn main() {
             .collect::<Vec<_>>()
             .into_iter()
             .map(|l| l.incoming().next().unwrap().unwrap())
-            .map(|r| EventReader::<_,u64,_>::new(r))
+            .map(|r| EventReader::<_, Vec<u64>, _>::new(r))
             .collect::<Vec<_>>();
 
         worker.dataflow::<u64,_,_>(|scope| {

--- a/timely/examples/distinct.rs
+++ b/timely/examples/distinct.rs
@@ -11,7 +11,7 @@ fn main() {
     // initializes and runs a timely dataflow.
     timely::execute_from_args(std::env::args(), |worker| {
         let index = worker.index();
-        let mut input = InputHandle::new();
+        let mut input = InputHandle::<_, Vec<_>>::new();
         let mut probe = ProbeHandle::new();
 
         // create a new input, exchange data, and inspect its output

--- a/timely/examples/hashjoin.rs
+++ b/timely/examples/hashjoin.rs
@@ -22,8 +22,8 @@ fn main() {
         let index = worker.index();
         let peers = worker.peers();
 
-        let mut input1 = InputHandle::new();
-        let mut input2 = InputHandle::new();
+        let mut input1 = InputHandle::<_, Vec<_>>::new();
+        let mut input2 = InputHandle::<_, Vec<_>>::new();
         let mut probe = ProbeHandle::new();
 
         worker.dataflow(|scope| {

--- a/timely/examples/logging-recv.rs
+++ b/timely/examples/logging-recv.rs
@@ -20,7 +20,7 @@ fn main() {
             .collect::<Vec<_>>()
             .into_iter()
             .map(|l| l.incoming().next().unwrap().unwrap())
-            .map(|r| EventReader::<Duration,(Duration,TimelySetup,TimelyEvent),_>::new(r))
+            .map(|r| EventReader::<Duration, Vec<(Duration, TimelySetup, TimelyEvent)>, _>::new(r))
             .collect::<Vec<_>>();
 
         worker.dataflow(|scope| {

--- a/timely/examples/pagerank.rs
+++ b/timely/examples/pagerank.rs
@@ -22,7 +22,7 @@ fn main() {
             let edge_stream = input.to_stream(scope);
 
             // create a new feedback stream, which will be changes to ranks.
-            let (handle, rank_stream) = scope.feedback(1);
+            let (handle, rank_stream) = scope.feedback::<Vec<_>>(1);
 
             // bring edges and ranks together!
             let changes = edge_stream.binary_frontier(

--- a/timely/examples/pagerank.rs
+++ b/timely/examples/pagerank.rs
@@ -13,7 +13,7 @@ fn main() {
 
     timely::execute_from_args(std::env::args().skip(3), move |worker| {
 
-        let mut input = InputHandle::new();
+        let mut input = InputHandle::<_, Vec<_>>::new();
         let mut probe = ProbeHandle::new();
 
         worker.dataflow::<usize,_,_>(|scope| {

--- a/timely/examples/unionfind.rs
+++ b/timely/examples/unionfind.rs
@@ -54,8 +54,8 @@ trait UnionFind {
     fn union_find(&self) -> Self;
 }
 
-impl<G: Scope> UnionFind for StreamCore<G, Vec<(usize, usize)>> {
-    fn union_find(&self) -> StreamCore<G, Vec<(usize, usize)>> {
+impl<G: Scope> UnionFind for Stream<G, Vec<(usize, usize)>> {
+    fn union_find(&self) -> Stream<G, Vec<(usize, usize)>> {
 
         self.unary(Pipeline, "UnionFind", |_,_| {
 

--- a/timely/examples/unionfind.rs
+++ b/timely/examples/unionfind.rs
@@ -54,8 +54,8 @@ trait UnionFind {
     fn union_find(&self) -> Self;
 }
 
-impl<G: Scope> UnionFind for Stream<G, (usize, usize)> {
-    fn union_find(&self) -> Stream<G, (usize, usize)> {
+impl<G: Scope> UnionFind for StreamCore<G, Vec<(usize, usize)>> {
+    fn union_find(&self) -> StreamCore<G, Vec<(usize, usize)>> {
 
         self.unary(Pipeline, "UnionFind", |_,_| {
 

--- a/timely/src/dataflow/channels/mod.rs
+++ b/timely/src/dataflow/channels/mod.rs
@@ -11,7 +11,7 @@ pub mod pullers;
 pub mod pact;
 
 /// The input to and output from timely dataflow communication channels.
-pub type BundleCore<T, D> = crate::communication::Message<Message<T, D>>;
+pub type Bundle<T, D> = crate::communication::Message<Message<T, D>>;
 
 /// A serializable representation of timestamped data.
 #[derive(Clone, Abomonation, Serialize, Deserialize)]
@@ -43,11 +43,11 @@ impl<T, D: Container> Message<T, D> {
     /// Forms a message, and pushes contents at `pusher`. Replaces `buffer` with what the pusher
     /// leaves in place, or the container's default element.
     #[inline]
-    pub fn push_at<P: Push<BundleCore<T, D>>>(buffer: &mut D, time: T, pusher: &mut P) {
+    pub fn push_at<P: Push<Bundle<T, D>>>(buffer: &mut D, time: T, pusher: &mut P) {
 
         let data = ::std::mem::take(buffer);
         let message = Message::new(time, data, 0, 0);
-        let mut bundle = Some(BundleCore::from_typed(message));
+        let mut bundle = Some(Bundle::from_typed(message));
 
         pusher.push(&mut bundle);
 

--- a/timely/src/dataflow/channels/mod.rs
+++ b/timely/src/dataflow/channels/mod.rs
@@ -13,9 +13,6 @@ pub mod pact;
 /// The input to and output from timely dataflow communication channels.
 pub type BundleCore<T, D> = crate::communication::Message<Message<T, D>>;
 
-/// The input to and output from timely dataflow communication channels specialized to vectors.
-pub type Bundle<T, D> = BundleCore<T, Vec<D>>;
-
 /// A serializable representation of timestamped data.
 #[derive(Clone, Abomonation, Serialize, Deserialize)]
 pub struct Message<T, D> {

--- a/timely/src/dataflow/channels/pact.rs
+++ b/timely/src/dataflow/channels/pact.rs
@@ -31,11 +31,6 @@ pub trait ParallelizationContractCore<T, D> {
     fn connect<A: AsWorker>(self, allocator: &mut A, identifier: usize, address: &[usize], logging: Option<Logger>) -> (Self::Pusher, Self::Puller);
 }
 
-/// A `ParallelizationContractCore` specialized for `Vec` containers
-/// TODO: Use trait aliases once stable.
-pub trait ParallelizationContract<T, D: Clone>: ParallelizationContractCore<T, Vec<D>> { }
-impl<T, D: Clone, P: ParallelizationContractCore<T, Vec<D>>> ParallelizationContract<T, D> for P { }
-
 /// A direct connection
 #[derive(Debug)]
 pub struct Pipeline;

--- a/timely/src/dataflow/channels/pact.rs
+++ b/timely/src/dataflow/channels/pact.rs
@@ -48,15 +48,12 @@ impl<T: 'static, D: Container> ParallelizationContract<T, D> for Pipeline {
 }
 
 /// An exchange between multiple observers by data
-pub struct ExchangeCore<C, D, F> { hash_func: F, phantom: PhantomData<(C, D)> }
+pub struct Exchange<C, D, F> { hash_func: F, phantom: PhantomData<(C, D)> }
 
-/// [ExchangeCore] specialized to vector-based containers.
-pub type Exchange<D, F> = ExchangeCore<Vec<D>, D, F>;
-
-impl<C, D, F: FnMut(&D)->u64+'static> ExchangeCore<C, D, F> {
+impl<C, D, F: FnMut(&D)->u64+'static> Exchange<C, D, F> {
     /// Allocates a new `Exchange` pact from a distribution function.
-    pub fn new(func: F) -> ExchangeCore<C, D, F> {
-        ExchangeCore {
+    pub fn new(func: F) -> Exchange<C, D, F> {
+        Self {
             hash_func:  func,
             phantom:    PhantomData,
         }
@@ -64,7 +61,7 @@ impl<C, D, F: FnMut(&D)->u64+'static> ExchangeCore<C, D, F> {
 }
 
 // Exchange uses a `Box<Pushable>` because it cannot know what type of pushable will return from the allocator.
-impl<T: Timestamp, C, D: Data+Clone, F: FnMut(&D)->u64+'static> ParallelizationContract<T, C> for ExchangeCore<C, D, F>
+impl<T: Timestamp, C, D: Data+Clone, F: FnMut(&D)->u64+'static> ParallelizationContract<T, C> for Exchange<C, D, F>
 where
     C: Data + Container + PushPartitioned<Item=D>,
 {
@@ -78,7 +75,7 @@ where
     }
 }
 
-impl<C, D, F> Debug for ExchangeCore<C, D, F> {
+impl<C, D, F> Debug for Exchange<C, D, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Exchange").finish()
     }

--- a/timely/src/dataflow/channels/pact.rs
+++ b/timely/src/dataflow/channels/pact.rs
@@ -21,8 +21,8 @@ use super::{Bundle, Message};
 use crate::logging::{TimelyLogger as Logger, MessagesEvent};
 use crate::progress::Timestamp;
 
-/// A `ParallelizationContractCore` allocates paired `Push` and `Pull` implementors.
-pub trait ParallelizationContractCore<T, D> {
+/// A `ParallelizationContract` allocates paired `Push` and `Pull` implementors.
+pub trait ParallelizationContract<T, D> {
     /// Type implementing `Push` produced by this pact.
     type Pusher: Push<Bundle<T, D>>+'static;
     /// Type implementing `Pull` produced by this pact.
@@ -35,7 +35,7 @@ pub trait ParallelizationContractCore<T, D> {
 #[derive(Debug)]
 pub struct Pipeline;
 
-impl<T: 'static, D: Container> ParallelizationContractCore<T, D> for Pipeline {
+impl<T: 'static, D: Container> ParallelizationContract<T, D> for Pipeline {
     type Pusher = LogPusher<T, D, ThreadPusher<Bundle<T, D>>>;
     type Puller = LogPuller<T, D, ThreadPuller<Bundle<T, D>>>;
     fn connect<A: AsWorker>(self, allocator: &mut A, identifier: usize, address: &[usize], logging: Option<Logger>) -> (Self::Pusher, Self::Puller) {
@@ -64,7 +64,7 @@ impl<C, D, F: FnMut(&D)->u64+'static> ExchangeCore<C, D, F> {
 }
 
 // Exchange uses a `Box<Pushable>` because it cannot know what type of pushable will return from the allocator.
-impl<T: Timestamp, C, D: Data+Clone, F: FnMut(&D)->u64+'static> ParallelizationContractCore<T, C> for ExchangeCore<C, D, F>
+impl<T: Timestamp, C, D: Data+Clone, F: FnMut(&D)->u64+'static> ParallelizationContract<T, C> for ExchangeCore<C, D, F>
 where
     C: Data + Container + PushPartitioned<Item=D>,
 {

--- a/timely/src/dataflow/channels/pushers/buffer.rs
+++ b/timely/src/dataflow/channels/pushers/buffer.rs
@@ -12,7 +12,7 @@ use crate::{Container, Data};
 /// The `Buffer` type should be used by calling `session` with a time, which checks whether
 /// data must be flushed and creates a `Session` object which allows sending at the given time.
 #[derive(Debug)]
-pub struct BufferCore<T, D: Container, P: Push<Bundle<T, D>>> {
+pub struct Buffer<T, D: Container, P: Push<Bundle<T, D>>> {
     /// the currently open time, if it is open
     time: Option<T>,
     /// a buffer for records, to send at self.time
@@ -20,7 +20,7 @@ pub struct BufferCore<T, D: Container, P: Push<Bundle<T, D>>> {
     pusher: P,
 }
 
-impl<T, C: Container, P: Push<Bundle<T, C>>> BufferCore<T, C, P> where T: Eq+Clone {
+impl<T, C: Container, P: Push<Bundle<T, C>>> Buffer<T, C, P> where T: Eq+Clone {
 
     /// Creates a new `Buffer`.
     pub fn new(pusher: P) -> Self {
@@ -76,7 +76,7 @@ impl<T, C: Container, P: Push<Bundle<T, C>>> BufferCore<T, C, P> where T: Eq+Clo
     }
 }
 
-impl<T, D: Data, P: Push<Bundle<T, Vec<D>>>> BufferCore<T, Vec<D>, P> where T: Eq+Clone {
+impl<T, D: Data, P: Push<Bundle<T, Vec<D>>>> Buffer<T, Vec<D>, P> where T: Eq+Clone {
     // internal method for use by `Session`.
     #[inline]
     fn give(&mut self, data: D) {
@@ -108,7 +108,7 @@ impl<T, D: Data, P: Push<Bundle<T, Vec<D>>>> BufferCore<T, Vec<D>, P> where T: E
 /// the `Buffer` type. A `Session` wraps a session of output at a specified time, and
 /// avoids what would otherwise be a constant cost of checking timestamp equality.
 pub struct Session<'a, T, C: Container, P: Push<Bundle<T, C>>+'a> where T: Eq+Clone+'a, C: 'a {
-    buffer: &'a mut BufferCore<T, C, P>,
+    buffer: &'a mut Buffer<T, C, P>,
 }
 
 impl<'a, T, C: Container, P: Push<Bundle<T, C>>+'a> Session<'a, T, C, P>  where T: Eq+Clone+'a, C: 'a {
@@ -148,7 +148,7 @@ impl<'a, T, D: Data, P: Push<Bundle<T, Vec<D>>>+'a> Session<'a, T, Vec<D>, P>  w
 pub struct AutoflushSessionCore<'a, T: Timestamp, C: Container, P: Push<Bundle<T, C>>+'a> where
     T: Eq+Clone+'a, C: 'a {
     /// A reference to the underlying buffer.
-    buffer: &'a mut BufferCore<T, C, P>,
+    buffer: &'a mut Buffer<T, C, P>,
     /// The capability being used to send the data.
     _capability: Capability<T>,
 }

--- a/timely/src/dataflow/channels/pushers/buffer.rs
+++ b/timely/src/dataflow/channels/pushers/buffer.rs
@@ -1,7 +1,7 @@
 //! Buffering and session mechanisms to provide the appearance of record-at-a-time sending,
 //! with the performance of batched sends.
 
-use crate::dataflow::channels::{BundleCore, Message};
+use crate::dataflow::channels::{Bundle, Message};
 use crate::progress::Timestamp;
 use crate::dataflow::operators::Capability;
 use crate::communication::Push;
@@ -12,7 +12,7 @@ use crate::{Container, Data};
 /// The `Buffer` type should be used by calling `session` with a time, which checks whether
 /// data must be flushed and creates a `Session` object which allows sending at the given time.
 #[derive(Debug)]
-pub struct BufferCore<T, D: Container, P: Push<BundleCore<T, D>>> {
+pub struct BufferCore<T, D: Container, P: Push<Bundle<T, D>>> {
     /// the currently open time, if it is open
     time: Option<T>,
     /// a buffer for records, to send at self.time
@@ -23,7 +23,7 @@ pub struct BufferCore<T, D: Container, P: Push<BundleCore<T, D>>> {
 /// A buffer specialized to vector-based containers.
 pub type Buffer<T, D, P> = BufferCore<T, Vec<D>, P>;
 
-impl<T, C: Container, P: Push<BundleCore<T, C>>> BufferCore<T, C, P> where T: Eq+Clone {
+impl<T, C: Container, P: Push<Bundle<T, C>>> BufferCore<T, C, P> where T: Eq+Clone {
 
     /// Creates a new `Buffer`.
     pub fn new(pusher: P) -> Self {
@@ -79,7 +79,7 @@ impl<T, C: Container, P: Push<BundleCore<T, C>>> BufferCore<T, C, P> where T: Eq
     }
 }
 
-impl<T, D: Data, P: Push<BundleCore<T, Vec<D>>>> Buffer<T, D, P> where T: Eq+Clone {
+impl<T, D: Data, P: Push<Bundle<T, Vec<D>>>> Buffer<T, D, P> where T: Eq+Clone {
     // internal method for use by `Session`.
     #[inline]
     fn give(&mut self, data: D) {
@@ -110,18 +110,18 @@ impl<T, D: Data, P: Push<BundleCore<T, Vec<D>>>> Buffer<T, D, P> where T: Eq+Clo
 /// The `Session` struct provides the user-facing interface to an operator output, namely
 /// the `Buffer` type. A `Session` wraps a session of output at a specified time, and
 /// avoids what would otherwise be a constant cost of checking timestamp equality.
-pub struct Session<'a, T, C: Container, P: Push<BundleCore<T, C>>+'a> where T: Eq+Clone+'a, C: 'a {
+pub struct Session<'a, T, C: Container, P: Push<Bundle<T, C>>+'a> where T: Eq+Clone+'a, C: 'a {
     buffer: &'a mut BufferCore<T, C, P>,
 }
 
-impl<'a, T, C: Container, P: Push<BundleCore<T, C>>+'a> Session<'a, T, C, P>  where T: Eq+Clone+'a, C: 'a {
+impl<'a, T, C: Container, P: Push<Bundle<T, C>>+'a> Session<'a, T, C, P>  where T: Eq+Clone+'a, C: 'a {
     /// Provide a container at the time specified by the [Session].
     pub fn give_container(&mut self, container: &mut C) {
         self.buffer.give_container(container)
     }
 }
 
-impl<'a, T, D: Data, P: Push<BundleCore<T, Vec<D>>>+'a> Session<'a, T, Vec<D>, P>  where T: Eq+Clone+'a, D: 'a {
+impl<'a, T, D: Data, P: Push<Bundle<T, Vec<D>>>+'a> Session<'a, T, Vec<D>, P>  where T: Eq+Clone+'a, D: 'a {
     /// Provides one record at the time specified by the `Session`.
     #[inline]
     pub fn give(&mut self, data: D) {
@@ -148,7 +148,7 @@ impl<'a, T, D: Data, P: Push<BundleCore<T, Vec<D>>>+'a> Session<'a, T, Vec<D>, P
 }
 
 /// A session which will flush itself when dropped.
-pub struct AutoflushSessionCore<'a, T: Timestamp, C: Container, P: Push<BundleCore<T, C>>+'a> where
+pub struct AutoflushSessionCore<'a, T: Timestamp, C: Container, P: Push<Bundle<T, C>>+'a> where
     T: Eq+Clone+'a, C: 'a {
     /// A reference to the underlying buffer.
     buffer: &'a mut BufferCore<T, C, P>,
@@ -159,7 +159,7 @@ pub struct AutoflushSessionCore<'a, T: Timestamp, C: Container, P: Push<BundleCo
 /// Auto-flush session specialized to vector-based containers.
 pub type AutoflushSession<'a, T, D, P> = AutoflushSessionCore<'a, T, Vec<D>, P>;
 
-impl<'a, T: Timestamp, D: Data, P: Push<BundleCore<T, Vec<D>>>+'a> AutoflushSessionCore<'a, T, Vec<D>, P> where T: Eq+Clone+'a, D: 'a {
+impl<'a, T: Timestamp, D: Data, P: Push<Bundle<T, Vec<D>>>+'a> AutoflushSessionCore<'a, T, Vec<D>, P> where T: Eq+Clone+'a, D: 'a {
     /// Transmits a single record.
     #[inline]
     pub fn give(&mut self, data: D) {
@@ -181,7 +181,7 @@ impl<'a, T: Timestamp, D: Data, P: Push<BundleCore<T, Vec<D>>>+'a> AutoflushSess
     }
 }
 
-impl<'a, T: Timestamp, C: Container, P: Push<BundleCore<T, C>>+'a> Drop for AutoflushSessionCore<'a, T, C, P> where T: Eq+Clone+'a, C: 'a {
+impl<'a, T: Timestamp, C: Container, P: Push<Bundle<T, C>>+'a> Drop for AutoflushSessionCore<'a, T, C, P> where T: Eq+Clone+'a, C: 'a {
     fn drop(&mut self) {
         self.buffer.cease();
     }

--- a/timely/src/dataflow/channels/pushers/buffer.rs
+++ b/timely/src/dataflow/channels/pushers/buffer.rs
@@ -20,9 +20,6 @@ pub struct BufferCore<T, D: Container, P: Push<Bundle<T, D>>> {
     pusher: P,
 }
 
-/// A buffer specialized to vector-based containers.
-pub type Buffer<T, D, P> = BufferCore<T, Vec<D>, P>;
-
 impl<T, C: Container, P: Push<Bundle<T, C>>> BufferCore<T, C, P> where T: Eq+Clone {
 
     /// Creates a new `Buffer`.
@@ -79,7 +76,7 @@ impl<T, C: Container, P: Push<Bundle<T, C>>> BufferCore<T, C, P> where T: Eq+Clo
     }
 }
 
-impl<T, D: Data, P: Push<Bundle<T, Vec<D>>>> Buffer<T, D, P> where T: Eq+Clone {
+impl<T, D: Data, P: Push<Bundle<T, Vec<D>>>> BufferCore<T, Vec<D>, P> where T: Eq+Clone {
     // internal method for use by `Session`.
     #[inline]
     fn give(&mut self, data: D) {

--- a/timely/src/dataflow/channels/pushers/buffer.rs
+++ b/timely/src/dataflow/channels/pushers/buffer.rs
@@ -1,7 +1,7 @@
 //! Buffering and session mechanisms to provide the appearance of record-at-a-time sending,
 //! with the performance of batched sends.
 
-use crate::dataflow::channels::{Bundle, BundleCore, Message};
+use crate::dataflow::channels::{BundleCore, Message};
 use crate::progress::Timestamp;
 use crate::dataflow::operators::Capability;
 use crate::communication::Push;
@@ -79,7 +79,7 @@ impl<T, C: Container, P: Push<BundleCore<T, C>>> BufferCore<T, C, P> where T: Eq
     }
 }
 
-impl<T, D: Data, P: Push<Bundle<T, D>>> Buffer<T, D, P> where T: Eq+Clone {
+impl<T, D: Data, P: Push<BundleCore<T, Vec<D>>>> Buffer<T, D, P> where T: Eq+Clone {
     // internal method for use by `Session`.
     #[inline]
     fn give(&mut self, data: D) {

--- a/timely/src/dataflow/channels/pushers/counter.rs
+++ b/timely/src/dataflow/channels/pushers/counter.rs
@@ -5,13 +5,13 @@ use std::rc::Rc;
 use std::cell::RefCell;
 
 use crate::progress::{ChangeBatch, Timestamp};
-use crate::dataflow::channels::BundleCore;
+use crate::dataflow::channels::Bundle;
 use crate::communication::Push;
 use crate::Container;
 
 /// A wrapper which updates shared `produced` based on the number of records pushed.
 #[derive(Debug)]
-pub struct CounterCore<T, D, P: Push<BundleCore<T, D>>> {
+pub struct CounterCore<T, D, P: Push<Bundle<T, D>>> {
     pushee: P,
     produced: Rc<RefCell<ChangeBatch<T>>>,
     phantom: PhantomData<D>,
@@ -20,9 +20,9 @@ pub struct CounterCore<T, D, P: Push<BundleCore<T, D>>> {
 /// A counter specialized to vector.
 pub type Counter<T, D, P> = CounterCore<T, Vec<D>, P>;
 
-impl<T: Timestamp, D: Container, P> Push<BundleCore<T, D>> for CounterCore<T, D, P> where P: Push<BundleCore<T, D>> {
+impl<T: Timestamp, D: Container, P> Push<Bundle<T, D>> for CounterCore<T, D, P> where P: Push<Bundle<T, D>> {
     #[inline]
-    fn push(&mut self, message: &mut Option<BundleCore<T, D>>) {
+    fn push(&mut self, message: &mut Option<Bundle<T, D>>) {
         if let Some(message) = message {
             self.produced.borrow_mut().update(message.time.clone(), message.data.len() as i64);
         }
@@ -34,7 +34,7 @@ impl<T: Timestamp, D: Container, P> Push<BundleCore<T, D>> for CounterCore<T, D,
     }
 }
 
-impl<T, D, P: Push<BundleCore<T, D>>> CounterCore<T, D, P> where T : Ord+Clone+'static {
+impl<T, D, P: Push<Bundle<T, D>>> CounterCore<T, D, P> where T : Ord+Clone+'static {
     /// Allocates a new `Counter` from a pushee and shared counts.
     pub fn new(pushee: P) -> CounterCore<T, D, P> {
         CounterCore {

--- a/timely/src/dataflow/channels/pushers/counter.rs
+++ b/timely/src/dataflow/channels/pushers/counter.rs
@@ -11,13 +11,13 @@ use crate::Container;
 
 /// A wrapper which updates shared `produced` based on the number of records pushed.
 #[derive(Debug)]
-pub struct CounterCore<T, D, P: Push<Bundle<T, D>>> {
+pub struct Counter<T, D, P: Push<Bundle<T, D>>> {
     pushee: P,
     produced: Rc<RefCell<ChangeBatch<T>>>,
     phantom: PhantomData<D>,
 }
 
-impl<T: Timestamp, D: Container, P> Push<Bundle<T, D>> for CounterCore<T, D, P> where P: Push<Bundle<T, D>> {
+impl<T: Timestamp, D: Container, P> Push<Bundle<T, D>> for Counter<T, D, P> where P: Push<Bundle<T, D>> {
     #[inline]
     fn push(&mut self, message: &mut Option<Bundle<T, D>>) {
         if let Some(message) = message {
@@ -31,10 +31,10 @@ impl<T: Timestamp, D: Container, P> Push<Bundle<T, D>> for CounterCore<T, D, P> 
     }
 }
 
-impl<T, D, P: Push<Bundle<T, D>>> CounterCore<T, D, P> where T : Ord+Clone+'static {
+impl<T, D, P: Push<Bundle<T, D>>> Counter<T, D, P> where T : Ord+Clone+'static {
     /// Allocates a new `Counter` from a pushee and shared counts.
-    pub fn new(pushee: P) -> CounterCore<T, D, P> {
-        CounterCore {
+    pub fn new(pushee: P) -> Counter<T, D, P> {
+        Counter {
             pushee,
             produced: Rc::new(RefCell::new(ChangeBatch::new())),
             phantom: PhantomData,

--- a/timely/src/dataflow/channels/pushers/counter.rs
+++ b/timely/src/dataflow/channels/pushers/counter.rs
@@ -17,9 +17,6 @@ pub struct CounterCore<T, D, P: Push<Bundle<T, D>>> {
     phantom: PhantomData<D>,
 }
 
-/// A counter specialized to vector.
-pub type Counter<T, D, P> = CounterCore<T, Vec<D>, P>;
-
 impl<T: Timestamp, D: Container, P> Push<Bundle<T, D>> for CounterCore<T, D, P> where P: Push<Bundle<T, D>> {
     #[inline]
     fn push(&mut self, message: &mut Option<Bundle<T, D>>) {

--- a/timely/src/dataflow/channels/pushers/mod.rs
+++ b/timely/src/dataflow/channels/pushers/mod.rs
@@ -1,4 +1,4 @@
-pub use self::tee::{Tee, TeeCore, TeeHelper};
+pub use self::tee::{TeeCore, TeeHelper};
 pub use self::exchange::Exchange;
 pub use self::counter::Counter;
 

--- a/timely/src/dataflow/channels/pushers/mod.rs
+++ b/timely/src/dataflow/channels/pushers/mod.rs
@@ -1,4 +1,4 @@
-pub use self::tee::{TeeCore, TeeHelper};
+pub use self::tee::{Tee, TeeHelper};
 pub use self::exchange::Exchange;
 pub use self::counter::Counter;
 

--- a/timely/src/dataflow/channels/pushers/mod.rs
+++ b/timely/src/dataflow/channels/pushers/mod.rs
@@ -1,6 +1,6 @@
 pub use self::tee::{Tee, TeeCore, TeeHelper};
 pub use self::exchange::Exchange;
-pub use self::counter::CounterCore;
+pub use self::counter::Counter;
 
 pub mod tee;
 pub mod exchange;

--- a/timely/src/dataflow/channels/pushers/mod.rs
+++ b/timely/src/dataflow/channels/pushers/mod.rs
@@ -1,6 +1,6 @@
 pub use self::tee::{Tee, TeeCore, TeeHelper};
 pub use self::exchange::Exchange;
-pub use self::counter::{Counter, CounterCore};
+pub use self::counter::CounterCore;
 
 pub mod tee;
 pub mod exchange;

--- a/timely/src/dataflow/channels/pushers/tee.rs
+++ b/timely/src/dataflow/channels/pushers/tee.rs
@@ -12,12 +12,12 @@ use crate::{Container, Data};
 type PushList<T, D> = Rc<RefCell<Vec<Box<dyn Push<Bundle<T, D>>>>>>;
 
 /// Wraps a shared list of `Box<Push>` to forward pushes to. Owned by `Stream`.
-pub struct TeeCore<T, D> {
+pub struct Tee<T, D> {
     buffer: D,
     shared: PushList<T, D>,
 }
 
-impl<T: Data, D: Container> Push<Bundle<T, D>> for TeeCore<T, D> {
+impl<T: Data, D: Container> Push<Bundle<T, D>> for Tee<T, D> {
     #[inline]
     fn push(&mut self, message: &mut Option<Bundle<T, D>>) {
         let mut pushers = self.shared.borrow_mut();
@@ -39,11 +39,11 @@ impl<T: Data, D: Container> Push<Bundle<T, D>> for TeeCore<T, D> {
     }
 }
 
-impl<T, D: Container> TeeCore<T, D> {
+impl<T, D: Container> Tee<T, D> {
     /// Allocates a new pair of `Tee` and `TeeHelper`.
-    pub fn new() -> (TeeCore<T, D>, TeeHelper<T, D>) {
+    pub fn new() -> (Tee<T, D>, TeeHelper<T, D>) {
         let shared = Rc::new(RefCell::new(Vec::new()));
-        let port = TeeCore {
+        let port = Tee {
             buffer: Default::default(),
             shared: shared.clone(),
         };
@@ -52,7 +52,7 @@ impl<T, D: Container> TeeCore<T, D> {
     }
 }
 
-impl<T, D: Container> Clone for TeeCore<T, D> {
+impl<T, D: Container> Clone for Tee<T, D> {
     fn clone(&self) -> Self {
         Self {
             buffer: Default::default(),
@@ -61,7 +61,7 @@ impl<T, D: Container> Clone for TeeCore<T, D> {
     }
 }
 
-impl<T, D> Debug for TeeCore<T, D>
+impl<T, D> Debug for Tee<T, D>
 where
     D: Debug,
 {

--- a/timely/src/dataflow/channels/pushers/tee.rs
+++ b/timely/src/dataflow/channels/pushers/tee.rs
@@ -4,12 +4,12 @@ use std::cell::RefCell;
 use std::fmt::{self, Debug};
 use std::rc::Rc;
 
-use crate::dataflow::channels::{BundleCore, Message};
+use crate::dataflow::channels::{Bundle, Message};
 
 use crate::communication::Push;
 use crate::{Container, Data};
 
-type PushList<T, D> = Rc<RefCell<Vec<Box<dyn Push<BundleCore<T, D>>>>>>;
+type PushList<T, D> = Rc<RefCell<Vec<Box<dyn Push<Bundle<T, D>>>>>>;
 
 /// Wraps a shared list of `Box<Push>` to forward pushes to. Owned by `Stream`.
 pub struct TeeCore<T, D> {
@@ -20,9 +20,9 @@ pub struct TeeCore<T, D> {
 /// [TeeCore] specialized to `Vec`-based container.
 pub type Tee<T, D> = TeeCore<T, Vec<D>>;
 
-impl<T: Data, D: Container> Push<BundleCore<T, D>> for TeeCore<T, D> {
+impl<T: Data, D: Container> Push<Bundle<T, D>> for TeeCore<T, D> {
     #[inline]
-    fn push(&mut self, message: &mut Option<BundleCore<T, D>>) {
+    fn push(&mut self, message: &mut Option<Bundle<T, D>>) {
         let mut pushers = self.shared.borrow_mut();
         if let Some(message) = message {
             for index in 1..pushers.len() {
@@ -89,7 +89,7 @@ pub struct TeeHelper<T, D> {
 
 impl<T, D> TeeHelper<T, D> {
     /// Adds a new `Push` implementor to the list of recipients shared with a `Stream`.
-    pub fn add_pusher<P: Push<BundleCore<T, D>>+'static>(&self, pusher: P) {
+    pub fn add_pusher<P: Push<Bundle<T, D>>+'static>(&self, pusher: P) {
         self.shared.borrow_mut().push(Box::new(pusher));
     }
 }

--- a/timely/src/dataflow/channels/pushers/tee.rs
+++ b/timely/src/dataflow/channels/pushers/tee.rs
@@ -17,9 +17,6 @@ pub struct TeeCore<T, D> {
     shared: PushList<T, D>,
 }
 
-/// [TeeCore] specialized to `Vec`-based container.
-pub type Tee<T, D> = TeeCore<T, Vec<D>>;
-
 impl<T: Data, D: Container> Push<Bundle<T, D>> for TeeCore<T, D> {
     #[inline]
     fn push(&mut self, message: &mut Option<Bundle<T, D>>) {

--- a/timely/src/dataflow/mod.rs
+++ b/timely/src/dataflow/mod.rs
@@ -13,7 +13,7 @@
 //! });
 //! ```
 
-pub use self::stream::{StreamCore, Stream};
+pub use self::stream::StreamCore;
 pub use self::scopes::{Scope, ScopeParent};
 
 pub use self::operators::input::HandleCore as InputHandleCore;

--- a/timely/src/dataflow/mod.rs
+++ b/timely/src/dataflow/mod.rs
@@ -16,7 +16,6 @@
 pub use self::stream::Stream;
 pub use self::scopes::{Scope, ScopeParent};
 
-pub use self::operators::input::HandleCore as InputHandleCore;
 pub use self::operators::input::Handle as InputHandle;
 pub use self::operators::probe::Handle as ProbeHandle;
 

--- a/timely/src/dataflow/mod.rs
+++ b/timely/src/dataflow/mod.rs
@@ -13,7 +13,7 @@
 //! });
 //! ```
 
-pub use self::stream::StreamCore;
+pub use self::stream::Stream;
 pub use self::scopes::{Scope, ScopeParent};
 
 pub use self::operators::input::HandleCore as InputHandleCore;

--- a/timely/src/dataflow/operators/aggregation/aggregate.rs
+++ b/timely/src/dataflow/operators/aggregation/aggregate.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 use std::collections::HashMap;
 
 use crate::{Data, ExchangeData};
-use crate::dataflow::{Stream, Scope};
+use crate::dataflow::{Scope, StreamCore};
 use crate::dataflow::operators::generic::operator::Operator;
 use crate::dataflow::channels::pact::Exchange;
 
@@ -64,16 +64,16 @@ pub trait Aggregate<S: Scope, K: ExchangeData+Hash, V: ExchangeData> {
         &self,
         fold: F,
         emit: E,
-        hash: H) -> Stream<S, R> where S::Timestamp: Eq;
+        hash: H) -> StreamCore<S, Vec<R>> where S::Timestamp: Eq;
 }
 
-impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> Aggregate<S, K, V> for Stream<S, (K, V)> {
+impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> Aggregate<S, K, V> for StreamCore<S, Vec<(K, V)>> {
 
     fn aggregate<R: Data, D: Default+'static, F: Fn(&K, V, &mut D)+'static, E: Fn(K, D)->R+'static, H: Fn(&K)->u64+'static>(
         &self,
         fold: F,
         emit: E,
-        hash: H) -> Stream<S, R> where S::Timestamp: Eq {
+        hash: H) -> StreamCore<S, Vec<R>> where S::Timestamp: Eq {
 
         let mut aggregates = HashMap::new();
         let mut vector = Vec::new();

--- a/timely/src/dataflow/operators/aggregation/aggregate.rs
+++ b/timely/src/dataflow/operators/aggregation/aggregate.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 use std::collections::HashMap;
 
 use crate::{Data, ExchangeData};
-use crate::dataflow::{Scope, StreamCore};
+use crate::dataflow::{Scope, Stream};
 use crate::dataflow::operators::generic::operator::Operator;
 use crate::dataflow::channels::pact::Exchange;
 
@@ -64,16 +64,16 @@ pub trait Aggregate<S: Scope, K: ExchangeData+Hash, V: ExchangeData> {
         &self,
         fold: F,
         emit: E,
-        hash: H) -> StreamCore<S, Vec<R>> where S::Timestamp: Eq;
+        hash: H) -> Stream<S, Vec<R>> where S::Timestamp: Eq;
 }
 
-impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> Aggregate<S, K, V> for StreamCore<S, Vec<(K, V)>> {
+impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> Aggregate<S, K, V> for Stream<S, Vec<(K, V)>> {
 
     fn aggregate<R: Data, D: Default+'static, F: Fn(&K, V, &mut D)+'static, E: Fn(K, D)->R+'static, H: Fn(&K)->u64+'static>(
         &self,
         fold: F,
         emit: E,
-        hash: H) -> StreamCore<S, Vec<R>> where S::Timestamp: Eq {
+        hash: H) -> Stream<S, Vec<R>> where S::Timestamp: Eq {
 
         let mut aggregates = HashMap::new();
         let mut vector = Vec::new();

--- a/timely/src/dataflow/operators/aggregation/state_machine.rs
+++ b/timely/src/dataflow/operators/aggregation/state_machine.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 use std::collections::HashMap;
 
 use crate::{Data, ExchangeData};
-use crate::dataflow::{Scope, StreamCore};
+use crate::dataflow::{Scope, Stream};
 use crate::dataflow::operators::generic::operator::Operator;
 use crate::dataflow::channels::pact::Exchange;
 
@@ -51,17 +51,17 @@ pub trait StateMachine<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> {
         I: IntoIterator<Item=R>,                    // type of output iterator
         F: Fn(&K, V, &mut D)->(bool, I)+'static,    // state update logic
         H: Fn(&K)->u64+'static,                     // "hash" function for keys
-    >(&self, fold: F, hash: H) -> StreamCore<S, Vec<R>> where S::Timestamp : Hash+Eq ;
+    >(&self, fold: F, hash: H) -> Stream<S, Vec<R>> where S::Timestamp : Hash+Eq ;
 }
 
-impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> StateMachine<S, K, V> for StreamCore<S, Vec<(K, V)>> {
+impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> StateMachine<S, K, V> for Stream<S, Vec<(K, V)>> {
     fn state_machine<
             R: Data,                                    // output type
             D: Default+'static,                         // per-key state (data)
             I: IntoIterator<Item=R>,                    // type of output iterator
             F: Fn(&K, V, &mut D)->(bool, I)+'static,    // state update logic
             H: Fn(&K)->u64+'static,                     // "hash" function for keys
-        >(&self, fold: F, hash: H) -> StreamCore<S, Vec<R>> where S::Timestamp : Hash+Eq {
+        >(&self, fold: F, hash: H) -> Stream<S, Vec<R>> where S::Timestamp : Hash+Eq {
 
         let mut pending: HashMap<_, Vec<(K, V)>> = HashMap::new();   // times -> (keys -> state)
         let mut states = HashMap::new();    // keys -> state

--- a/timely/src/dataflow/operators/aggregation/state_machine.rs
+++ b/timely/src/dataflow/operators/aggregation/state_machine.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 use std::collections::HashMap;
 
 use crate::{Data, ExchangeData};
-use crate::dataflow::{Stream, Scope};
+use crate::dataflow::{Scope, StreamCore};
 use crate::dataflow::operators::generic::operator::Operator;
 use crate::dataflow::channels::pact::Exchange;
 
@@ -51,17 +51,17 @@ pub trait StateMachine<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> {
         I: IntoIterator<Item=R>,                    // type of output iterator
         F: Fn(&K, V, &mut D)->(bool, I)+'static,    // state update logic
         H: Fn(&K)->u64+'static,                     // "hash" function for keys
-    >(&self, fold: F, hash: H) -> Stream<S, R> where S::Timestamp : Hash+Eq ;
+    >(&self, fold: F, hash: H) -> StreamCore<S, Vec<R>> where S::Timestamp : Hash+Eq ;
 }
 
-impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> StateMachine<S, K, V> for Stream<S, (K, V)> {
+impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> StateMachine<S, K, V> for StreamCore<S, Vec<(K, V)>> {
     fn state_machine<
             R: Data,                                    // output type
             D: Default+'static,                         // per-key state (data)
             I: IntoIterator<Item=R>,                    // type of output iterator
             F: Fn(&K, V, &mut D)->(bool, I)+'static,    // state update logic
             H: Fn(&K)->u64+'static,                     // "hash" function for keys
-        >(&self, fold: F, hash: H) -> Stream<S, R> where S::Timestamp : Hash+Eq {
+        >(&self, fold: F, hash: H) -> StreamCore<S, Vec<R>> where S::Timestamp : Hash+Eq {
 
         let mut pending: HashMap<_, Vec<(K, V)>> = HashMap::new();   // times -> (keys -> state)
         let mut states = HashMap::new();    // keys -> state

--- a/timely/src/dataflow/operators/branch.rs
+++ b/timely/src/dataflow/operators/branch.rs
@@ -2,7 +2,7 @@
 
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use crate::dataflow::{Scope, Stream, StreamCore};
+use crate::dataflow::{Scope, StreamCore};
 use crate::{Container, Data};
 
 /// Extension trait for `Stream`.
@@ -31,14 +31,14 @@ pub trait Branch<S: Scope, D: Data> {
     fn branch(
         &self,
         condition: impl Fn(&S::Timestamp, &D) -> bool + 'static,
-    ) -> (Stream<S, D>, Stream<S, D>);
+    ) -> (StreamCore<S, Vec<D>>, StreamCore<S, Vec<D>>);
 }
 
-impl<S: Scope, D: Data> Branch<S, D> for Stream<S, D> {
+impl<S: Scope, D: Data> Branch<S, D> for StreamCore<S, Vec<D>> {
     fn branch(
         &self,
         condition: impl Fn(&S::Timestamp, &D) -> bool + 'static,
-    ) -> (Stream<S, D>, Stream<S, D>) {
+    ) -> (StreamCore<S, Vec<D>>, StreamCore<S, Vec<D>>) {
         let mut builder = OperatorBuilder::new("Branch".to_owned(), self.scope());
 
         let mut input = builder.new_input(self, Pipeline);

--- a/timely/src/dataflow/operators/branch.rs
+++ b/timely/src/dataflow/operators/branch.rs
@@ -2,7 +2,7 @@
 
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use crate::dataflow::{Scope, StreamCore};
+use crate::dataflow::{Scope, Stream};
 use crate::{Container, Data};
 
 /// Extension trait for `Stream`.
@@ -31,14 +31,14 @@ pub trait Branch<S: Scope, D: Data> {
     fn branch(
         &self,
         condition: impl Fn(&S::Timestamp, &D) -> bool + 'static,
-    ) -> (StreamCore<S, Vec<D>>, StreamCore<S, Vec<D>>);
+    ) -> (Stream<S, Vec<D>>, Stream<S, Vec<D>>);
 }
 
-impl<S: Scope, D: Data> Branch<S, D> for StreamCore<S, Vec<D>> {
+impl<S: Scope, D: Data> Branch<S, D> for Stream<S, Vec<D>> {
     fn branch(
         &self,
         condition: impl Fn(&S::Timestamp, &D) -> bool + 'static,
-    ) -> (StreamCore<S, Vec<D>>, StreamCore<S, Vec<D>>) {
+    ) -> (Stream<S, Vec<D>>, Stream<S, Vec<D>>) {
         let mut builder = OperatorBuilder::new("Branch".to_owned(), self.scope());
 
         let mut input = builder.new_input(self, Pipeline);
@@ -94,7 +94,7 @@ pub trait BranchWhen<T>: Sized {
     fn branch_when(&self, condition: impl Fn(&T) -> bool + 'static) -> (Self, Self);
 }
 
-impl<S: Scope, C: Container> BranchWhen<S::Timestamp> for StreamCore<S, C> {
+impl<S: Scope, C: Container> BranchWhen<S::Timestamp> for Stream<S, C> {
     fn branch_when(&self, condition: impl Fn(&S::Timestamp) -> bool + 'static) -> (Self, Self) {
         let mut builder = OperatorBuilder::new("Branch".to_owned(), self.scope());
 

--- a/timely/src/dataflow/operators/broadcast.rs
+++ b/timely/src/dataflow/operators/broadcast.rs
@@ -1,7 +1,7 @@
 //! Broadcast records to all workers.
 
 use crate::ExchangeData;
-use crate::dataflow::{Stream, Scope};
+use crate::dataflow::{Scope, StreamCore};
 use crate::dataflow::operators::{Map, Exchange};
 
 /// Broadcast records to all workers.
@@ -21,8 +21,8 @@ pub trait Broadcast<D: ExchangeData> {
     fn broadcast(&self) -> Self;
 }
 
-impl<G: Scope, D: ExchangeData> Broadcast<D> for Stream<G, D> {
-    fn broadcast(&self) -> Stream<G, D> {
+impl<G: Scope, D: ExchangeData> Broadcast<D> for StreamCore<G, Vec<D>> {
+    fn broadcast(&self) -> StreamCore<G, Vec<D>> {
 
         // NOTE: Simplified implementation due to underlying motion
         // in timely dataflow internals. Optimize once they have

--- a/timely/src/dataflow/operators/broadcast.rs
+++ b/timely/src/dataflow/operators/broadcast.rs
@@ -1,7 +1,7 @@
 //! Broadcast records to all workers.
 
 use crate::ExchangeData;
-use crate::dataflow::{Scope, StreamCore};
+use crate::dataflow::{Scope, Stream};
 use crate::dataflow::operators::{Map, Exchange};
 
 /// Broadcast records to all workers.
@@ -21,8 +21,8 @@ pub trait Broadcast<D: ExchangeData> {
     fn broadcast(&self) -> Self;
 }
 
-impl<G: Scope, D: ExchangeData> Broadcast<D> for StreamCore<G, Vec<D>> {
-    fn broadcast(&self) -> StreamCore<G, Vec<D>> {
+impl<G: Scope, D: ExchangeData> Broadcast<D> for Stream<G, Vec<D>> {
+    fn broadcast(&self) -> Stream<G, Vec<D>> {
 
         // NOTE: Simplified implementation due to underlying motion
         // in timely dataflow internals. Optimize once they have

--- a/timely/src/dataflow/operators/capture/capture.rs
+++ b/timely/src/dataflow/operators/capture/capture.rs
@@ -30,7 +30,7 @@ pub trait Capture<T: Timestamp, D: Container> {
     /// use std::sync::{Arc, Mutex};
     /// use timely::dataflow::Scope;
     /// use timely::dataflow::operators::{Capture, ToStream, Inspect};
-    /// use timely::dataflow::operators::capture::{EventLinkCore, Replay, Extract};
+    /// use timely::dataflow::operators::capture::{EventLink, Replay, Extract};
     ///
     /// // get send and recv endpoints, wrap send to share
     /// let (send, recv) = ::std::sync::mpsc::channel();
@@ -42,7 +42,7 @@ pub trait Capture<T: Timestamp, D: Container> {
     ///     let send = send.lock().unwrap().clone();
     ///
     ///     // these are to capture/replay the stream.
-    ///     let handle1 = Rc::new(EventLinkCore::new());
+    ///     let handle1 = Rc::new(EventLink::new());
     ///     let handle2 = Some(handle1.clone());
     ///
     ///     worker.dataflow::<u64,_,_>(|scope1|

--- a/timely/src/dataflow/operators/capture/capture.rs
+++ b/timely/src/dataflow/operators/capture/capture.rs
@@ -95,7 +95,7 @@ pub trait Capture<T: Timestamp, D: Container> {
     ///     );
     ///
     ///     worker.dataflow::<u64,_,_>(|scope2| {
-    ///         Some(EventReader::<_,u64,_>::new(recv))
+    ///         Some(EventReader::<_, Vec<u64>,_>::new(recv))
     ///             .replay_into(scope2)
     ///             .capture_into(send0)
     ///     });

--- a/timely/src/dataflow/operators/capture/capture.rs
+++ b/timely/src/dataflow/operators/capture/capture.rs
@@ -70,7 +70,7 @@ pub trait Capture<T: Timestamp, D: Container> {
     /// use std::sync::{Arc, Mutex};
     /// use timely::dataflow::Scope;
     /// use timely::dataflow::operators::{Capture, ToStream, Inspect};
-    /// use timely::dataflow::operators::capture::{EventReader, EventWriter, Replay, Extract};
+    /// use timely::dataflow::operators::capture::{EventReader, Replay, Extract, EventWriter};
     ///
     /// // get send and recv endpoints, wrap send to share
     /// let (send0, recv0) = ::std::sync::mpsc::channel();

--- a/timely/src/dataflow/operators/capture/capture.rs
+++ b/timely/src/dataflow/operators/capture/capture.rs
@@ -14,7 +14,7 @@ use crate::Container;
 use crate::progress::ChangeBatch;
 use crate::progress::Timestamp;
 
-use super::{EventCore, EventPusherCore};
+use super::{EventCore, EventPusher};
 
 /// Capture a stream of timestamped data for later replay.
 pub trait Capture<T: Timestamp, D: Container> {
@@ -103,7 +103,7 @@ pub trait Capture<T: Timestamp, D: Container> {
     ///
     /// assert_eq!(recv0.extract()[0].1, (0..10).collect::<Vec<_>>());
     /// ```
-    fn capture_into<P: EventPusherCore<T, D>+'static>(&self, pusher: P);
+    fn capture_into<P: EventPusher<T, D>+'static>(&self, pusher: P);
 
     /// Captures a stream using Rust's MPSC channels.
     fn capture(&self) -> ::std::sync::mpsc::Receiver<EventCore<T, D>> {
@@ -114,7 +114,7 @@ pub trait Capture<T: Timestamp, D: Container> {
 }
 
 impl<S: Scope, D: Container> Capture<S::Timestamp, D> for Stream<S, D> {
-    fn capture_into<P: EventPusherCore<S::Timestamp, D>+'static>(&self, mut event_pusher: P) {
+    fn capture_into<P: EventPusher<S::Timestamp, D>+'static>(&self, mut event_pusher: P) {
 
         let mut builder = OperatorBuilder::new("Capture".to_owned(), self.scope());
         let mut input = PullCounter::new(builder.new_input(self, Pipeline));

--- a/timely/src/dataflow/operators/capture/capture.rs
+++ b/timely/src/dataflow/operators/capture/capture.rs
@@ -5,7 +5,7 @@
 //! and there are several default implementations, including a linked-list, Rust's MPSC
 //! queue, and a binary serializer wrapping any `W: Write`.
 
-use crate::dataflow::{Scope, StreamCore};
+use crate::dataflow::{Scope, Stream};
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::channels::pullers::Counter as PullCounter;
 use crate::dataflow::operators::generic::builder_raw::OperatorBuilder;
@@ -113,7 +113,7 @@ pub trait Capture<T: Timestamp, D: Container> {
     }
 }
 
-impl<S: Scope, D: Container> Capture<S::Timestamp, D> for StreamCore<S, D> {
+impl<S: Scope, D: Container> Capture<S::Timestamp, D> for Stream<S, D> {
     fn capture_into<P: EventPusherCore<S::Timestamp, D>+'static>(&self, mut event_pusher: P) {
 
         let mut builder = OperatorBuilder::new("Capture".to_owned(), self.scope());

--- a/timely/src/dataflow/operators/capture/event.rs
+++ b/timely/src/dataflow/operators/capture/event.rs
@@ -124,15 +124,12 @@ pub mod binary {
     use super::{Event, EventPusher, EventIterator};
 
     /// A wrapper for `W: Write` implementing `EventPusherCore<T, D>`.
-    pub struct EventWriterCore<T, D, W: ::std::io::Write> {
+    pub struct EventWriter<T, D, W: ::std::io::Write> {
         stream: W,
         phant: ::std::marker::PhantomData<(T,D)>,
     }
 
-    /// [EventWriterCore] specialized to vector-based containers.
-    pub type EventWriter<T, D, W> = EventWriterCore<T, Vec<D>, W>;
-
-    impl<T, D, W: ::std::io::Write> EventWriterCore<T, D, W> {
+    impl<T, D, W: ::std::io::Write> EventWriter<T, D, W> {
         /// Allocates a new `EventWriter` wrapping a supplied writer.
         pub fn new(w: W) -> Self {
             Self {
@@ -142,7 +139,7 @@ pub mod binary {
         }
     }
 
-    impl<T: Abomonation, D: Abomonation, W: ::std::io::Write> EventPusher<T, D> for EventWriterCore<T, D, W> {
+    impl<T: Abomonation, D: Abomonation, W: ::std::io::Write> EventPusher<T, D> for EventWriter<T, D, W> {
         fn push(&mut self, event: Event<T, D>) {
             // TODO: `push` has no mechanism to report errors, so we `unwrap`.
             unsafe { ::abomonation::encode(&event, &mut self.stream).expect("Event abomonation/write failed"); }

--- a/timely/src/dataflow/operators/capture/event.rs
+++ b/timely/src/dataflow/operators/capture/event.rs
@@ -147,7 +147,7 @@ pub mod binary {
     }
 
     /// A Wrapper for `R: Read` implementing `EventIterator<T, D>`.
-    pub struct EventReaderCore<T, D, R: ::std::io::Read> {
+    pub struct EventReader<T, D, R: ::std::io::Read> {
         reader: R,
         bytes: Vec<u8>,
         buff1: Vec<u8>,
@@ -157,10 +157,7 @@ pub mod binary {
         phant: ::std::marker::PhantomData<(T,D)>,
     }
 
-    /// [EventReaderCore] specialized to vector-based containers.
-    pub type EventReader<T, D, R> = EventReaderCore<T, Vec<D>, R>;
-
-    impl<T, D, R: ::std::io::Read> EventReaderCore<T, D, R> {
+    impl<T, D, R: ::std::io::Read> EventReader<T, D, R> {
         /// Allocates a new `EventReader` wrapping a supplied reader.
         pub fn new(r: R) -> Self {
             Self {
@@ -175,7 +172,7 @@ pub mod binary {
         }
     }
 
-    impl<T: Abomonation, D: Abomonation, R: ::std::io::Read> EventIterator<T, D> for EventReaderCore<T, D, R> {
+    impl<T: Abomonation, D: Abomonation, R: ::std::io::Read> EventIterator<T, D> for EventReader<T, D, R> {
         fn next(&mut self) -> Option<&Event<T, D>> {
 
             // if we can decode something, we should just return it! :D

--- a/timely/src/dataflow/operators/capture/extract.rs
+++ b/timely/src/dataflow/operators/capture/extract.rs
@@ -1,6 +1,6 @@
 //! Traits and types for extracting captured timely dataflow streams.
 
-use super::EventCore;
+use super::Event;
 use crate::Container;
 use crate::Data;
 
@@ -49,7 +49,7 @@ pub trait Extract<T: Ord, D: Ord> {
     fn extract(self) -> Vec<(T, Vec<D>)>;
 }
 
-impl<T: Ord, D: Ord+Data> Extract<T,D> for ::std::sync::mpsc::Receiver<EventCore<T, Vec<D>>> {
+impl<T: Ord, D: Ord+Data> Extract<T,D> for ::std::sync::mpsc::Receiver<Event<T, Vec<D>>> {
     fn extract(self) -> Vec<(T, Vec<D>)> {
         let mut result = self.extract_core();
 
@@ -117,11 +117,11 @@ pub trait ExtractCore<T, C> {
     fn extract_core(self) -> Vec<(T, C)>;
 }
 
-impl<T, C: Container> ExtractCore<T, C> for ::std::sync::mpsc::Receiver<EventCore<T, C>> {
+impl<T, C: Container> ExtractCore<T, C> for ::std::sync::mpsc::Receiver<Event<T, C>> {
     fn extract_core(self) -> Vec<(T, C)> {
         let mut result = Vec::new();
         for event in self {
-            if let EventCore::Messages(time, data) = event {
+            if let Event::Messages(time, data) = event {
                 result.push((time, data));
             }
         }

--- a/timely/src/dataflow/operators/capture/extract.rs
+++ b/timely/src/dataflow/operators/capture/extract.rs
@@ -18,7 +18,7 @@ pub trait Extract<T: Ord, D: Ord> {
     /// use std::sync::{Arc, Mutex};
     /// use timely::dataflow::Scope;
     /// use timely::dataflow::operators::{Capture, ToStream, Inspect};
-    /// use timely::dataflow::operators::capture::{EventLinkCore, Replay, Extract};
+    /// use timely::dataflow::operators::capture::{EventLink, Replay, Extract};
     ///
     /// // get send and recv endpoints, wrap send to share
     /// let (send, recv) = ::std::sync::mpsc::channel();
@@ -30,7 +30,7 @@ pub trait Extract<T: Ord, D: Ord> {
     ///     let send = send.lock().unwrap().clone();
     ///
     ///     // these are to capture/replay the stream.
-    ///     let handle1 = Rc::new(EventLinkCore::new());
+    ///     let handle1 = Rc::new(EventLink::new());
     ///     let handle2 = Some(handle1.clone());
     ///
     ///     worker.dataflow::<u64,_,_>(|scope1|
@@ -86,7 +86,7 @@ pub trait ExtractCore<T, C> {
     /// use std::sync::{Arc, Mutex};
     /// use timely::dataflow::Scope;
     /// use timely::dataflow::operators::{Capture, ToStream, Inspect};
-    /// use timely::dataflow::operators::capture::{EventLinkCore, Replay, ExtractCore};
+    /// use timely::dataflow::operators::capture::{EventLink, Replay, ExtractCore};
     ///
     /// // get send and recv endpoints, wrap send to share
     /// let (send, recv) = ::std::sync::mpsc::channel();
@@ -98,7 +98,7 @@ pub trait ExtractCore<T, C> {
     ///     let send = send.lock().unwrap().clone();
     ///
     ///     // these are to capture/replay the stream.
-    ///     let handle1 = Rc::new(EventLinkCore::new());
+    ///     let handle1 = Rc::new(EventLink::new());
     ///     let handle2 = Some(handle1.clone());
     ///
     ///     worker.dataflow::<u64,_,_>(|scope1|

--- a/timely/src/dataflow/operators/capture/mod.rs
+++ b/timely/src/dataflow/operators/capture/mod.rs
@@ -79,7 +79,7 @@ pub use self::extract::{Extract, ExtractCore};
 pub use self::event::{Event, EventPusher};
 pub use self::event::link::EventLink;
 pub use self::event::binary::{EventReader, EventReaderCore};
-pub use self::event::binary::{EventWriter, EventWriterCore};
+pub use self::event::binary::EventWriter;
 
 pub mod capture;
 pub mod replay;

--- a/timely/src/dataflow/operators/capture/mod.rs
+++ b/timely/src/dataflow/operators/capture/mod.rs
@@ -22,10 +22,10 @@
 //! use std::rc::Rc;
 //! use timely::dataflow::Scope;
 //! use timely::dataflow::operators::{Capture, ToStream, Inspect};
-//! use timely::dataflow::operators::capture::{EventLinkCore, Replay};
+//! use timely::dataflow::operators::capture::{EventLink, Replay};
 //!
 //! timely::execute(timely::Config::thread(), |worker| {
-//!     let handle1 = Rc::new(EventLinkCore::new());
+//!     let handle1 = Rc::new(EventLink::new());
 //!     let handle2 = Some(handle1.clone());
 //!
 //!     worker.dataflow::<u64,_,_>(|scope1|
@@ -77,7 +77,7 @@ pub use self::capture::Capture;
 pub use self::replay::Replay;
 pub use self::extract::{Extract, ExtractCore};
 pub use self::event::{Event, EventPusher};
-pub use self::event::link::{EventLink, EventLinkCore};
+pub use self::event::link::EventLink;
 pub use self::event::binary::{EventReader, EventReaderCore};
 pub use self::event::binary::{EventWriter, EventWriterCore};
 

--- a/timely/src/dataflow/operators/capture/mod.rs
+++ b/timely/src/dataflow/operators/capture/mod.rs
@@ -66,7 +66,7 @@
 //!     );
 //!
 //!     worker.dataflow::<u64,_,_>(|scope2| {
-//!         Some(EventReader::<_,u64,_>::new(recv))
+//!         Some(EventReader::<u64, Vec<u64>, TcpStream>::new(recv))
 //!             .replay_into(scope2)
 //!             .inspect(|x| println!("replayed: {:?}", x));
 //!     })
@@ -78,7 +78,7 @@ pub use self::replay::Replay;
 pub use self::extract::{Extract, ExtractCore};
 pub use self::event::{Event, EventPusher};
 pub use self::event::link::EventLink;
-pub use self::event::binary::{EventReader, EventReaderCore};
+pub use self::event::binary::EventReader;
 pub use self::event::binary::EventWriter;
 
 pub mod capture;

--- a/timely/src/dataflow/operators/capture/mod.rs
+++ b/timely/src/dataflow/operators/capture/mod.rs
@@ -76,7 +76,7 @@
 pub use self::capture::Capture;
 pub use self::replay::Replay;
 pub use self::extract::{Extract, ExtractCore};
-pub use self::event::{Event, EventCore, EventPusher};
+pub use self::event::{Event, EventPusher};
 pub use self::event::link::{EventLink, EventLinkCore};
 pub use self::event::binary::{EventReader, EventReaderCore};
 pub use self::event::binary::{EventWriter, EventWriterCore};

--- a/timely/src/dataflow/operators/capture/mod.rs
+++ b/timely/src/dataflow/operators/capture/mod.rs
@@ -76,7 +76,7 @@
 pub use self::capture::Capture;
 pub use self::replay::Replay;
 pub use self::extract::{Extract, ExtractCore};
-pub use self::event::{Event, EventCore, EventPusher, EventPusherCore};
+pub use self::event::{Event, EventCore, EventPusher};
 pub use self::event::link::{EventLink, EventLinkCore};
 pub use self::event::binary::{EventReader, EventReaderCore};
 pub use self::event::binary::{EventWriter, EventWriterCore};

--- a/timely/src/dataflow/operators/capture/replay.rs
+++ b/timely/src/dataflow/operators/capture/replay.rs
@@ -38,7 +38,7 @@
 //! allowing the replay to occur in a timely dataflow computation with more or fewer workers
 //! than that in which the stream was captured.
 
-use crate::dataflow::{Scope, StreamCore};
+use crate::dataflow::{Scope, Stream};
 use crate::dataflow::channels::pushers::CounterCore as PushCounter;
 use crate::dataflow::channels::pushers::buffer::BufferCore as PushBuffer;
 use crate::dataflow::operators::generic::builder_raw::OperatorBuilder;
@@ -51,7 +51,7 @@ use crate::Container;
 /// Replay a capture stream into a scope with the same timestamp.
 pub trait Replay<T: Timestamp, C> : Sized {
     /// Replays `self` into the provided scope, as a `Stream<S, D>`.
-    fn replay_into<S: Scope<Timestamp=T>>(self, scope: &mut S) -> StreamCore<S, C> {
+    fn replay_into<S: Scope<Timestamp=T>>(self, scope: &mut S) -> Stream<S, C> {
         self.replay_core(scope, Some(std::time::Duration::new(0, 0)))
     }
     /// Replays `self` into the provided scope, as a `Stream<S, D>'.
@@ -59,13 +59,13 @@ pub trait Replay<T: Timestamp, C> : Sized {
     /// The `period` argument allows the specification of a re-activation period, where the operator
     /// will re-activate itself every so often. The `None` argument instructs the operator not to
     /// re-activate itself.us
-    fn replay_core<S: Scope<Timestamp=T>>(self, scope: &mut S, period: Option<std::time::Duration>) -> StreamCore<S, C>;
+    fn replay_core<S: Scope<Timestamp=T>>(self, scope: &mut S, period: Option<std::time::Duration>) -> Stream<S, C>;
 }
 
 impl<T: Timestamp, C: Container, I> Replay<T, C> for I
 where I : IntoIterator,
       <I as IntoIterator>::Item: EventIteratorCore<T, C>+'static {
-    fn replay_core<S: Scope<Timestamp=T>>(self, scope: &mut S, period: Option<std::time::Duration>) -> StreamCore<S, C>{
+    fn replay_core<S: Scope<Timestamp=T>>(self, scope: &mut S, period: Option<std::time::Duration>) -> Stream<S, C>{
 
         let mut builder = OperatorBuilder::new("Replay".to_owned(), scope.clone());
 

--- a/timely/src/dataflow/operators/capture/replay.rs
+++ b/timely/src/dataflow/operators/capture/replay.rs
@@ -40,7 +40,7 @@
 
 use crate::dataflow::{Scope, Stream};
 use crate::dataflow::channels::pushers::Counter as PushCounter;
-use crate::dataflow::channels::pushers::buffer::BufferCore as PushBuffer;
+use crate::dataflow::channels::pushers::buffer::Buffer as PushBuffer;
 use crate::dataflow::operators::generic::builder_raw::OperatorBuilder;
 use crate::progress::Timestamp;
 

--- a/timely/src/dataflow/operators/capture/replay.rs
+++ b/timely/src/dataflow/operators/capture/replay.rs
@@ -44,7 +44,7 @@ use crate::dataflow::channels::pushers::buffer::Buffer as PushBuffer;
 use crate::dataflow::operators::generic::builder_raw::OperatorBuilder;
 use crate::progress::Timestamp;
 
-use super::EventCore;
+use super::Event;
 use super::event::EventIteratorCore;
 use crate::Container;
 
@@ -93,10 +93,10 @@ where I : IntoIterator,
                 for event_stream in event_streams.iter_mut() {
                     while let Some(event) = event_stream.next() {
                         match event {
-                            EventCore::Progress(vec) => {
+                            Event::Progress(vec) => {
                                 progress.internals[0].extend(vec.iter().cloned());
                             },
-                            EventCore::Messages(ref time, data) => {
+                            Event::Messages(ref time, data) => {
                                 allocation.clone_from(data);
                                 output.session(time).give_container(&mut allocation);
                             }

--- a/timely/src/dataflow/operators/capture/replay.rs
+++ b/timely/src/dataflow/operators/capture/replay.rs
@@ -39,7 +39,7 @@
 //! than that in which the stream was captured.
 
 use crate::dataflow::{Scope, Stream};
-use crate::dataflow::channels::pushers::CounterCore as PushCounter;
+use crate::dataflow::channels::pushers::Counter as PushCounter;
 use crate::dataflow::channels::pushers::buffer::BufferCore as PushBuffer;
 use crate::dataflow::operators::generic::builder_raw::OperatorBuilder;
 use crate::progress::Timestamp;

--- a/timely/src/dataflow/operators/capture/replay.rs
+++ b/timely/src/dataflow/operators/capture/replay.rs
@@ -45,7 +45,7 @@ use crate::dataflow::operators::generic::builder_raw::OperatorBuilder;
 use crate::progress::Timestamp;
 
 use super::Event;
-use super::event::EventIteratorCore;
+use super::event::EventIterator;
 use crate::Container;
 
 /// Replay a capture stream into a scope with the same timestamp.
@@ -64,7 +64,7 @@ pub trait Replay<T: Timestamp, C> : Sized {
 
 impl<T: Timestamp, C: Container, I> Replay<T, C> for I
 where I : IntoIterator,
-      <I as IntoIterator>::Item: EventIteratorCore<T, C>+'static {
+      <I as IntoIterator>::Item: EventIterator<T, C>+'static {
     fn replay_core<S: Scope<Timestamp=T>>(self, scope: &mut S, period: Option<std::time::Duration>) -> Stream<S, C>{
 
         let mut builder = OperatorBuilder::new("Replay".to_owned(), scope.clone());

--- a/timely/src/dataflow/operators/concat.rs
+++ b/timely/src/dataflow/operators/concat.rs
@@ -3,7 +3,7 @@
 
 use crate::Container;
 use crate::dataflow::channels::pact::Pipeline;
-use crate::dataflow::{StreamCore, Scope};
+use crate::dataflow::{Stream, Scope};
 
 /// Merge the contents of two streams.
 pub trait Concat<G: Scope, D: Container> {
@@ -20,11 +20,11 @@ pub trait Concat<G: Scope, D: Container> {
     ///           .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn concat(&self, _: &StreamCore<G, D>) -> StreamCore<G, D>;
+    fn concat(&self, _: &Stream<G, D>) -> Stream<G, D>;
 }
 
-impl<G: Scope, D: Container> Concat<G, D> for StreamCore<G, D> {
-    fn concat(&self, other: &StreamCore<G, D>) -> StreamCore<G, D> {
+impl<G: Scope, D: Container> Concat<G, D> for Stream<G, D> {
+    fn concat(&self, other: &Stream<G, D>) -> Stream<G, D> {
         self.scope().concatenate([self.clone(), other.clone()])
     }
 }
@@ -47,15 +47,15 @@ pub trait Concatenate<G: Scope, D: Container> {
     ///          .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn concatenate<I>(&self, sources: I) -> StreamCore<G, D>
+    fn concatenate<I>(&self, sources: I) -> Stream<G, D>
     where
-        I: IntoIterator<Item=StreamCore<G, D>>;
+        I: IntoIterator<Item=Stream<G, D>>;
 }
 
-impl<G: Scope, D: Container> Concatenate<G, D> for StreamCore<G, D> {
-    fn concatenate<I>(&self, sources: I) -> StreamCore<G, D>
+impl<G: Scope, D: Container> Concatenate<G, D> for Stream<G, D> {
+    fn concatenate<I>(&self, sources: I) -> Stream<G, D>
     where
-        I: IntoIterator<Item=StreamCore<G, D>>
+        I: IntoIterator<Item=Stream<G, D>>
     {
         let clone = self.clone();
         self.scope().concatenate(Some(clone).into_iter().chain(sources))
@@ -63,9 +63,9 @@ impl<G: Scope, D: Container> Concatenate<G, D> for StreamCore<G, D> {
 }
 
 impl<G: Scope, D: Container> Concatenate<G, D> for G {
-    fn concatenate<I>(&self, sources: I) -> StreamCore<G, D>
+    fn concatenate<I>(&self, sources: I) -> Stream<G, D>
     where
-        I: IntoIterator<Item=StreamCore<G, D>>
+        I: IntoIterator<Item=Stream<G, D>>
     {
 
         // create an operator builder.

--- a/timely/src/dataflow/operators/count.rs
+++ b/timely/src/dataflow/operators/count.rs
@@ -5,7 +5,7 @@ use crate::communication::message::RefOrMut;
 
 use crate::Data;
 use crate::dataflow::channels::pact::Pipeline;
-use crate::dataflow::{Stream, Scope};
+use crate::dataflow::{Scope, StreamCore};
 use crate::dataflow::operators::generic::operator::Operator;
 
 /// Accumulates records within a timestamp.
@@ -27,7 +27,7 @@ pub trait Accumulate<G: Scope, D: Data> {
     /// let extracted = captured.extract();
     /// assert_eq!(extracted, vec![(0, vec![45])]);
     /// ```
-    fn accumulate<A: Data>(&self, default: A, logic: impl Fn(&mut A, RefOrMut<Vec<D>>)+'static) -> Stream<G, A>;
+    fn accumulate<A: Data>(&self, default: A, logic: impl Fn(&mut A, RefOrMut<Vec<D>>)+'static) -> StreamCore<G, Vec<A>>;
     /// Counts the number of records observed at each time.
     ///
     /// # Examples
@@ -45,13 +45,13 @@ pub trait Accumulate<G: Scope, D: Data> {
     /// let extracted = captured.extract();
     /// assert_eq!(extracted, vec![(0, vec![10])]);
     /// ```
-    fn count(&self) -> Stream<G, usize> {
+    fn count(&self) -> StreamCore<G, Vec<usize>> {
         self.accumulate(0, |sum, data| *sum += data.len())
     }
 }
 
-impl<G: Scope, D: Data> Accumulate<G, D> for Stream<G, D> {
-    fn accumulate<A: Data>(&self, default: A, logic: impl Fn(&mut A, RefOrMut<Vec<D>>)+'static) -> Stream<G, A> {
+impl<G: Scope, D: Data> Accumulate<G, D> for StreamCore<G, Vec<D>> {
+    fn accumulate<A: Data>(&self, default: A, logic: impl Fn(&mut A, RefOrMut<Vec<D>>)+'static) -> StreamCore<G, Vec<A>> {
 
         let mut accums = HashMap::new();
         self.unary_notify(Pipeline, "Accumulate", vec![], move |input, output, notificator| {

--- a/timely/src/dataflow/operators/count.rs
+++ b/timely/src/dataflow/operators/count.rs
@@ -5,7 +5,7 @@ use crate::communication::message::RefOrMut;
 
 use crate::Data;
 use crate::dataflow::channels::pact::Pipeline;
-use crate::dataflow::{Scope, StreamCore};
+use crate::dataflow::{Scope, Stream};
 use crate::dataflow::operators::generic::operator::Operator;
 
 /// Accumulates records within a timestamp.
@@ -27,7 +27,7 @@ pub trait Accumulate<G: Scope, D: Data> {
     /// let extracted = captured.extract();
     /// assert_eq!(extracted, vec![(0, vec![45])]);
     /// ```
-    fn accumulate<A: Data>(&self, default: A, logic: impl Fn(&mut A, RefOrMut<Vec<D>>)+'static) -> StreamCore<G, Vec<A>>;
+    fn accumulate<A: Data>(&self, default: A, logic: impl Fn(&mut A, RefOrMut<Vec<D>>)+'static) -> Stream<G, Vec<A>>;
     /// Counts the number of records observed at each time.
     ///
     /// # Examples
@@ -45,13 +45,13 @@ pub trait Accumulate<G: Scope, D: Data> {
     /// let extracted = captured.extract();
     /// assert_eq!(extracted, vec![(0, vec![10])]);
     /// ```
-    fn count(&self) -> StreamCore<G, Vec<usize>> {
+    fn count(&self) -> Stream<G, Vec<usize>> {
         self.accumulate(0, |sum, data| *sum += data.len())
     }
 }
 
-impl<G: Scope, D: Data> Accumulate<G, D> for StreamCore<G, Vec<D>> {
-    fn accumulate<A: Data>(&self, default: A, logic: impl Fn(&mut A, RefOrMut<Vec<D>>)+'static) -> StreamCore<G, Vec<A>> {
+impl<G: Scope, D: Data> Accumulate<G, D> for Stream<G, Vec<D>> {
+    fn accumulate<A: Data>(&self, default: A, logic: impl Fn(&mut A, RefOrMut<Vec<D>>)+'static) -> Stream<G, Vec<A>> {
 
         let mut accums = HashMap::new();
         self.unary_notify(Pipeline, "Accumulate", vec![], move |input, output, notificator| {

--- a/timely/src/dataflow/operators/delay.rs
+++ b/timely/src/dataflow/operators/delay.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::Data;
 use crate::order::{PartialOrder, TotalOrder};
 use crate::dataflow::channels::pact::Pipeline;
-use crate::dataflow::{Stream, Scope};
+use crate::dataflow::{Scope, StreamCore};
 use crate::dataflow::operators::generic::operator::Operator;
 
 /// Methods to advance the timestamps of records or batches of records.
@@ -94,7 +94,7 @@ pub trait Delay<G: Scope, D: Data> {
     fn delay_batch<L: FnMut(&G::Timestamp)->G::Timestamp+'static>(&self, func: L) -> Self;
 }
 
-impl<G: Scope, D: Data> Delay<G, D> for Stream<G, D> {
+impl<G: Scope, D: Data> Delay<G, D> for StreamCore<G, Vec<D>> {
     fn delay<L: FnMut(&D, &G::Timestamp)->G::Timestamp+'static>(&self, mut func: L) -> Self {
         let mut elements = HashMap::new();
         let mut vector = Vec::new();

--- a/timely/src/dataflow/operators/delay.rs
+++ b/timely/src/dataflow/operators/delay.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::Data;
 use crate::order::{PartialOrder, TotalOrder};
 use crate::dataflow::channels::pact::Pipeline;
-use crate::dataflow::{Scope, StreamCore};
+use crate::dataflow::{Scope, Stream};
 use crate::dataflow::operators::generic::operator::Operator;
 
 /// Methods to advance the timestamps of records or batches of records.
@@ -94,7 +94,7 @@ pub trait Delay<G: Scope, D: Data> {
     fn delay_batch<L: FnMut(&G::Timestamp)->G::Timestamp+'static>(&self, func: L) -> Self;
 }
 
-impl<G: Scope, D: Data> Delay<G, D> for StreamCore<G, Vec<D>> {
+impl<G: Scope, D: Data> Delay<G, D> for Stream<G, Vec<D>> {
     fn delay<L: FnMut(&D, &G::Timestamp)->G::Timestamp+'static>(&self, mut func: L) -> Self {
         let mut elements = HashMap::new();
         let mut vector = Vec::new();

--- a/timely/src/dataflow/operators/enterleave.rs
+++ b/timely/src/dataflow/operators/enterleave.rs
@@ -27,7 +27,7 @@ use crate::progress::{Source, Target};
 use crate::order::Product;
 use crate::{Container, Data};
 use crate::communication::Push;
-use crate::dataflow::channels::pushers::{Counter, TeeCore};
+use crate::dataflow::channels::pushers::{Counter, Tee};
 use crate::dataflow::channels::{Bundle, Message};
 
 use crate::worker::AsWorker;
@@ -87,7 +87,7 @@ impl<G: Scope, T: Timestamp+Refines<G::Timestamp>, C: Data+Container> Enter<G, T
 
         use crate::scheduling::Scheduler;
 
-        let (targets, registrar) = TeeCore::<T, C>::new();
+        let (targets, registrar) = Tee::<T, C>::new();
         let ingress = IngressNub {
             targets: Counter::new(targets),
             phantom: ::std::marker::PhantomData,
@@ -129,7 +129,7 @@ impl<'a, G: Scope, D: Clone+Container, T: Timestamp+Refines<G::Timestamp>> Leave
         let scope = self.scope();
 
         let output = scope.subgraph.borrow_mut().new_output();
-        let (targets, registrar) = TeeCore::<G::Timestamp, D>::new();
+        let (targets, registrar) = Tee::<G::Timestamp, D>::new();
         let channel_id = scope.clone().new_identifier();
         self.connect_to(Target::new(0, output.port), EgressNub { targets, phantom: PhantomData }, channel_id);
 
@@ -143,7 +143,7 @@ impl<'a, G: Scope, D: Clone+Container, T: Timestamp+Refines<G::Timestamp>> Leave
 
 
 struct IngressNub<TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TData: Container> {
-    targets: Counter<TInner, TData, TeeCore<TInner, TData>>,
+    targets: Counter<TInner, TData, Tee<TInner, TData>>,
     phantom: ::std::marker::PhantomData<TOuter>,
     activator: crate::scheduling::Activator,
     active: bool,
@@ -175,7 +175,7 @@ impl<TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TData: Container> Pus
 
 
 struct EgressNub<TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TData: Data> {
-    targets: TeeCore<TOuter, TData>,
+    targets: Tee<TOuter, TData>,
     phantom: PhantomData<TInner>,
 }
 

--- a/timely/src/dataflow/operators/enterleave.rs
+++ b/timely/src/dataflow/operators/enterleave.rs
@@ -28,7 +28,7 @@ use crate::order::Product;
 use crate::{Container, Data};
 use crate::communication::Push;
 use crate::dataflow::channels::pushers::{CounterCore, TeeCore};
-use crate::dataflow::channels::{BundleCore, Message};
+use crate::dataflow::channels::{Bundle, Message};
 
 use crate::worker::AsWorker;
 use crate::dataflow::{Stream, Scope};
@@ -149,12 +149,12 @@ struct IngressNub<TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TData: C
     active: bool,
 }
 
-impl<TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TData: Container> Push<BundleCore<TOuter, TData>> for IngressNub<TOuter, TInner, TData> {
-    fn push(&mut self, element: &mut Option<BundleCore<TOuter, TData>>) {
+impl<TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TData: Container> Push<Bundle<TOuter, TData>> for IngressNub<TOuter, TInner, TData> {
+    fn push(&mut self, element: &mut Option<Bundle<TOuter, TData>>) {
         if let Some(message) = element {
             let outer_message = message.as_mut();
             let data = ::std::mem::take(&mut outer_message.data);
-            let mut inner_message = Some(BundleCore::from_typed(Message::new(TInner::to_inner(outer_message.time.clone()), data, 0, 0)));
+            let mut inner_message = Some(Bundle::from_typed(Message::new(TInner::to_inner(outer_message.time.clone()), data, 0, 0)));
             self.targets.push(&mut inner_message);
             if let Some(inner_message) = inner_message {
                 if let Some(inner_message) = inner_message.if_typed() {
@@ -179,13 +179,13 @@ struct EgressNub<TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TData: Da
     phantom: PhantomData<TInner>,
 }
 
-impl<TOuter, TInner, TData: Container> Push<BundleCore<TInner, TData>> for EgressNub<TOuter, TInner, TData>
+impl<TOuter, TInner, TData: Container> Push<Bundle<TInner, TData>> for EgressNub<TOuter, TInner, TData>
 where TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TData: Data {
-    fn push(&mut self, message: &mut Option<BundleCore<TInner, TData>>) {
+    fn push(&mut self, message: &mut Option<Bundle<TInner, TData>>) {
         if let Some(message) = message {
             let inner_message = message.as_mut();
             let data = ::std::mem::take(&mut inner_message.data);
-            let mut outer_message = Some(BundleCore::from_typed(Message::new(inner_message.time.clone().to_outer(), data, 0, 0)));
+            let mut outer_message = Some(Bundle::from_typed(Message::new(inner_message.time.clone().to_outer(), data, 0, 0)));
             self.targets.push(&mut outer_message);
             if let Some(outer_message) = outer_message {
                 if let Some(outer_message) = outer_message.if_typed() {

--- a/timely/src/dataflow/operators/enterleave.rs
+++ b/timely/src/dataflow/operators/enterleave.rs
@@ -27,7 +27,7 @@ use crate::progress::{Source, Target};
 use crate::order::Product;
 use crate::{Container, Data};
 use crate::communication::Push;
-use crate::dataflow::channels::pushers::{CounterCore, TeeCore};
+use crate::dataflow::channels::pushers::{Counter, TeeCore};
 use crate::dataflow::channels::{Bundle, Message};
 
 use crate::worker::AsWorker;
@@ -89,7 +89,7 @@ impl<G: Scope, T: Timestamp+Refines<G::Timestamp>, C: Data+Container> Enter<G, T
 
         let (targets, registrar) = TeeCore::<T, C>::new();
         let ingress = IngressNub {
-            targets: CounterCore::new(targets),
+            targets: Counter::new(targets),
             phantom: ::std::marker::PhantomData,
             activator: scope.activator_for(&scope.addr()),
             active: false,
@@ -143,7 +143,7 @@ impl<'a, G: Scope, D: Clone+Container, T: Timestamp+Refines<G::Timestamp>> Leave
 
 
 struct IngressNub<TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TData: Container> {
-    targets: CounterCore<TInner, TData, TeeCore<TInner, TData>>,
+    targets: Counter<TInner, TData, TeeCore<TInner, TData>>,
     phantom: ::std::marker::PhantomData<TOuter>,
     activator: crate::scheduling::Activator,
     active: bool,

--- a/timely/src/dataflow/operators/enterleave.rs
+++ b/timely/src/dataflow/operators/enterleave.rs
@@ -31,7 +31,7 @@ use crate::dataflow::channels::pushers::{CounterCore, TeeCore};
 use crate::dataflow::channels::{BundleCore, Message};
 
 use crate::worker::AsWorker;
-use crate::dataflow::{StreamCore, Scope, Stream};
+use crate::dataflow::{StreamCore, Scope};
 use crate::dataflow::scopes::{Child, ScopeParent};
 use crate::dataflow::operators::delay::Delay;
 
@@ -72,12 +72,12 @@ pub trait EnterAt<G: Scope, T: Timestamp, D: Data> {
     ///     });
     /// });
     /// ```
-    fn enter_at<'a, F:FnMut(&D)->T+'static>(&self, scope: &Iterative<'a, G, T>, initial: F) -> Stream<Iterative<'a, G, T>, D> ;
+    fn enter_at<'a, F:FnMut(&D)->T+'static>(&self, scope: &Iterative<'a, G, T>, initial: F) -> StreamCore<Iterative<'a, G, T>, Vec<D>>;
 }
 
 impl<G: Scope, T: Timestamp, D: Data, E: Enter<G, Product<<G as ScopeParent>::Timestamp, T>, Vec<D>>> EnterAt<G, T, D> for E {
     fn enter_at<'a, F:FnMut(&D)->T+'static>(&self, scope: &Iterative<'a, G, T>, mut initial: F) ->
-        Stream<Iterative<'a, G, T>, D> {
+    StreamCore<Iterative<'a, G, T>, Vec<D>> {
             self.enter(scope).delay(move |datum, time| Product::new(time.clone().to_outer(), initial(datum)))
     }
 }

--- a/timely/src/dataflow/operators/exchange.rs
+++ b/timely/src/dataflow/operators/exchange.rs
@@ -2,7 +2,7 @@
 
 use crate::ExchangeData;
 use crate::container::PushPartitioned;
-use crate::dataflow::channels::pact::ExchangeCore;
+use crate::dataflow::channels::pact::Exchange as ExchangePact;
 use crate::dataflow::operators::generic::operator::Operator;
 use crate::dataflow::{Scope, Stream};
 
@@ -33,7 +33,7 @@ where
 {
     fn exchange(&self, route: impl FnMut(&C::Item) -> u64 + 'static) -> Stream<G, C> {
         let mut container = Default::default();
-        self.unary(ExchangeCore::new(route), "Exchange", |_, _| {
+        self.unary(ExchangePact::new(route), "Exchange", |_, _| {
             move |input, output| {
                 input.for_each(|time, data| {
                     data.swap(&mut container);

--- a/timely/src/dataflow/operators/exchange.rs
+++ b/timely/src/dataflow/operators/exchange.rs
@@ -4,7 +4,7 @@ use crate::ExchangeData;
 use crate::container::PushPartitioned;
 use crate::dataflow::channels::pact::ExchangeCore;
 use crate::dataflow::operators::generic::operator::Operator;
-use crate::dataflow::{Scope, StreamCore};
+use crate::dataflow::{Scope, Stream};
 
 /// Exchange records between workers.
 pub trait Exchange<D> {
@@ -26,12 +26,12 @@ pub trait Exchange<D> {
     fn exchange(&self, route: impl FnMut(&D) -> u64 + 'static) -> Self;
 }
 
-impl<G: Scope, C> Exchange<C::Item> for StreamCore<G, C>
+impl<G: Scope, C> Exchange<C::Item> for Stream<G, C>
 where
     C: PushPartitioned + ExchangeData,
     C::Item: ExchangeData,
 {
-    fn exchange(&self, route: impl FnMut(&C::Item) -> u64 + 'static) -> StreamCore<G, C> {
+    fn exchange(&self, route: impl FnMut(&C::Item) -> u64 + 'static) -> Stream<G, C> {
         let mut container = Default::default();
         self.unary(ExchangeCore::new(route), "Exchange", |_, _| {
             move |input, output| {

--- a/timely/src/dataflow/operators/feedback.rs
+++ b/timely/src/dataflow/operators/feedback.rs
@@ -8,7 +8,7 @@ use crate::order::Product;
 
 use crate::dataflow::channels::pushers::TeeCore;
 use crate::dataflow::channels::pact::Pipeline;
-use crate::dataflow::{StreamCore, Scope};
+use crate::dataflow::{Stream, Scope};
 use crate::dataflow::scopes::child::Iterative;
 use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use crate::dataflow::operators::generic::OutputWrapper;
@@ -36,9 +36,9 @@ pub trait Feedback<G: Scope> {
     ///            .connect_loop(handle);
     /// });
     /// ```
-    fn feedback<D: Data>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (Handle<G, D>, StreamCore<G, Vec<D>>);
+    fn feedback<D: Data>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (Handle<G, D>, Stream<G, Vec<D>>);
 
-    /// Creates a [StreamCore] and a [HandleCore] to later bind the source of that `Stream`.
+    /// Creates a [Stream] and a [HandleCore] to later bind the source of that `Stream`.
     ///
     /// The resulting `Stream` will have its data defined by a future call to `connect_loop` with
     /// its `Handle` passed as an argument. Data passed through the stream will have their
@@ -59,7 +59,7 @@ pub trait Feedback<G: Scope> {
     ///            .connect_loop(handle);
     /// });
     /// ```
-    fn feedback_core<D: Container>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (HandleCore<G, D>, StreamCore<G, D>);
+    fn feedback_core<D: Container>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (HandleCore<G, D>, Stream<G, D>);
 }
 
 /// Creates a `Stream` and a `Handle` to later bind the source of that `Stream`.
@@ -87,15 +87,15 @@ pub trait LoopVariable<'a, G: Scope, T: Timestamp> {
     ///     });
     /// });
     /// ```
-    fn loop_variable<D: Container>(&mut self, summary: T::Summary) -> (HandleCore<Iterative<'a, G, T>, D>, StreamCore<Iterative<'a, G, T>, D>);
+    fn loop_variable<D: Container>(&mut self, summary: T::Summary) -> (HandleCore<Iterative<'a, G, T>, D>, Stream<Iterative<'a, G, T>, D>);
 }
 
 impl<G: Scope> Feedback<G> for G {
-    fn feedback<D: Data>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (Handle<G, D>, StreamCore<G, Vec<D>>) {
+    fn feedback<D: Data>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (Handle<G, D>, Stream<G, Vec<D>>) {
         self.feedback_core(summary)
     }
 
-    fn feedback_core<D: Container>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (HandleCore<G, D>, StreamCore<G, D>) {
+    fn feedback_core<D: Container>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (HandleCore<G, D>, Stream<G, D>) {
 
         let mut builder = OperatorBuilder::new("Feedback".to_owned(), self.clone());
         let (output, stream) = builder.new_output();
@@ -105,7 +105,7 @@ impl<G: Scope> Feedback<G> for G {
 }
 
 impl<'a, G: Scope, T: Timestamp> LoopVariable<'a, G, T> for Iterative<'a, G, T> {
-    fn loop_variable<D: Container>(&mut self, summary: T::Summary) -> (HandleCore<Iterative<'a, G, T>, D>, StreamCore<Iterative<'a, G, T>, D>) {
+    fn loop_variable<D: Container>(&mut self, summary: T::Summary) -> (HandleCore<Iterative<'a, G, T>, D>, Stream<Iterative<'a, G, T>, D>) {
         self.feedback_core(Product::new(Default::default(), summary))
     }
 }
@@ -132,7 +132,7 @@ pub trait ConnectLoop<G: Scope, D: Container> {
     fn connect_loop(&self, _: HandleCore<G, D>);
 }
 
-impl<G: Scope, D: Container> ConnectLoop<G, D> for StreamCore<G, D> {
+impl<G: Scope, D: Container> ConnectLoop<G, D> for Stream<G, D> {
     fn connect_loop(&self, helper: HandleCore<G, D>) {
 
         let mut builder = helper.builder;

--- a/timely/src/dataflow/operators/feedback.rs
+++ b/timely/src/dataflow/operators/feedback.rs
@@ -8,7 +8,7 @@ use crate::order::Product;
 
 use crate::dataflow::channels::pushers::TeeCore;
 use crate::dataflow::channels::pact::Pipeline;
-use crate::dataflow::{StreamCore, Scope, Stream};
+use crate::dataflow::{StreamCore, Scope};
 use crate::dataflow::scopes::child::Iterative;
 use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use crate::dataflow::operators::generic::OutputWrapper;
@@ -36,7 +36,7 @@ pub trait Feedback<G: Scope> {
     ///            .connect_loop(handle);
     /// });
     /// ```
-    fn feedback<D: Data>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (Handle<G, D>, Stream<G, D>);
+    fn feedback<D: Data>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (Handle<G, D>, StreamCore<G, Vec<D>>);
 
     /// Creates a [StreamCore] and a [HandleCore] to later bind the source of that `Stream`.
     ///
@@ -91,7 +91,7 @@ pub trait LoopVariable<'a, G: Scope, T: Timestamp> {
 }
 
 impl<G: Scope> Feedback<G> for G {
-    fn feedback<D: Data>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (Handle<G, D>, Stream<G, D>) {
+    fn feedback<D: Data>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (Handle<G, D>, StreamCore<G, Vec<D>>) {
         self.feedback_core(summary)
     }
 

--- a/timely/src/dataflow/operators/feedback.rs
+++ b/timely/src/dataflow/operators/feedback.rs
@@ -6,7 +6,7 @@ use crate::progress::{Timestamp, PathSummary};
 use crate::progress::frontier::Antichain;
 use crate::order::Product;
 
-use crate::dataflow::channels::pushers::TeeCore;
+use crate::dataflow::channels::pushers::Tee;
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::{Stream, Scope};
 use crate::dataflow::scopes::child::Iterative;
@@ -162,7 +162,7 @@ impl<G: Scope, D: Container> ConnectLoop<G, D> for Stream<G, D> {
 pub struct HandleCore<G: Scope, D: Container> {
     builder: OperatorBuilder<G>,
     summary: <G::Timestamp as Timestamp>::Summary,
-    output: OutputWrapper<G::Timestamp, D, TeeCore<G::Timestamp, D>>,
+    output: OutputWrapper<G::Timestamp, D, Tee<G::Timestamp, D>>,
 }
 
 /// A `HandleCore` specialized for using `Vec` as container

--- a/timely/src/dataflow/operators/filter.rs
+++ b/timely/src/dataflow/operators/filter.rs
@@ -2,7 +2,7 @@
 
 use crate::Data;
 use crate::dataflow::channels::pact::Pipeline;
-use crate::dataflow::{Stream, Scope};
+use crate::dataflow::{Scope, StreamCore};
 use crate::dataflow::operators::generic::operator::Operator;
 
 /// Extension trait for filtering.
@@ -22,8 +22,8 @@ pub trait Filter<D: Data> {
     fn filter<P: FnMut(&D)->bool+'static>(&self, predicate: P) -> Self;
 }
 
-impl<G: Scope, D: Data> Filter<D> for Stream<G, D> {
-    fn filter<P: FnMut(&D)->bool+'static>(&self, mut predicate: P) -> Stream<G, D> {
+impl<G: Scope, D: Data> Filter<D> for StreamCore<G, Vec<D>> {
+    fn filter<P: FnMut(&D)->bool+'static>(&self, mut predicate: P) -> StreamCore<G, Vec<D>> {
         let mut vector = Vec::new();
         self.unary(Pipeline, "Filter", move |_,_| move |input, output| {
             input.for_each(|time, data| {

--- a/timely/src/dataflow/operators/filter.rs
+++ b/timely/src/dataflow/operators/filter.rs
@@ -2,7 +2,7 @@
 
 use crate::Data;
 use crate::dataflow::channels::pact::Pipeline;
-use crate::dataflow::{Scope, StreamCore};
+use crate::dataflow::{Scope, Stream};
 use crate::dataflow::operators::generic::operator::Operator;
 
 /// Extension trait for filtering.
@@ -22,8 +22,8 @@ pub trait Filter<D: Data> {
     fn filter<P: FnMut(&D)->bool+'static>(&self, predicate: P) -> Self;
 }
 
-impl<G: Scope, D: Data> Filter<D> for StreamCore<G, Vec<D>> {
-    fn filter<P: FnMut(&D)->bool+'static>(&self, mut predicate: P) -> StreamCore<G, Vec<D>> {
+impl<G: Scope, D: Data> Filter<D> for Stream<G, Vec<D>> {
+    fn filter<P: FnMut(&D)->bool+'static>(&self, mut predicate: P) -> Stream<G, Vec<D>> {
         let mut vector = Vec::new();
         self.unary(Pipeline, "Filter", move |_,_| move |input, output| {
             input.for_each(|time, data| {

--- a/timely/src/dataflow/operators/flow_controlled.rs
+++ b/timely/src/dataflow/operators/flow_controlled.rs
@@ -5,7 +5,7 @@ use crate::order::{PartialOrder, TotalOrder};
 use crate::progress::timestamp::Timestamp;
 use crate::dataflow::operators::generic::operator::source;
 use crate::dataflow::operators::probe::Handle;
-use crate::dataflow::{Stream, Scope};
+use crate::dataflow::{Scope, StreamCore};
 
 /// Output of the input reading function for iterator_source.
 pub struct IteratorSourceInput<T: Clone, D: Data, DI: IntoIterator<Item=D>, I: IntoIterator<Item=(T, DI)>> {
@@ -82,7 +82,7 @@ pub fn iterator_source<
         name: &str,
         mut input_f: F,
         probe: Handle<G::Timestamp>,
-        ) -> Stream<G, D> where G::Timestamp: TotalOrder {
+        ) -> StreamCore<G, Vec<D>> where G::Timestamp: TotalOrder {
 
     let mut target = G::Timestamp::minimum();
     source(scope, name, |cap, info| {

--- a/timely/src/dataflow/operators/flow_controlled.rs
+++ b/timely/src/dataflow/operators/flow_controlled.rs
@@ -5,7 +5,7 @@ use crate::order::{PartialOrder, TotalOrder};
 use crate::progress::timestamp::Timestamp;
 use crate::dataflow::operators::generic::operator::source;
 use crate::dataflow::operators::probe::Handle;
-use crate::dataflow::{Scope, StreamCore};
+use crate::dataflow::{Scope, Stream};
 
 /// Output of the input reading function for iterator_source.
 pub struct IteratorSourceInput<T: Clone, D: Data, DI: IntoIterator<Item=D>, I: IntoIterator<Item=(T, DI)>> {
@@ -82,7 +82,7 @@ pub fn iterator_source<
         name: &str,
         mut input_f: F,
         probe: Handle<G::Timestamp>,
-        ) -> StreamCore<G, Vec<D>> where G::Timestamp: TotalOrder {
+        ) -> Stream<G, Vec<D>> where G::Timestamp: TotalOrder {
 
     let mut target = G::Timestamp::minimum();
     source(scope, name, |cap, info| {

--- a/timely/src/dataflow/operators/generic/builder_raw.rs
+++ b/timely/src/dataflow/operators/generic/builder_raw.rs
@@ -14,7 +14,7 @@ use crate::progress::{Source, Target};
 use crate::progress::{Timestamp, Operate, operate::SharedProgress, Antichain};
 
 use crate::Container;
-use crate::dataflow::{StreamCore, Scope};
+use crate::dataflow::{Stream, Scope};
 use crate::dataflow::channels::pushers::TeeCore;
 use crate::dataflow::channels::pact::ParallelizationContractCore;
 use crate::dataflow::operators::generic::operator_info::OperatorInfo;
@@ -105,7 +105,7 @@ impl<G: Scope> OperatorBuilder<G> {
     }
 
     /// Adds a new input to a generic operator builder, returning the `Pull` implementor to use.
-    pub fn new_input<D: Container, P>(&mut self, stream: &StreamCore<G, D>, pact: P) -> P::Puller
+    pub fn new_input<D: Container, P>(&mut self, stream: &Stream<G, D>, pact: P) -> P::Puller
         where
             P: ParallelizationContractCore<G::Timestamp, D> {
         let connection = vec![Antichain::from_elem(Default::default()); self.shape.outputs];
@@ -113,7 +113,7 @@ impl<G: Scope> OperatorBuilder<G> {
     }
 
     /// Adds a new input to a generic operator builder, returning the `Pull` implementor to use.
-    pub fn new_input_connection<D: Container, P>(&mut self, stream: &StreamCore<G, D>, pact: P, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> P::Puller
+    pub fn new_input_connection<D: Container, P>(&mut self, stream: &Stream<G, D>, pact: P, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> P::Puller
     where
         P: ParallelizationContractCore<G::Timestamp, D> {
 
@@ -131,18 +131,18 @@ impl<G: Scope> OperatorBuilder<G> {
     }
 
     /// Adds a new output to a generic operator builder, returning the `Push` implementor to use.
-    pub fn new_output<D: Container>(&mut self) -> (TeeCore<G::Timestamp, D>, StreamCore<G, D>) {
+    pub fn new_output<D: Container>(&mut self) -> (TeeCore<G::Timestamp, D>, Stream<G, D>) {
 
         let connection = vec![Antichain::from_elem(Default::default()); self.shape.inputs];
         self.new_output_connection(connection)
     }
 
     /// Adds a new output to a generic operator builder, returning the `Push` implementor to use.
-    pub fn new_output_connection<D: Container>(&mut self, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> (TeeCore<G::Timestamp, D>, StreamCore<G, D>) {
+    pub fn new_output_connection<D: Container>(&mut self, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> (TeeCore<G::Timestamp, D>, Stream<G, D>) {
 
         let (targets, registrar) = TeeCore::<G::Timestamp,D>::new();
         let source = Source::new(self.index, self.shape.outputs);
-        let stream = StreamCore::new(source, registrar, self.scope.clone());
+        let stream = Stream::new(source, registrar, self.scope.clone());
 
         self.shape.outputs += 1;
         assert_eq!(self.shape.inputs, connection.len());

--- a/timely/src/dataflow/operators/generic/builder_raw.rs
+++ b/timely/src/dataflow/operators/generic/builder_raw.rs
@@ -16,7 +16,7 @@ use crate::progress::{Timestamp, Operate, operate::SharedProgress, Antichain};
 use crate::Container;
 use crate::dataflow::{Stream, Scope};
 use crate::dataflow::channels::pushers::TeeCore;
-use crate::dataflow::channels::pact::ParallelizationContractCore;
+use crate::dataflow::channels::pact::ParallelizationContract;
 use crate::dataflow::operators::generic::operator_info::OperatorInfo;
 
 /// Contains type-free information about the operator properties.
@@ -107,7 +107,7 @@ impl<G: Scope> OperatorBuilder<G> {
     /// Adds a new input to a generic operator builder, returning the `Pull` implementor to use.
     pub fn new_input<D: Container, P>(&mut self, stream: &Stream<G, D>, pact: P) -> P::Puller
         where
-            P: ParallelizationContractCore<G::Timestamp, D> {
+            P: ParallelizationContract<G::Timestamp, D> {
         let connection = vec![Antichain::from_elem(Default::default()); self.shape.outputs];
         self.new_input_connection(stream, pact, connection)
     }
@@ -115,7 +115,7 @@ impl<G: Scope> OperatorBuilder<G> {
     /// Adds a new input to a generic operator builder, returning the `Pull` implementor to use.
     pub fn new_input_connection<D: Container, P>(&mut self, stream: &Stream<G, D>, pact: P, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> P::Puller
     where
-        P: ParallelizationContractCore<G::Timestamp, D> {
+        P: ParallelizationContract<G::Timestamp, D> {
 
         let channel_id = self.scope.new_identifier();
         let logging = self.scope.logging();

--- a/timely/src/dataflow/operators/generic/builder_raw.rs
+++ b/timely/src/dataflow/operators/generic/builder_raw.rs
@@ -15,7 +15,7 @@ use crate::progress::{Timestamp, Operate, operate::SharedProgress, Antichain};
 
 use crate::Container;
 use crate::dataflow::{Stream, Scope};
-use crate::dataflow::channels::pushers::TeeCore;
+use crate::dataflow::channels::pushers::Tee;
 use crate::dataflow::channels::pact::ParallelizationContract;
 use crate::dataflow::operators::generic::operator_info::OperatorInfo;
 
@@ -131,16 +131,16 @@ impl<G: Scope> OperatorBuilder<G> {
     }
 
     /// Adds a new output to a generic operator builder, returning the `Push` implementor to use.
-    pub fn new_output<D: Container>(&mut self) -> (TeeCore<G::Timestamp, D>, Stream<G, D>) {
+    pub fn new_output<D: Container>(&mut self) -> (Tee<G::Timestamp, D>, Stream<G, D>) {
 
         let connection = vec![Antichain::from_elem(Default::default()); self.shape.inputs];
         self.new_output_connection(connection)
     }
 
     /// Adds a new output to a generic operator builder, returning the `Push` implementor to use.
-    pub fn new_output_connection<D: Container>(&mut self, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> (TeeCore<G::Timestamp, D>, Stream<G, D>) {
+    pub fn new_output_connection<D: Container>(&mut self, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> (Tee<G::Timestamp, D>, Stream<G, D>) {
 
-        let (targets, registrar) = TeeCore::<G::Timestamp,D>::new();
+        let (targets, registrar) = Tee::<G::Timestamp,D>::new();
         let source = Source::new(self.index, self.shape.outputs);
         let stream = Stream::new(source, registrar, self.scope.clone());
 

--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -12,7 +12,7 @@ use crate::Container;
 use crate::dataflow::{Scope, Stream};
 use crate::dataflow::channels::pushers::TeeCore;
 use crate::dataflow::channels::pushers::Counter as PushCounter;
-use crate::dataflow::channels::pushers::buffer::BufferCore as PushBuffer;
+use crate::dataflow::channels::pushers::buffer::Buffer as PushBuffer;
 use crate::dataflow::channels::pact::ParallelizationContract;
 use crate::dataflow::channels::pullers::Counter as PullCounter;
 use crate::dataflow::operators::capability::Capability;

--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -11,7 +11,7 @@ use crate::progress::frontier::{Antichain, MutableAntichain};
 use crate::Container;
 use crate::dataflow::{Scope, Stream};
 use crate::dataflow::channels::pushers::TeeCore;
-use crate::dataflow::channels::pushers::CounterCore as PushCounter;
+use crate::dataflow::channels::pushers::Counter as PushCounter;
 use crate::dataflow::channels::pushers::buffer::BufferCore as PushBuffer;
 use crate::dataflow::channels::pact::ParallelizationContract;
 use crate::dataflow::channels::pullers::Counter as PullCounter;

--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -16,7 +16,7 @@ use crate::dataflow::channels::pushers::buffer::Buffer as PushBuffer;
 use crate::dataflow::channels::pact::ParallelizationContract;
 use crate::dataflow::channels::pullers::Counter as PullCounter;
 use crate::dataflow::operators::capability::Capability;
-use crate::dataflow::operators::generic::handles::{InputHandleCore, new_input_handle, OutputWrapper};
+use crate::dataflow::operators::generic::handles::{InputHandle, new_input_handle, OutputWrapper};
 use crate::dataflow::operators::generic::operator_info::OperatorInfo;
 use crate::dataflow::operators::generic::builder_raw::OperatorShape;
 
@@ -59,7 +59,7 @@ impl<G: Scope> OperatorBuilder<G> {
     }
 
     /// Adds a new input to a generic operator builder, returning the `Pull` implementor to use.
-    pub fn new_input<D: Container, P>(&mut self, stream: &Stream<G, D>, pact: P) -> InputHandleCore<G::Timestamp, D, P::Puller>
+    pub fn new_input<D: Container, P>(&mut self, stream: &Stream<G, D>, pact: P) -> InputHandle<G::Timestamp, D, P::Puller>
     where
         P: ParallelizationContract<G::Timestamp, D> {
 
@@ -75,7 +75,7 @@ impl<G: Scope> OperatorBuilder<G> {
     ///
     /// Commonly the connections are either the unit summary, indicating the same timestamp might be produced as output, or an empty
     /// antichain indicating that there is no connection from the input to the output.
-    pub fn new_input_connection<D: Container, P>(&mut self, stream: &Stream<G, D>, pact: P, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> InputHandleCore<G::Timestamp, D, P::Puller>
+    pub fn new_input_connection<D: Container, P>(&mut self, stream: &Stream<G, D>, pact: P, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> InputHandle<G::Timestamp, D, P::Puller>
         where
             P: ParallelizationContract<G::Timestamp, D> {
 

--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -13,7 +13,7 @@ use crate::dataflow::{Scope, Stream};
 use crate::dataflow::channels::pushers::TeeCore;
 use crate::dataflow::channels::pushers::CounterCore as PushCounter;
 use crate::dataflow::channels::pushers::buffer::BufferCore as PushBuffer;
-use crate::dataflow::channels::pact::ParallelizationContractCore;
+use crate::dataflow::channels::pact::ParallelizationContract;
 use crate::dataflow::channels::pullers::Counter as PullCounter;
 use crate::dataflow::operators::capability::Capability;
 use crate::dataflow::operators::generic::handles::{InputHandleCore, new_input_handle, OutputWrapper};
@@ -61,7 +61,7 @@ impl<G: Scope> OperatorBuilder<G> {
     /// Adds a new input to a generic operator builder, returning the `Pull` implementor to use.
     pub fn new_input<D: Container, P>(&mut self, stream: &Stream<G, D>, pact: P) -> InputHandleCore<G::Timestamp, D, P::Puller>
     where
-        P: ParallelizationContractCore<G::Timestamp, D> {
+        P: ParallelizationContract<G::Timestamp, D> {
 
         let connection = vec![Antichain::from_elem(Default::default()); self.builder.shape().outputs()];
         self.new_input_connection(stream, pact, connection)
@@ -77,7 +77,7 @@ impl<G: Scope> OperatorBuilder<G> {
     /// antichain indicating that there is no connection from the input to the output.
     pub fn new_input_connection<D: Container, P>(&mut self, stream: &Stream<G, D>, pact: P, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> InputHandleCore<G::Timestamp, D, P::Puller>
         where
-            P: ParallelizationContractCore<G::Timestamp, D> {
+            P: ParallelizationContract<G::Timestamp, D> {
 
         let puller = self.builder.new_input_connection(stream, pact, connection.clone());
 

--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -9,7 +9,7 @@ use crate::progress::operate::SharedProgress;
 use crate::progress::frontier::{Antichain, MutableAntichain};
 
 use crate::Container;
-use crate::dataflow::{Scope, StreamCore};
+use crate::dataflow::{Scope, Stream};
 use crate::dataflow::channels::pushers::TeeCore;
 use crate::dataflow::channels::pushers::CounterCore as PushCounter;
 use crate::dataflow::channels::pushers::buffer::BufferCore as PushBuffer;
@@ -59,7 +59,7 @@ impl<G: Scope> OperatorBuilder<G> {
     }
 
     /// Adds a new input to a generic operator builder, returning the `Pull` implementor to use.
-    pub fn new_input<D: Container, P>(&mut self, stream: &StreamCore<G, D>, pact: P) -> InputHandleCore<G::Timestamp, D, P::Puller>
+    pub fn new_input<D: Container, P>(&mut self, stream: &Stream<G, D>, pact: P) -> InputHandleCore<G::Timestamp, D, P::Puller>
     where
         P: ParallelizationContractCore<G::Timestamp, D> {
 
@@ -75,7 +75,7 @@ impl<G: Scope> OperatorBuilder<G> {
     ///
     /// Commonly the connections are either the unit summary, indicating the same timestamp might be produced as output, or an empty
     /// antichain indicating that there is no connection from the input to the output.
-    pub fn new_input_connection<D: Container, P>(&mut self, stream: &StreamCore<G, D>, pact: P, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> InputHandleCore<G::Timestamp, D, P::Puller>
+    pub fn new_input_connection<D: Container, P>(&mut self, stream: &Stream<G, D>, pact: P, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> InputHandleCore<G::Timestamp, D, P::Puller>
         where
             P: ParallelizationContractCore<G::Timestamp, D> {
 
@@ -92,7 +92,7 @@ impl<G: Scope> OperatorBuilder<G> {
     }
 
     /// Adds a new output to a generic operator builder, returning the `Push` implementor to use.
-    pub fn new_output<D: Container>(&mut self) -> (OutputWrapper<G::Timestamp, D, TeeCore<G::Timestamp, D>>, StreamCore<G, D>) {
+    pub fn new_output<D: Container>(&mut self) -> (OutputWrapper<G::Timestamp, D, TeeCore<G::Timestamp, D>>, Stream<G, D>) {
         let connection = vec![Antichain::from_elem(Default::default()); self.builder.shape().inputs()];
         self.new_output_connection(connection)
     }
@@ -105,7 +105,7 @@ impl<G: Scope> OperatorBuilder<G> {
     ///
     /// Commonly the connections are either the unit summary, indicating the same timestamp might be produced as output, or an empty
     /// antichain indicating that there is no connection from the input to the output.
-    pub fn new_output_connection<D: Container>(&mut self, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> (OutputWrapper<G::Timestamp, D, TeeCore<G::Timestamp, D>>, StreamCore<G, D>) {
+    pub fn new_output_connection<D: Container>(&mut self, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> (OutputWrapper<G::Timestamp, D, TeeCore<G::Timestamp, D>>, Stream<G, D>) {
 
         let (tee, stream) = self.builder.new_output_connection(connection.clone());
 

--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -10,7 +10,7 @@ use crate::progress::frontier::{Antichain, MutableAntichain};
 
 use crate::Container;
 use crate::dataflow::{Scope, Stream};
-use crate::dataflow::channels::pushers::TeeCore;
+use crate::dataflow::channels::pushers::Tee;
 use crate::dataflow::channels::pushers::Counter as PushCounter;
 use crate::dataflow::channels::pushers::buffer::Buffer as PushBuffer;
 use crate::dataflow::channels::pact::ParallelizationContract;
@@ -92,7 +92,7 @@ impl<G: Scope> OperatorBuilder<G> {
     }
 
     /// Adds a new output to a generic operator builder, returning the `Push` implementor to use.
-    pub fn new_output<D: Container>(&mut self) -> (OutputWrapper<G::Timestamp, D, TeeCore<G::Timestamp, D>>, Stream<G, D>) {
+    pub fn new_output<D: Container>(&mut self) -> (OutputWrapper<G::Timestamp, D, Tee<G::Timestamp, D>>, Stream<G, D>) {
         let connection = vec![Antichain::from_elem(Default::default()); self.builder.shape().inputs()];
         self.new_output_connection(connection)
     }
@@ -105,7 +105,7 @@ impl<G: Scope> OperatorBuilder<G> {
     ///
     /// Commonly the connections are either the unit summary, indicating the same timestamp might be produced as output, or an empty
     /// antichain indicating that there is no connection from the input to the output.
-    pub fn new_output_connection<D: Container>(&mut self, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> (OutputWrapper<G::Timestamp, D, TeeCore<G::Timestamp, D>>, Stream<G, D>) {
+    pub fn new_output_connection<D: Container>(&mut self, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> (OutputWrapper<G::Timestamp, D, Tee<G::Timestamp, D>>, Stream<G, D>) {
 
         let (tee, stream) = self.builder.new_output_connection(connection.clone());
 

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -11,7 +11,7 @@ use crate::progress::Timestamp;
 use crate::progress::ChangeBatch;
 use crate::progress::frontier::MutableAntichain;
 use crate::dataflow::channels::pullers::Counter as PullCounter;
-use crate::dataflow::channels::pushers::CounterCore as PushCounter;
+use crate::dataflow::channels::pushers::Counter as PushCounter;
 use crate::dataflow::channels::pushers::buffer::{BufferCore, Session};
 use crate::dataflow::channels::Bundle;
 use crate::communication::{Push, Pull, message::RefOrMut};

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -33,9 +33,6 @@ pub struct InputHandleCore<T: Timestamp, D: Container, P: Pull<Bundle<T, D>>> {
     logging: Option<Logger>,
 }
 
-/// Handle to an operator's input stream, specialized to vectors.
-pub type InputHandle<T, D, P> = InputHandleCore<T, Vec<D>, P>;
-
 /// Handle to an operator's input stream and frontier.
 pub struct FrontieredInputHandle<'a, T: Timestamp, D: Container+'a, P: Pull<Bundle<T, D>>+'a> {
     /// The underlying input handle.

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -22,7 +22,7 @@ use crate::dataflow::operators::InputCapability;
 use crate::dataflow::operators::capability::CapabilityTrait;
 
 /// Handle to an operator's input stream.
-pub struct InputHandleCore<T: Timestamp, D: Container, P: Pull<Bundle<T, D>>> {
+pub struct InputHandle<T: Timestamp, D: Container, P: Pull<Bundle<T, D>>> {
     pull_counter: PullCounter<T, D, P>,
     internal: Rc<RefCell<Vec<Rc<RefCell<ChangeBatch<T>>>>>>,
     /// Timestamp summaries from this input to each output.
@@ -36,12 +36,12 @@ pub struct InputHandleCore<T: Timestamp, D: Container, P: Pull<Bundle<T, D>>> {
 /// Handle to an operator's input stream and frontier.
 pub struct FrontieredInputHandle<'a, T: Timestamp, D: Container+'a, P: Pull<Bundle<T, D>>+'a> {
     /// The underlying input handle.
-    pub handle: &'a mut InputHandleCore<T, D, P>,
+    pub handle: &'a mut InputHandle<T, D, P>,
     /// The frontier as reported by timely progress tracking.
     pub frontier: &'a MutableAntichain<T>,
 }
 
-impl<'a, T: Timestamp, D: Container, P: Pull<Bundle<T, D>>> InputHandleCore<T, D, P> {
+impl<'a, T: Timestamp, D: Container, P: Pull<Bundle<T, D>>> InputHandle<T, D, P> {
 
     /// Reads the next input buffer (at some timestamp `t`) and a corresponding capability for `t`.
     /// The timestamp `t` of the input buffer can be retrieved by invoking `.time()` on the capability.
@@ -95,7 +95,7 @@ impl<'a, T: Timestamp, D: Container, P: Pull<Bundle<T, D>>> InputHandleCore<T, D
 
 impl<'a, T: Timestamp, D: Container, P: Pull<Bundle<T, D>>+'a> FrontieredInputHandle<'a, T, D, P> {
     /// Allocate a new frontiered input handle.
-    pub fn new(handle: &'a mut InputHandleCore<T, D, P>, frontier: &'a MutableAntichain<T>) -> Self {
+    pub fn new(handle: &'a mut InputHandle<T, D, P>, frontier: &'a MutableAntichain<T>) -> Self {
         FrontieredInputHandle {
             handle,
             frontier,
@@ -140,7 +140,7 @@ impl<'a, T: Timestamp, D: Container, P: Pull<Bundle<T, D>>+'a> FrontieredInputHa
     }
 }
 
-pub fn _access_pull_counter<T: Timestamp, D: Container, P: Pull<Bundle<T, D>>>(input: &mut InputHandleCore<T, D, P>) -> &mut PullCounter<T, D, P> {
+pub fn _access_pull_counter<T: Timestamp, D: Container, P: Pull<Bundle<T, D>>>(input: &mut InputHandle<T, D, P>) -> &mut PullCounter<T, D, P> {
     &mut input.pull_counter
 }
 
@@ -151,8 +151,8 @@ pub fn new_input_handle<T: Timestamp, D: Container, P: Pull<Bundle<T, D>>>(
     internal: Rc<RefCell<Vec<Rc<RefCell<ChangeBatch<T>>>>>>, 
     summaries: Rc<RefCell<Vec<Antichain<T::Summary>>>>, 
     logging: Option<Logger>
-) -> InputHandleCore<T, D, P> {
-    InputHandleCore {
+) -> InputHandle<T, D, P> {
+    InputHandle {
         pull_counter,
         internal,
         summaries,

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -44,9 +44,6 @@ pub struct FrontieredInputHandleCore<'a, T: Timestamp, D: Container+'a, P: Pull<
     pub frontier: &'a MutableAntichain<T>,
 }
 
-/// Handle to an operator's input stream and frontier, specialized to vectors.
-pub type FrontieredInputHandle<'a, T, D, P> = FrontieredInputHandleCore<'a, T, Vec<D>, P>;
-
 impl<'a, T: Timestamp, D: Container, P: Pull<Bundle<T, D>>> InputHandleCore<T, D, P> {
 
     /// Reads the next input buffer (at some timestamp `t`) and a corresponding capability for `t`.

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -12,7 +12,7 @@ use crate::progress::ChangeBatch;
 use crate::progress::frontier::MutableAntichain;
 use crate::dataflow::channels::pullers::Counter as PullCounter;
 use crate::dataflow::channels::pushers::Counter as PushCounter;
-use crate::dataflow::channels::pushers::buffer::{BufferCore, Session};
+use crate::dataflow::channels::pushers::buffer::{Buffer, Session};
 use crate::dataflow::channels::Bundle;
 use crate::communication::{Push, Pull, message::RefOrMut};
 use crate::Container;
@@ -173,13 +173,13 @@ pub fn new_input_handle<T: Timestamp, D: Container, P: Pull<Bundle<T, D>>>(
 /// pusher is flushed (via the `cease` method) once it is no longer used.
 #[derive(Debug)]
 pub struct OutputWrapper<T: Timestamp, D: Container, P: Push<Bundle<T, D>>> {
-    push_buffer: BufferCore<T, D, PushCounter<T, D, P>>,
+    push_buffer: Buffer<T, D, PushCounter<T, D, P>>,
     internal_buffer: Rc<RefCell<ChangeBatch<T>>>,
 }
 
 impl<T: Timestamp, D: Container, P: Push<Bundle<T, D>>> OutputWrapper<T, D, P> {
     /// Creates a new output wrapper from a push buffer.
-    pub fn new(push_buffer: BufferCore<T, D, PushCounter<T, D, P>>, internal_buffer: Rc<RefCell<ChangeBatch<T>>>) -> Self {
+    pub fn new(push_buffer: Buffer<T, D, PushCounter<T, D, P>>, internal_buffer: Rc<RefCell<ChangeBatch<T>>>) -> Self {
         OutputWrapper {
             push_buffer,
             internal_buffer,
@@ -200,7 +200,7 @@ impl<T: Timestamp, D: Container, P: Push<Bundle<T, D>>> OutputWrapper<T, D, P> {
 
 /// Handle to an operator's output stream.
 pub struct OutputHandleCore<'a, T: Timestamp, C: Container+'a, P: Push<Bundle<T, C>>+'a> {
-    push_buffer: &'a mut BufferCore<T, C, PushCounter<T, C, P>>,
+    push_buffer: &'a mut Buffer<T, C, PushCounter<T, C, P>>,
     internal_buffer: &'a Rc<RefCell<ChangeBatch<T>>>,
 }
 

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -183,8 +183,8 @@ impl<T: Timestamp, D: Container, P: Push<Bundle<T, D>>> OutputWrapper<T, D, P> {
     ///
     /// This method ensures that the only access to the push buffer is through the `OutputHandle`
     /// type which ensures the use of capabilities, and which calls `cease` when it is dropped.
-    pub fn activate(&mut self) -> OutputHandleCore<T, D, P> {
-        OutputHandleCore {
+    pub fn activate(&mut self) -> OutputHandle<T, D, P> {
+        OutputHandle {
             push_buffer: &mut self.push_buffer,
             internal_buffer: &self.internal_buffer,
         }
@@ -193,12 +193,12 @@ impl<T: Timestamp, D: Container, P: Push<Bundle<T, D>>> OutputWrapper<T, D, P> {
 
 
 /// Handle to an operator's output stream.
-pub struct OutputHandleCore<'a, T: Timestamp, C: Container+'a, P: Push<Bundle<T, C>>+'a> {
+pub struct OutputHandle<'a, T: Timestamp, C: Container+'a, P: Push<Bundle<T, C>>+'a> {
     push_buffer: &'a mut Buffer<T, C, PushCounter<T, C, P>>,
     internal_buffer: &'a Rc<RefCell<ChangeBatch<T>>>,
 }
 
-impl<'a, T: Timestamp, C: Container, P: Push<Bundle<T, C>>> OutputHandleCore<'a, T, C, P> {
+impl<'a, T: Timestamp, C: Container, P: Push<Bundle<T, C>>> OutputHandle<'a, T, C, P> {
     /// Obtains a session that can send data at the timestamp associated with capability `cap`.
     ///
     /// In order to send data at a future timestamp, obtain a capability for the new timestamp
@@ -232,7 +232,7 @@ impl<'a, T: Timestamp, C: Container, P: Push<Bundle<T, C>>> OutputHandleCore<'a,
     }
 }
 
-impl<'a, T: Timestamp, C: Container, P: Push<Bundle<T, C>>> Drop for OutputHandleCore<'a, T, C, P> {
+impl<'a, T: Timestamp, C: Container, P: Push<Bundle<T, C>>> Drop for OutputHandle<'a, T, C, P> {
     fn drop(&mut self) {
         self.push_buffer.cease();
     }

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -37,7 +37,7 @@ pub struct InputHandleCore<T: Timestamp, D: Container, P: Pull<Bundle<T, D>>> {
 pub type InputHandle<T, D, P> = InputHandleCore<T, Vec<D>, P>;
 
 /// Handle to an operator's input stream and frontier.
-pub struct FrontieredInputHandleCore<'a, T: Timestamp, D: Container+'a, P: Pull<Bundle<T, D>>+'a> {
+pub struct FrontieredInputHandle<'a, T: Timestamp, D: Container+'a, P: Pull<Bundle<T, D>>+'a> {
     /// The underlying input handle.
     pub handle: &'a mut InputHandleCore<T, D, P>,
     /// The frontier as reported by timely progress tracking.
@@ -96,10 +96,10 @@ impl<'a, T: Timestamp, D: Container, P: Pull<Bundle<T, D>>> InputHandleCore<T, D
 
 }
 
-impl<'a, T: Timestamp, D: Container, P: Pull<Bundle<T, D>>+'a> FrontieredInputHandleCore<'a, T, D, P> {
+impl<'a, T: Timestamp, D: Container, P: Pull<Bundle<T, D>>+'a> FrontieredInputHandle<'a, T, D, P> {
     /// Allocate a new frontiered input handle.
     pub fn new(handle: &'a mut InputHandleCore<T, D, P>, frontier: &'a MutableAntichain<T>) -> Self {
-        FrontieredInputHandleCore {
+        FrontieredInputHandle {
             handle,
             frontier,
         }

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -198,9 +198,6 @@ pub struct OutputHandleCore<'a, T: Timestamp, C: Container+'a, P: Push<Bundle<T,
     internal_buffer: &'a Rc<RefCell<ChangeBatch<T>>>,
 }
 
-/// Handle specialized to `Vec`-based container.
-pub type OutputHandle<'a, T, D, P> = OutputHandleCore<'a, T, Vec<D>, P>;
-
 impl<'a, T: Timestamp, C: Container, P: Push<Bundle<T, C>>> OutputHandleCore<'a, T, C, P> {
     /// Obtains a session that can send data at the timestamp associated with capability `cap`.
     ///

--- a/timely/src/dataflow/operators/generic/mod.rs
+++ b/timely/src/dataflow/operators/generic/mod.rs
@@ -8,7 +8,7 @@ mod handles;
 mod notificator;
 mod operator_info;
 
-pub use self::handles::{InputHandle, InputHandleCore, FrontieredInputHandleCore, OutputHandle, OutputHandleCore, OutputWrapper};
+pub use self::handles::{InputHandle, InputHandleCore, FrontieredInputHandle, OutputHandle, OutputHandleCore, OutputWrapper};
 pub use self::notificator::{Notificator, FrontierNotificator};
 
 pub use self::operator::{Operator, source};

--- a/timely/src/dataflow/operators/generic/mod.rs
+++ b/timely/src/dataflow/operators/generic/mod.rs
@@ -8,7 +8,7 @@ mod handles;
 mod notificator;
 mod operator_info;
 
-pub use self::handles::{InputHandle, FrontieredInputHandle, OutputHandle, OutputHandleCore, OutputWrapper};
+pub use self::handles::{InputHandle, FrontieredInputHandle, OutputHandleCore, OutputWrapper};
 pub use self::notificator::{Notificator, FrontierNotificator};
 
 pub use self::operator::{Operator, source};

--- a/timely/src/dataflow/operators/generic/mod.rs
+++ b/timely/src/dataflow/operators/generic/mod.rs
@@ -8,7 +8,7 @@ mod handles;
 mod notificator;
 mod operator_info;
 
-pub use self::handles::{InputHandle, InputHandleCore, FrontieredInputHandle, OutputHandle, OutputHandleCore, OutputWrapper};
+pub use self::handles::{InputHandleCore, FrontieredInputHandle, OutputHandle, OutputHandleCore, OutputWrapper};
 pub use self::notificator::{Notificator, FrontierNotificator};
 
 pub use self::operator::{Operator, source};

--- a/timely/src/dataflow/operators/generic/mod.rs
+++ b/timely/src/dataflow/operators/generic/mod.rs
@@ -8,7 +8,7 @@ mod handles;
 mod notificator;
 mod operator_info;
 
-pub use self::handles::{InputHandleCore, FrontieredInputHandle, OutputHandle, OutputHandleCore, OutputWrapper};
+pub use self::handles::{InputHandle, FrontieredInputHandle, OutputHandle, OutputHandleCore, OutputWrapper};
 pub use self::notificator::{Notificator, FrontierNotificator};
 
 pub use self::operator::{Operator, source};

--- a/timely/src/dataflow/operators/generic/mod.rs
+++ b/timely/src/dataflow/operators/generic/mod.rs
@@ -8,7 +8,7 @@ mod handles;
 mod notificator;
 mod operator_info;
 
-pub use self::handles::{InputHandle, FrontieredInputHandle, OutputHandleCore, OutputWrapper};
+pub use self::handles::{InputHandle, FrontieredInputHandle, OutputHandle, OutputWrapper};
 pub use self::notificator::{Notificator, FrontierNotificator};
 
 pub use self::operator::{Operator, source};

--- a/timely/src/dataflow/operators/generic/mod.rs
+++ b/timely/src/dataflow/operators/generic/mod.rs
@@ -8,7 +8,7 @@ mod handles;
 mod notificator;
 mod operator_info;
 
-pub use self::handles::{InputHandle, InputHandleCore, FrontieredInputHandle, FrontieredInputHandleCore, OutputHandle, OutputHandleCore, OutputWrapper};
+pub use self::handles::{InputHandle, InputHandleCore, FrontieredInputHandleCore, OutputHandle, OutputHandleCore, OutputWrapper};
 pub use self::notificator::{Notificator, FrontierNotificator};
 
 pub use self::operator::{Operator, source};

--- a/timely/src/dataflow/operators/generic/notificator.rs
+++ b/timely/src/dataflow/operators/generic/notificator.rs
@@ -193,8 +193,8 @@ fn notificator_delivers_notifications_in_topo_order() {
 ///
 /// timely::execute(timely::Config::thread(), |worker| {
 ///     let (mut in1, mut in2) = worker.dataflow::<usize,_,_>(|scope| {
-///         let (in1_handle, in1) = scope.new_input();
-///         let (in2_handle, in2) = scope.new_input();
+///         let (in1_handle, in1) = scope.new_input::<Vec<_>>();
+///         let (in2_handle, in2) = scope.new_input::<Vec<_>>();
 ///         in1.binary_frontier(&in2, Pipeline, Pipeline, "example", |mut _default_cap, _info| {
 ///             let mut notificator = FrontierNotificator::new();
 ///             let mut stash = HashMap::new();

--- a/timely/src/dataflow/operators/generic/operator.rs
+++ b/timely/src/dataflow/operators/generic/operator.rs
@@ -4,7 +4,7 @@
 use crate::dataflow::channels::pushers::TeeCore;
 use crate::dataflow::channels::pact::ParallelizationContract;
 
-use crate::dataflow::operators::generic::handles::{InputHandleCore, FrontieredInputHandle, OutputHandleCore};
+use crate::dataflow::operators::generic::handles::{InputHandle, FrontieredInputHandle, OutputHandleCore};
 use crate::dataflow::operators::capability::Capability;
 
 use crate::dataflow::{Scope, Stream};
@@ -93,7 +93,7 @@ pub trait Operator<G: Scope, D1: Container> {
     /// }
     /// ```
     fn unary_notify<D2: Container,
-            L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P::Puller>,
+            L: FnMut(&mut InputHandle<G::Timestamp, D1, P::Puller>,
                      &mut OutputHandleCore<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>,
                      &mut Notificator<G::Timestamp>)+'static,
              P: ParallelizationContract<G::Timestamp, D1>>
@@ -131,7 +131,7 @@ pub trait Operator<G: Scope, D1: Container> {
     where
         D2: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
-        L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P::Puller>,
+        L: FnMut(&mut InputHandle<G::Timestamp, D1, P::Puller>,
                  &mut OutputHandleCore<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
         P: ParallelizationContract<G::Timestamp, D1>;
 
@@ -243,8 +243,8 @@ pub trait Operator<G: Scope, D1: Container> {
     /// ```
     fn binary_notify<D2: Container,
               D3: Container,
-              L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P1::Puller>,
-                       &mut InputHandleCore<G::Timestamp, D2, P2::Puller>,
+              L: FnMut(&mut InputHandle<G::Timestamp, D1, P1::Puller>,
+                       &mut InputHandle<G::Timestamp, D2, P2::Puller>,
                        &mut OutputHandleCore<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>,
                        &mut Notificator<G::Timestamp>)+'static,
               P1: ParallelizationContract<G::Timestamp, D1>,
@@ -290,8 +290,8 @@ pub trait Operator<G: Scope, D1: Container> {
         D2: Container,
         D3: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
-        L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P1::Puller>,
-                 &mut InputHandleCore<G::Timestamp, D2, P2::Puller>,
+        L: FnMut(&mut InputHandle<G::Timestamp, D1, P1::Puller>,
+                 &mut InputHandle<G::Timestamp, D2, P2::Puller>,
                  &mut OutputHandleCore<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
         P1: ParallelizationContract<G::Timestamp, D1>,
         P2: ParallelizationContract<G::Timestamp, D2>;
@@ -356,7 +356,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
     }
 
     fn unary_notify<D2: Container,
-            L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P::Puller>,
+            L: FnMut(&mut InputHandle<G::Timestamp, D1, P::Puller>,
                      &mut OutputHandleCore<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>,
                      &mut Notificator<G::Timestamp>)+'static,
              P: ParallelizationContract<G::Timestamp, D1>>
@@ -381,7 +381,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
     where
         D2: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
-        L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P::Puller>,
+        L: FnMut(&mut InputHandle<G::Timestamp, D1, P::Puller>,
                  &mut OutputHandleCore<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
         P: ParallelizationContract<G::Timestamp, D1> {
 
@@ -440,8 +440,8 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
 
     fn binary_notify<D2: Container,
               D3: Container,
-              L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P1::Puller>,
-                       &mut InputHandleCore<G::Timestamp, D2, P2::Puller>,
+              L: FnMut(&mut InputHandle<G::Timestamp, D1, P1::Puller>,
+                       &mut InputHandle<G::Timestamp, D2, P2::Puller>,
                        &mut OutputHandleCore<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>,
                        &mut Notificator<G::Timestamp>)+'static,
               P1: ParallelizationContract<G::Timestamp, D1>,
@@ -470,8 +470,8 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
         D2: Container,
         D3: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
-        L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P1::Puller>,
-                 &mut InputHandleCore<G::Timestamp, D2, P2::Puller>,
+        L: FnMut(&mut InputHandle<G::Timestamp, D1, P1::Puller>,
+                 &mut InputHandle<G::Timestamp, D2, P2::Puller>,
                  &mut OutputHandleCore<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
         P1: ParallelizationContract<G::Timestamp, D1>,
         P2: ParallelizationContract<G::Timestamp, D2> {

--- a/timely/src/dataflow/operators/generic/operator.rs
+++ b/timely/src/dataflow/operators/generic/operator.rs
@@ -4,7 +4,7 @@
 use crate::dataflow::channels::pushers::TeeCore;
 use crate::dataflow::channels::pact::ParallelizationContract;
 
-use crate::dataflow::operators::generic::handles::{InputHandle, FrontieredInputHandle, OutputHandleCore};
+use crate::dataflow::operators::generic::handles::{InputHandle, FrontieredInputHandle, OutputHandle};
 use crate::dataflow::operators::capability::Capability;
 
 use crate::dataflow::{Scope, Stream};
@@ -60,7 +60,7 @@ pub trait Operator<G: Scope, D1: Container> {
         D2: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut FrontieredInputHandle<G::Timestamp, D1, P::Puller>,
-                 &mut OutputHandleCore<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
+                 &mut OutputHandle<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
         P: ParallelizationContract<G::Timestamp, D1>;
 
     /// Creates a new dataflow operator that partitions its input stream by a parallelization
@@ -94,7 +94,7 @@ pub trait Operator<G: Scope, D1: Container> {
     /// ```
     fn unary_notify<D2: Container,
             L: FnMut(&mut InputHandle<G::Timestamp, D1, P::Puller>,
-                     &mut OutputHandleCore<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>,
+                     &mut OutputHandle<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>,
                      &mut Notificator<G::Timestamp>)+'static,
              P: ParallelizationContract<G::Timestamp, D1>>
              (&self, pact: P, name: &str, init: impl IntoIterator<Item=G::Timestamp>, logic: L) -> Stream<G, D2>;
@@ -132,7 +132,7 @@ pub trait Operator<G: Scope, D1: Container> {
         D2: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut InputHandle<G::Timestamp, D1, P::Puller>,
-                 &mut OutputHandleCore<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
+                 &mut OutputHandle<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
         P: ParallelizationContract<G::Timestamp, D1>;
 
     /// Creates a new dataflow operator that partitions its input streams by a parallelization
@@ -192,7 +192,7 @@ pub trait Operator<G: Scope, D1: Container> {
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut FrontieredInputHandle<G::Timestamp, D1, P1::Puller>,
                  &mut FrontieredInputHandle<G::Timestamp, D2, P2::Puller>,
-                 &mut OutputHandleCore<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
+                 &mut OutputHandle<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
         P1: ParallelizationContract<G::Timestamp, D1>,
         P2: ParallelizationContract<G::Timestamp, D2>;
 
@@ -245,7 +245,7 @@ pub trait Operator<G: Scope, D1: Container> {
               D3: Container,
               L: FnMut(&mut InputHandle<G::Timestamp, D1, P1::Puller>,
                        &mut InputHandle<G::Timestamp, D2, P2::Puller>,
-                       &mut OutputHandleCore<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>,
+                       &mut OutputHandle<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>,
                        &mut Notificator<G::Timestamp>)+'static,
               P1: ParallelizationContract<G::Timestamp, D1>,
               P2: ParallelizationContract<G::Timestamp, D2>>
@@ -292,7 +292,7 @@ pub trait Operator<G: Scope, D1: Container> {
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut InputHandle<G::Timestamp, D1, P1::Puller>,
                  &mut InputHandle<G::Timestamp, D2, P2::Puller>,
-                 &mut OutputHandleCore<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
+                 &mut OutputHandle<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
         P1: ParallelizationContract<G::Timestamp, D1>,
         P2: ParallelizationContract<G::Timestamp, D2>;
 
@@ -332,7 +332,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
         D2: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut FrontieredInputHandle<G::Timestamp, D1, P::Puller>,
-                 &mut OutputHandleCore<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
+                 &mut OutputHandle<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
         P: ParallelizationContract<G::Timestamp, D1> {
 
         let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
@@ -357,7 +357,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
 
     fn unary_notify<D2: Container,
             L: FnMut(&mut InputHandle<G::Timestamp, D1, P::Puller>,
-                     &mut OutputHandleCore<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>,
+                     &mut OutputHandle<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>,
                      &mut Notificator<G::Timestamp>)+'static,
              P: ParallelizationContract<G::Timestamp, D1>>
              (&self, pact: P, name: &str, init: impl IntoIterator<Item=G::Timestamp>, mut logic: L) -> Stream<G, D2> {
@@ -382,7 +382,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
         D2: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut InputHandle<G::Timestamp, D1, P::Puller>,
-                 &mut OutputHandleCore<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
+                 &mut OutputHandle<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
         P: ParallelizationContract<G::Timestamp, D1> {
 
         let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
@@ -412,7 +412,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut FrontieredInputHandle<G::Timestamp, D1, P1::Puller>,
                  &mut FrontieredInputHandle<G::Timestamp, D2, P2::Puller>,
-                 &mut OutputHandleCore<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
+                 &mut OutputHandle<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
         P1: ParallelizationContract<G::Timestamp, D1>,
         P2: ParallelizationContract<G::Timestamp, D2> {
 
@@ -442,7 +442,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
               D3: Container,
               L: FnMut(&mut InputHandle<G::Timestamp, D1, P1::Puller>,
                        &mut InputHandle<G::Timestamp, D2, P2::Puller>,
-                       &mut OutputHandleCore<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>,
+                       &mut OutputHandle<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>,
                        &mut Notificator<G::Timestamp>)+'static,
               P1: ParallelizationContract<G::Timestamp, D1>,
               P2: ParallelizationContract<G::Timestamp, D2>>
@@ -472,7 +472,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut InputHandle<G::Timestamp, D1, P1::Puller>,
                  &mut InputHandle<G::Timestamp, D2, P2::Puller>,
-                 &mut OutputHandleCore<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
+                 &mut OutputHandle<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
         P1: ParallelizationContract<G::Timestamp, D1>,
         P2: ParallelizationContract<G::Timestamp, D2> {
 
@@ -559,7 +559,7 @@ pub fn source<G: Scope, D, B, L>(scope: &G, name: &str, constructor: B) -> Strea
 where
     D: Container,
     B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
-    L: FnMut(&mut OutputHandleCore<G::Timestamp, D, TeeCore<G::Timestamp, D>>)+'static {
+    L: FnMut(&mut OutputHandle<G::Timestamp, D, TeeCore<G::Timestamp, D>>)+'static {
 
     let mut builder = OperatorBuilder::new(name.to_owned(), scope.clone());
     let operator_info = builder.operator_info();

--- a/timely/src/dataflow/operators/generic/operator.rs
+++ b/timely/src/dataflow/operators/generic/operator.rs
@@ -148,8 +148,8 @@ pub trait Operator<G: Scope, D1: Container> {
     ///
     /// timely::execute(timely::Config::thread(), |worker| {
     ///    let (mut in1, mut in2) = worker.dataflow::<usize,_,_>(|scope| {
-    ///        let (in1_handle, in1) = scope.new_input();
-    ///        let (in2_handle, in2) = scope.new_input();
+    ///        let (in1_handle, in1) = scope.new_input::<Vec<_>>();
+    ///        let (in2_handle, in2) = scope.new_input::<Vec<_>>();
     ///        in1.binary_frontier(&in2, Pipeline, Pipeline, "example", |mut _default_cap, _info| {
     ///            let mut notificator = FrontierNotificator::new();
     ///            let mut stash = HashMap::new();
@@ -209,8 +209,8 @@ pub trait Operator<G: Scope, D1: Container> {
     ///
     /// timely::execute(timely::Config::thread(), |worker| {
     ///    let (mut in1, mut in2) = worker.dataflow::<usize,_,_>(|scope| {
-    ///        let (in1_handle, in1) = scope.new_input();
-    ///        let (in2_handle, in2) = scope.new_input();
+    ///        let (in1_handle, in1) = scope.new_input::<Vec<_>>();
+    ///        let (in2_handle, in2) = scope.new_input::<Vec<_>>();
     ///
     ///        let mut vector1 = Vec::new();
     ///        let mut vector2 = Vec::new();

--- a/timely/src/dataflow/operators/generic/operator.rs
+++ b/timely/src/dataflow/operators/generic/operator.rs
@@ -2,7 +2,7 @@
 //! Methods to construct generic streaming and blocking unary operators.
 
 use crate::dataflow::channels::pushers::TeeCore;
-use crate::dataflow::channels::pact::ParallelizationContractCore;
+use crate::dataflow::channels::pact::ParallelizationContract;
 
 use crate::dataflow::operators::generic::handles::{InputHandleCore, FrontieredInputHandleCore, OutputHandleCore};
 use crate::dataflow::operators::capability::Capability;
@@ -61,7 +61,7 @@ pub trait Operator<G: Scope, D1: Container> {
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, D1, P::Puller>,
                  &mut OutputHandleCore<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
-        P: ParallelizationContractCore<G::Timestamp, D1>;
+        P: ParallelizationContract<G::Timestamp, D1>;
 
     /// Creates a new dataflow operator that partitions its input stream by a parallelization
     /// strategy `pact`, and repeatedly invokes `logic`, the function returned by the function passed as `constructor`.
@@ -96,7 +96,7 @@ pub trait Operator<G: Scope, D1: Container> {
             L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P::Puller>,
                      &mut OutputHandleCore<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>,
                      &mut Notificator<G::Timestamp>)+'static,
-             P: ParallelizationContractCore<G::Timestamp, D1>>
+             P: ParallelizationContract<G::Timestamp, D1>>
              (&self, pact: P, name: &str, init: impl IntoIterator<Item=G::Timestamp>, logic: L) -> Stream<G, D2>;
 
     /// Creates a new dataflow operator that partitions its input stream by a parallelization
@@ -133,7 +133,7 @@ pub trait Operator<G: Scope, D1: Container> {
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P::Puller>,
                  &mut OutputHandleCore<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
-        P: ParallelizationContractCore<G::Timestamp, D1>;
+        P: ParallelizationContract<G::Timestamp, D1>;
 
     /// Creates a new dataflow operator that partitions its input streams by a parallelization
     /// strategy `pact`, and repeatedly invokes `logic`, the function returned by the function passed as `constructor`.
@@ -193,8 +193,8 @@ pub trait Operator<G: Scope, D1: Container> {
         L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, D1, P1::Puller>,
                  &mut FrontieredInputHandleCore<G::Timestamp, D2, P2::Puller>,
                  &mut OutputHandleCore<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
-        P1: ParallelizationContractCore<G::Timestamp, D1>,
-        P2: ParallelizationContractCore<G::Timestamp, D2>;
+        P1: ParallelizationContract<G::Timestamp, D1>,
+        P2: ParallelizationContract<G::Timestamp, D2>;
 
     /// Creates a new dataflow operator that partitions its input streams by a parallelization
     /// strategy `pact`, and repeatedly invokes `logic`, the function returned by the function passed as `constructor`.
@@ -247,8 +247,8 @@ pub trait Operator<G: Scope, D1: Container> {
                        &mut InputHandleCore<G::Timestamp, D2, P2::Puller>,
                        &mut OutputHandleCore<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>,
                        &mut Notificator<G::Timestamp>)+'static,
-              P1: ParallelizationContractCore<G::Timestamp, D1>,
-              P2: ParallelizationContractCore<G::Timestamp, D2>>
+              P1: ParallelizationContract<G::Timestamp, D1>,
+              P2: ParallelizationContract<G::Timestamp, D2>>
             (&self, other: &Stream<G, D2>, pact1: P1, pact2: P2, name: &str, init: impl IntoIterator<Item=G::Timestamp>, logic: L) -> Stream<G, D3>;
 
     /// Creates a new dataflow operator that partitions its input streams by a parallelization
@@ -293,8 +293,8 @@ pub trait Operator<G: Scope, D1: Container> {
         L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P1::Puller>,
                  &mut InputHandleCore<G::Timestamp, D2, P2::Puller>,
                  &mut OutputHandleCore<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
-        P1: ParallelizationContractCore<G::Timestamp, D1>,
-        P2: ParallelizationContractCore<G::Timestamp, D2>;
+        P1: ParallelizationContract<G::Timestamp, D1>,
+        P2: ParallelizationContract<G::Timestamp, D2>;
 
     /// Creates a new dataflow operator that partitions its input stream by a parallelization
     /// strategy `pact`, and repeatedly invokes the function `logic` which can read from the input stream
@@ -322,7 +322,7 @@ pub trait Operator<G: Scope, D1: Container> {
     fn sink<L, P>(&self, pact: P, name: &str, logic: L)
     where
         L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, D1, P::Puller>)+'static,
-        P: ParallelizationContractCore<G::Timestamp, D1>;
+        P: ParallelizationContract<G::Timestamp, D1>;
 }
 
 impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
@@ -333,7 +333,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, D1, P::Puller>,
                  &mut OutputHandleCore<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
-        P: ParallelizationContractCore<G::Timestamp, D1> {
+        P: ParallelizationContract<G::Timestamp, D1> {
 
         let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
         let operator_info = builder.operator_info();
@@ -359,7 +359,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
             L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P::Puller>,
                      &mut OutputHandleCore<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>,
                      &mut Notificator<G::Timestamp>)+'static,
-             P: ParallelizationContractCore<G::Timestamp, D1>>
+             P: ParallelizationContract<G::Timestamp, D1>>
              (&self, pact: P, name: &str, init: impl IntoIterator<Item=G::Timestamp>, mut logic: L) -> Stream<G, D2> {
 
         self.unary_frontier(pact, name, move |capability, _info| {
@@ -383,7 +383,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P::Puller>,
                  &mut OutputHandleCore<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
-        P: ParallelizationContractCore<G::Timestamp, D1> {
+        P: ParallelizationContract<G::Timestamp, D1> {
 
         let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
         let operator_info = builder.operator_info();
@@ -413,8 +413,8 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
         L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, D1, P1::Puller>,
                  &mut FrontieredInputHandleCore<G::Timestamp, D2, P2::Puller>,
                  &mut OutputHandleCore<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
-        P1: ParallelizationContractCore<G::Timestamp, D1>,
-        P2: ParallelizationContractCore<G::Timestamp, D2> {
+        P1: ParallelizationContract<G::Timestamp, D1>,
+        P2: ParallelizationContract<G::Timestamp, D2> {
 
         let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
         let operator_info = builder.operator_info();
@@ -444,8 +444,8 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
                        &mut InputHandleCore<G::Timestamp, D2, P2::Puller>,
                        &mut OutputHandleCore<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>,
                        &mut Notificator<G::Timestamp>)+'static,
-              P1: ParallelizationContractCore<G::Timestamp, D1>,
-              P2: ParallelizationContractCore<G::Timestamp, D2>>
+              P1: ParallelizationContract<G::Timestamp, D1>,
+              P2: ParallelizationContract<G::Timestamp, D2>>
             (&self, other: &Stream<G, D2>, pact1: P1, pact2: P2, name: &str, init: impl IntoIterator<Item=G::Timestamp>, mut logic: L) -> Stream<G, D3> {
 
         self.binary_frontier(other, pact1, pact2, name, |capability, _info| {
@@ -473,8 +473,8 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
         L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P1::Puller>,
                  &mut InputHandleCore<G::Timestamp, D2, P2::Puller>,
                  &mut OutputHandleCore<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
-        P1: ParallelizationContractCore<G::Timestamp, D1>,
-        P2: ParallelizationContractCore<G::Timestamp, D2> {
+        P1: ParallelizationContract<G::Timestamp, D1>,
+        P2: ParallelizationContract<G::Timestamp, D2> {
 
         let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
         let operator_info = builder.operator_info();
@@ -500,7 +500,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
     fn sink<L, P>(&self, pact: P, name: &str, mut logic: L)
     where
         L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, D1, P::Puller>)+'static,
-        P: ParallelizationContractCore<G::Timestamp, D1> {
+        P: ParallelizationContract<G::Timestamp, D1> {
 
         let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
         let mut input = builder.new_input(self, pact);

--- a/timely/src/dataflow/operators/generic/operator.rs
+++ b/timely/src/dataflow/operators/generic/operator.rs
@@ -1,7 +1,7 @@
 
 //! Methods to construct generic streaming and blocking unary operators.
 
-use crate::dataflow::channels::pushers::TeeCore;
+use crate::dataflow::channels::pushers::Tee;
 use crate::dataflow::channels::pact::ParallelizationContract;
 
 use crate::dataflow::operators::generic::handles::{InputHandle, FrontieredInputHandle, OutputHandle};
@@ -60,7 +60,7 @@ pub trait Operator<G: Scope, D1: Container> {
         D2: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut FrontieredInputHandle<G::Timestamp, D1, P::Puller>,
-                 &mut OutputHandle<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
+                 &mut OutputHandle<G::Timestamp, D2, Tee<G::Timestamp, D2>>)+'static,
         P: ParallelizationContract<G::Timestamp, D1>;
 
     /// Creates a new dataflow operator that partitions its input stream by a parallelization
@@ -94,7 +94,7 @@ pub trait Operator<G: Scope, D1: Container> {
     /// ```
     fn unary_notify<D2: Container,
             L: FnMut(&mut InputHandle<G::Timestamp, D1, P::Puller>,
-                     &mut OutputHandle<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>,
+                     &mut OutputHandle<G::Timestamp, D2, Tee<G::Timestamp, D2>>,
                      &mut Notificator<G::Timestamp>)+'static,
              P: ParallelizationContract<G::Timestamp, D1>>
              (&self, pact: P, name: &str, init: impl IntoIterator<Item=G::Timestamp>, logic: L) -> Stream<G, D2>;
@@ -132,7 +132,7 @@ pub trait Operator<G: Scope, D1: Container> {
         D2: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut InputHandle<G::Timestamp, D1, P::Puller>,
-                 &mut OutputHandle<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
+                 &mut OutputHandle<G::Timestamp, D2, Tee<G::Timestamp, D2>>)+'static,
         P: ParallelizationContract<G::Timestamp, D1>;
 
     /// Creates a new dataflow operator that partitions its input streams by a parallelization
@@ -192,7 +192,7 @@ pub trait Operator<G: Scope, D1: Container> {
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut FrontieredInputHandle<G::Timestamp, D1, P1::Puller>,
                  &mut FrontieredInputHandle<G::Timestamp, D2, P2::Puller>,
-                 &mut OutputHandle<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
+                 &mut OutputHandle<G::Timestamp, D3, Tee<G::Timestamp, D3>>)+'static,
         P1: ParallelizationContract<G::Timestamp, D1>,
         P2: ParallelizationContract<G::Timestamp, D2>;
 
@@ -245,7 +245,7 @@ pub trait Operator<G: Scope, D1: Container> {
               D3: Container,
               L: FnMut(&mut InputHandle<G::Timestamp, D1, P1::Puller>,
                        &mut InputHandle<G::Timestamp, D2, P2::Puller>,
-                       &mut OutputHandle<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>,
+                       &mut OutputHandle<G::Timestamp, D3, Tee<G::Timestamp, D3>>,
                        &mut Notificator<G::Timestamp>)+'static,
               P1: ParallelizationContract<G::Timestamp, D1>,
               P2: ParallelizationContract<G::Timestamp, D2>>
@@ -292,7 +292,7 @@ pub trait Operator<G: Scope, D1: Container> {
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut InputHandle<G::Timestamp, D1, P1::Puller>,
                  &mut InputHandle<G::Timestamp, D2, P2::Puller>,
-                 &mut OutputHandle<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
+                 &mut OutputHandle<G::Timestamp, D3, Tee<G::Timestamp, D3>>)+'static,
         P1: ParallelizationContract<G::Timestamp, D1>,
         P2: ParallelizationContract<G::Timestamp, D2>;
 
@@ -332,7 +332,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
         D2: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut FrontieredInputHandle<G::Timestamp, D1, P::Puller>,
-                 &mut OutputHandle<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
+                 &mut OutputHandle<G::Timestamp, D2, Tee<G::Timestamp, D2>>)+'static,
         P: ParallelizationContract<G::Timestamp, D1> {
 
         let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
@@ -357,7 +357,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
 
     fn unary_notify<D2: Container,
             L: FnMut(&mut InputHandle<G::Timestamp, D1, P::Puller>,
-                     &mut OutputHandle<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>,
+                     &mut OutputHandle<G::Timestamp, D2, Tee<G::Timestamp, D2>>,
                      &mut Notificator<G::Timestamp>)+'static,
              P: ParallelizationContract<G::Timestamp, D1>>
              (&self, pact: P, name: &str, init: impl IntoIterator<Item=G::Timestamp>, mut logic: L) -> Stream<G, D2> {
@@ -382,7 +382,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
         D2: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut InputHandle<G::Timestamp, D1, P::Puller>,
-                 &mut OutputHandle<G::Timestamp, D2, TeeCore<G::Timestamp, D2>>)+'static,
+                 &mut OutputHandle<G::Timestamp, D2, Tee<G::Timestamp, D2>>)+'static,
         P: ParallelizationContract<G::Timestamp, D1> {
 
         let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
@@ -412,7 +412,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut FrontieredInputHandle<G::Timestamp, D1, P1::Puller>,
                  &mut FrontieredInputHandle<G::Timestamp, D2, P2::Puller>,
-                 &mut OutputHandle<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
+                 &mut OutputHandle<G::Timestamp, D3, Tee<G::Timestamp, D3>>)+'static,
         P1: ParallelizationContract<G::Timestamp, D1>,
         P2: ParallelizationContract<G::Timestamp, D2> {
 
@@ -442,7 +442,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
               D3: Container,
               L: FnMut(&mut InputHandle<G::Timestamp, D1, P1::Puller>,
                        &mut InputHandle<G::Timestamp, D2, P2::Puller>,
-                       &mut OutputHandle<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>,
+                       &mut OutputHandle<G::Timestamp, D3, Tee<G::Timestamp, D3>>,
                        &mut Notificator<G::Timestamp>)+'static,
               P1: ParallelizationContract<G::Timestamp, D1>,
               P2: ParallelizationContract<G::Timestamp, D2>>
@@ -472,7 +472,7 @@ impl<G: Scope, D1: Container> Operator<G, D1> for Stream<G, D1> {
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
         L: FnMut(&mut InputHandle<G::Timestamp, D1, P1::Puller>,
                  &mut InputHandle<G::Timestamp, D2, P2::Puller>,
-                 &mut OutputHandle<G::Timestamp, D3, TeeCore<G::Timestamp, D3>>)+'static,
+                 &mut OutputHandle<G::Timestamp, D3, Tee<G::Timestamp, D3>>)+'static,
         P1: ParallelizationContract<G::Timestamp, D1>,
         P2: ParallelizationContract<G::Timestamp, D2> {
 
@@ -559,7 +559,7 @@ pub fn source<G: Scope, D, B, L>(scope: &G, name: &str, constructor: B) -> Strea
 where
     D: Container,
     B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
-    L: FnMut(&mut OutputHandle<G::Timestamp, D, TeeCore<G::Timestamp, D>>)+'static {
+    L: FnMut(&mut OutputHandle<G::Timestamp, D, Tee<G::Timestamp, D>>)+'static {
 
     let mut builder = OperatorBuilder::new(name.to_owned(), scope.clone());
     let operator_info = builder.operator_info();

--- a/timely/src/dataflow/operators/input.rs
+++ b/timely/src/dataflow/operators/input.rs
@@ -12,7 +12,7 @@ use crate::progress::Source;
 use crate::{Container, Data};
 use crate::communication::Push;
 use crate::dataflow::{ScopeParent, Scope, Stream};
-use crate::dataflow::channels::pushers::{TeeCore, CounterCore};
+use crate::dataflow::channels::pushers::{TeeCore, Counter};
 use crate::dataflow::channels::Message;
 
 
@@ -178,7 +178,7 @@ impl<G: Scope> Input for G where <G as ScopeParent>::Timestamp: TotalOrder {
 
     fn input_from_core<D: Container>(&mut self, handle: &mut HandleCore<<G as ScopeParent>::Timestamp, D>) -> Stream<G, D> {
         let (output, registrar) = TeeCore::<<G as ScopeParent>::Timestamp, D>::new();
-        let counter = CounterCore::new(output);
+        let counter = Counter::new(output);
         let produced = counter.produced().clone();
 
         let index = self.allocate_operator_index();
@@ -249,7 +249,7 @@ impl<T:Timestamp> Operate<T> for Operator<T> {
 pub struct HandleCore<T: Timestamp, C: Container> {
     activate: Vec<Activator>,
     progress: Vec<Rc<RefCell<ChangeBatch<T>>>>,
-    pushers: Vec<CounterCore<T, C, TeeCore<T, C>>>,
+    pushers: Vec<Counter<T, C, TeeCore<T, C>>>,
     buffer1: C,
     buffer2: C,
     now_at: T,
@@ -332,7 +332,7 @@ impl<T: Timestamp, D: Container> HandleCore<T, D> {
 
     fn register(
         &mut self,
-        pusher: CounterCore<T, D, TeeCore<T, D>>,
+        pusher: Counter<T, D, TeeCore<T, D>>,
         progress: Rc<RefCell<ChangeBatch<T>>>,
     ) {
         // flush current contents, so new registrant does not see existing data.

--- a/timely/src/dataflow/operators/input.rs
+++ b/timely/src/dataflow/operators/input.rs
@@ -11,7 +11,7 @@ use crate::progress::Source;
 
 use crate::{Container, Data};
 use crate::communication::Push;
-use crate::dataflow::{Stream, ScopeParent, Scope, StreamCore};
+use crate::dataflow::{ScopeParent, Scope, StreamCore};
 use crate::dataflow::channels::pushers::{TeeCore, CounterCore};
 use crate::dataflow::channels::Message;
 
@@ -58,7 +58,7 @@ pub trait Input : Scope {
     ///     }
     /// });
     /// ```
-    fn new_input<D: Data>(&mut self) -> (Handle<<Self as ScopeParent>::Timestamp, D>, Stream<Self, D>);
+    fn new_input<D: Data>(&mut self) -> (Handle<<Self as ScopeParent>::Timestamp, D>, StreamCore<Self, Vec<D>>);
 
     /// Create a new [StreamCore] and [HandleCore] through which to supply input.
     ///
@@ -125,7 +125,7 @@ pub trait Input : Scope {
     ///     }
     /// });
     /// ```
-    fn input_from<D: Data>(&mut self, handle: &mut Handle<<Self as ScopeParent>::Timestamp, D>) -> Stream<Self, D>;
+    fn input_from<D: Data>(&mut self, handle: &mut Handle<<Self as ScopeParent>::Timestamp, D>) -> StreamCore<Self, Vec<D>>;
 
     /// Create a new stream from a supplied interactive handle.
     ///
@@ -162,11 +162,11 @@ pub trait Input : Scope {
 
 use crate::order::TotalOrder;
 impl<G: Scope> Input for G where <G as ScopeParent>::Timestamp: TotalOrder {
-    fn new_input<D: Data>(&mut self) -> (Handle<<G as ScopeParent>::Timestamp, D>, Stream<G, D>) {
+    fn new_input<D: Data>(&mut self) -> (Handle<<G as ScopeParent>::Timestamp, D>, StreamCore<G, Vec<D>>) {
         self.new_input_core()
     }
 
-    fn input_from<D: Data>(&mut self, handle: &mut Handle<<G as ScopeParent>::Timestamp, D>) -> Stream<G, D> {
+    fn input_from<D: Data>(&mut self, handle: &mut Handle<<G as ScopeParent>::Timestamp, D>) -> StreamCore<G, Vec<D>> {
         self.input_from_core(handle)
     }
 

--- a/timely/src/dataflow/operators/input.rs
+++ b/timely/src/dataflow/operators/input.rs
@@ -12,7 +12,7 @@ use crate::progress::Source;
 use crate::{Container, Data};
 use crate::communication::Push;
 use crate::dataflow::{ScopeParent, Scope, Stream};
-use crate::dataflow::channels::pushers::{TeeCore, Counter};
+use crate::dataflow::channels::pushers::{Tee, Counter};
 use crate::dataflow::channels::Message;
 
 
@@ -177,7 +177,7 @@ impl<G: Scope> Input for G where <G as ScopeParent>::Timestamp: TotalOrder {
     }
 
     fn input_from_core<D: Container>(&mut self, handle: &mut HandleCore<<G as ScopeParent>::Timestamp, D>) -> Stream<G, D> {
-        let (output, registrar) = TeeCore::<<G as ScopeParent>::Timestamp, D>::new();
+        let (output, registrar) = Tee::<<G as ScopeParent>::Timestamp, D>::new();
         let counter = Counter::new(output);
         let produced = counter.produced().clone();
 
@@ -249,7 +249,7 @@ impl<T:Timestamp> Operate<T> for Operator<T> {
 pub struct HandleCore<T: Timestamp, C: Container> {
     activate: Vec<Activator>,
     progress: Vec<Rc<RefCell<ChangeBatch<T>>>>,
-    pushers: Vec<Counter<T, C, TeeCore<T, C>>>,
+    pushers: Vec<Counter<T, C, Tee<T, C>>>,
     buffer1: C,
     buffer2: C,
     now_at: T,
@@ -332,7 +332,7 @@ impl<T: Timestamp, D: Container> HandleCore<T, D> {
 
     fn register(
         &mut self,
-        pusher: Counter<T, D, TeeCore<T, D>>,
+        pusher: Counter<T, D, Tee<T, D>>,
         progress: Rc<RefCell<ChangeBatch<T>>>,
     ) {
         // flush current contents, so new registrant does not see existing data.

--- a/timely/src/dataflow/operators/map.rs
+++ b/timely/src/dataflow/operators/map.rs
@@ -1,7 +1,7 @@
 //! Extension methods for `Stream` based on record-by-record transformation.
 
 use crate::Data;
-use crate::dataflow::{Stream, Scope};
+use crate::dataflow::{Scope, StreamCore};
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::operators::generic::operator::Operator;
 
@@ -19,7 +19,7 @@ pub trait Map<S: Scope, D: Data> {
     ///            .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn map<D2: Data, L: FnMut(D)->D2+'static>(&self, logic: L) -> Stream<S, D2>;
+    fn map<D2: Data, L: FnMut(D)->D2+'static>(&self, logic: L) -> StreamCore<S, Vec<D2>>;
     /// Updates each element of the stream and yields the element, re-using memory where possible.
     ///
     /// # Examples
@@ -32,7 +32,7 @@ pub trait Map<S: Scope, D: Data> {
     ///            .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn map_in_place<L: FnMut(&mut D)+'static>(&self, logic: L) -> Stream<S, D>;
+    fn map_in_place<L: FnMut(&mut D)+'static>(&self, logic: L) -> StreamCore<S, Vec<D>>;
     /// Consumes each element of the stream and yields some number of new elements.
     ///
     /// # Examples
@@ -45,11 +45,11 @@ pub trait Map<S: Scope, D: Data> {
     ///            .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn flat_map<I: IntoIterator, L: FnMut(D)->I+'static>(&self, logic: L) -> Stream<S, I::Item> where I::Item: Data;
+    fn flat_map<I: IntoIterator, L: FnMut(D)->I+'static>(&self, logic: L) -> StreamCore<S, Vec<<I as IntoIterator>::Item>> where I::Item: Data;
 }
 
-impl<S: Scope, D: Data> Map<S, D> for Stream<S, D> {
-    fn map<D2: Data, L: FnMut(D)->D2+'static>(&self, mut logic: L) -> Stream<S, D2> {
+impl<S: Scope, D: Data> Map<S, D> for StreamCore<S, Vec<D>> {
+    fn map<D2: Data, L: FnMut(D)->D2+'static>(&self, mut logic: L) -> StreamCore<S, Vec<D2>> {
         let mut vector = Vec::new();
         self.unary(Pipeline, "Map", move |_,_| move |input, output| {
             input.for_each(|time, data| {
@@ -58,7 +58,7 @@ impl<S: Scope, D: Data> Map<S, D> for Stream<S, D> {
             });
         })
     }
-    fn map_in_place<L: FnMut(&mut D)+'static>(&self, mut logic: L) -> Stream<S, D> {
+    fn map_in_place<L: FnMut(&mut D)+'static>(&self, mut logic: L) -> StreamCore<S, Vec<D>> {
         let mut vector = Vec::new();
         self.unary(Pipeline, "MapInPlace", move |_,_| move |input, output| {
             input.for_each(|time, data| {
@@ -71,7 +71,7 @@ impl<S: Scope, D: Data> Map<S, D> for Stream<S, D> {
     // TODO : This would be more robust if it captured an iterator and then pulled an appropriate
     // TODO : number of elements from the iterator. This would allow iterators that produce many
     // TODO : records without taking arbitrarily long and arbitrarily much memory.
-    fn flat_map<I: IntoIterator, L: FnMut(D)->I+'static>(&self, mut logic: L) -> Stream<S, I::Item> where I::Item: Data {
+    fn flat_map<I: IntoIterator, L: FnMut(D)->I+'static>(&self, mut logic: L) -> StreamCore<S, Vec<<I as IntoIterator>::Item>> where I::Item: Data {
         let mut vector = Vec::new();
         self.unary(Pipeline, "FlatMap", move |_,_| move |input, output| {
             input.for_each(|time, data| {

--- a/timely/src/dataflow/operators/mod.rs
+++ b/timely/src/dataflow/operators/mod.rs
@@ -10,7 +10,7 @@
 
 pub use self::enterleave::{Enter, EnterAt, Leave};
 pub use self::input::Input;
-pub use self::unordered_input::{UnorderedInput, UnorderedInputCore};
+pub use self::unordered_input::UnorderedInput;
 pub use self::feedback::{Feedback, LoopVariable, ConnectLoop};
 pub use self::concat::{Concat, Concatenate};
 pub use self::partition::Partition;

--- a/timely/src/dataflow/operators/ok_err.rs
+++ b/timely/src/dataflow/operators/ok_err.rs
@@ -2,7 +2,7 @@
 
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use crate::dataflow::{Scope, StreamCore};
+use crate::dataflow::{Scope, Stream};
 use crate::Data;
 
 /// Extension trait for `Stream`.
@@ -32,7 +32,7 @@ pub trait OkErr<S: Scope, D: Data> {
     fn ok_err<D1, D2, L>(
         &self,
         logic: L,
-    ) -> (StreamCore<S, Vec<D1>>, StreamCore<S, Vec<D2>>)
+    ) -> (Stream<S, Vec<D1>>, Stream<S, Vec<D2>>)
 
     where
         D1: Data,
@@ -41,11 +41,11 @@ pub trait OkErr<S: Scope, D: Data> {
     ;
 }
 
-impl<S: Scope, D: Data> OkErr<S, D> for StreamCore<S, Vec<D>> {
+impl<S: Scope, D: Data> OkErr<S, D> for Stream<S, Vec<D>> {
     fn ok_err<D1, D2, L>(
         &self,
         mut logic: L,
-    ) -> (StreamCore<S, Vec<D1>>, StreamCore<S, Vec<D2>>)
+    ) -> (Stream<S, Vec<D1>>, Stream<S, Vec<D2>>)
 
     where
         D1: Data,

--- a/timely/src/dataflow/operators/ok_err.rs
+++ b/timely/src/dataflow/operators/ok_err.rs
@@ -2,7 +2,7 @@
 
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use crate::dataflow::{Scope, Stream};
+use crate::dataflow::{Scope, StreamCore};
 use crate::Data;
 
 /// Extension trait for `Stream`.
@@ -32,7 +32,7 @@ pub trait OkErr<S: Scope, D: Data> {
     fn ok_err<D1, D2, L>(
         &self,
         logic: L,
-    ) -> (Stream<S, D1>, Stream<S, D2>)
+    ) -> (StreamCore<S, Vec<D1>>, StreamCore<S, Vec<D2>>)
 
     where
         D1: Data,
@@ -41,11 +41,11 @@ pub trait OkErr<S: Scope, D: Data> {
     ;
 }
 
-impl<S: Scope, D: Data> OkErr<S, D> for Stream<S, D> {
+impl<S: Scope, D: Data> OkErr<S, D> for StreamCore<S, Vec<D>> {
     fn ok_err<D1, D2, L>(
         &self,
         mut logic: L,
-    ) -> (Stream<S, D1>, Stream<S, D2>)
+    ) -> (StreamCore<S, Vec<D1>>, StreamCore<S, Vec<D2>>)
 
     where
         D1: Data,

--- a/timely/src/dataflow/operators/partition.rs
+++ b/timely/src/dataflow/operators/partition.rs
@@ -2,7 +2,7 @@
 
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use crate::dataflow::{Scope, Stream};
+use crate::dataflow::{Scope, StreamCore};
 use crate::Data;
 
 /// Partition a stream of records into multiple streams.
@@ -22,11 +22,11 @@ pub trait Partition<G: Scope, D: Data, D2: Data, F: Fn(D) -> (u64, D2)> {
     ///     streams[2].inspect(|x| println!("seen 2: {:?}", x));
     /// });
     /// ```
-    fn partition(&self, parts: u64, route: F) -> Vec<Stream<G, D2>>;
+    fn partition(&self, parts: u64, route: F) -> Vec<StreamCore<G, Vec<D2>>>;
 }
 
-impl<G: Scope, D: Data, D2: Data, F: Fn(D)->(u64, D2)+'static> Partition<G, D, D2, F> for Stream<G, D> {
-    fn partition(&self, parts: u64, route: F) -> Vec<Stream<G, D2>> {
+impl<G: Scope, D: Data, D2: Data, F: Fn(D)->(u64, D2)+'static> Partition<G, D, D2, F> for StreamCore<G, Vec<D>> {
+    fn partition(&self, parts: u64, route: F) -> Vec<StreamCore<G, Vec<D2>>> {
         let mut builder = OperatorBuilder::new("Partition".to_owned(), self.scope());
 
         let mut input = builder.new_input(self, Pipeline);

--- a/timely/src/dataflow/operators/partition.rs
+++ b/timely/src/dataflow/operators/partition.rs
@@ -2,7 +2,7 @@
 
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use crate::dataflow::{Scope, StreamCore};
+use crate::dataflow::{Scope, Stream};
 use crate::Data;
 
 /// Partition a stream of records into multiple streams.
@@ -22,11 +22,11 @@ pub trait Partition<G: Scope, D: Data, D2: Data, F: Fn(D) -> (u64, D2)> {
     ///     streams[2].inspect(|x| println!("seen 2: {:?}", x));
     /// });
     /// ```
-    fn partition(&self, parts: u64, route: F) -> Vec<StreamCore<G, Vec<D2>>>;
+    fn partition(&self, parts: u64, route: F) -> Vec<Stream<G, Vec<D2>>>;
 }
 
-impl<G: Scope, D: Data, D2: Data, F: Fn(D)->(u64, D2)+'static> Partition<G, D, D2, F> for StreamCore<G, Vec<D>> {
-    fn partition(&self, parts: u64, route: F) -> Vec<StreamCore<G, Vec<D2>>> {
+impl<G: Scope, D: Data, D2: Data, F: Fn(D)->(u64, D2)+'static> Partition<G, D, D2, F> for Stream<G, Vec<D>> {
+    fn partition(&self, parts: u64, route: F) -> Vec<Stream<G, Vec<D2>>> {
         let mut builder = OperatorBuilder::new("Partition".to_owned(), self.scope());
 
         let mut input = builder.new_input(self, Pipeline);

--- a/timely/src/dataflow/operators/probe.rs
+++ b/timely/src/dataflow/operators/probe.rs
@@ -202,7 +202,7 @@ mod tests {
 
             // create a new input, and inspect its output
             let (mut input, probe) = worker.dataflow(move |scope| {
-                let (input, stream) = scope.new_input::<String>();
+                let (input, stream) = scope.new_input::<Vec<String>>();
                 (input, stream.probe())
             });
 

--- a/timely/src/dataflow/operators/probe.rs
+++ b/timely/src/dataflow/operators/probe.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 
 use crate::progress::Timestamp;
 use crate::progress::frontier::{AntichainRef, MutableAntichain};
-use crate::dataflow::channels::pushers::CounterCore as PushCounter;
+use crate::dataflow::channels::pushers::Counter as PushCounter;
 use crate::dataflow::channels::pushers::buffer::BufferCore as PushBuffer;
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::channels::pullers::Counter as PullCounter;

--- a/timely/src/dataflow/operators/probe.rs
+++ b/timely/src/dataflow/operators/probe.rs
@@ -12,7 +12,7 @@ use crate::dataflow::channels::pullers::Counter as PullCounter;
 use crate::dataflow::operators::generic::builder_raw::OperatorBuilder;
 
 
-use crate::dataflow::{StreamCore, Scope};
+use crate::dataflow::{Stream, Scope};
 use crate::Container;
 
 /// Monitors progress at a `Stream`.
@@ -76,10 +76,10 @@ pub trait Probe<G: Scope, D: Container> {
     ///     }
     /// }).unwrap();
     /// ```
-    fn probe_with(&self, handle: &mut Handle<G::Timestamp>) -> StreamCore<G, D>;
+    fn probe_with(&self, handle: &mut Handle<G::Timestamp>) -> Stream<G, D>;
 }
 
-impl<G: Scope, D: Container> Probe<G, D> for StreamCore<G, D> {
+impl<G: Scope, D: Container> Probe<G, D> for Stream<G, D> {
     fn probe(&self) -> Handle<G::Timestamp> {
 
         // the frontier is shared state; scope updates, handle reads.
@@ -87,7 +87,7 @@ impl<G: Scope, D: Container> Probe<G, D> for StreamCore<G, D> {
         self.probe_with(&mut handle);
         handle
     }
-    fn probe_with(&self, handle: &mut Handle<G::Timestamp>) -> StreamCore<G, D> {
+    fn probe_with(&self, handle: &mut Handle<G::Timestamp>) -> Stream<G, D> {
 
         let mut builder = OperatorBuilder::new("Probe".to_owned(), self.scope());
         let mut input = PullCounter::new(builder.new_input(self, Pipeline));

--- a/timely/src/dataflow/operators/probe.rs
+++ b/timely/src/dataflow/operators/probe.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 use crate::progress::Timestamp;
 use crate::progress::frontier::{AntichainRef, MutableAntichain};
 use crate::dataflow::channels::pushers::Counter as PushCounter;
-use crate::dataflow::channels::pushers::buffer::BufferCore as PushBuffer;
+use crate::dataflow::channels::pushers::buffer::Buffer as PushBuffer;
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::channels::pullers::Counter as PullCounter;
 use crate::dataflow::operators::generic::builder_raw::OperatorBuilder;

--- a/timely/src/dataflow/operators/rc.rs
+++ b/timely/src/dataflow/operators/rc.rs
@@ -2,7 +2,7 @@
 
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::operators::Operator;
-use crate::dataflow::{Scope, StreamCore};
+use crate::dataflow::{Scope, Stream};
 use crate::Container;
 use std::rc::Rc;
 
@@ -21,11 +21,11 @@ pub trait SharedStream<S: Scope, C: Container> {
     ///            .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn shared(&self) -> StreamCore<S, Rc<C>>;
+    fn shared(&self) -> Stream<S, Rc<C>>;
 }
 
-impl<S: Scope, C: Container> SharedStream<S, C> for StreamCore<S, C> {
-    fn shared(&self) -> StreamCore<S, Rc<C>> {
+impl<S: Scope, C: Container> SharedStream<S, C> for Stream<S, C> {
+    fn shared(&self) -> Stream<S, Rc<C>> {
         let mut container = Default::default();
         self.unary(Pipeline, "Shared", move |_, _| {
             move |input, output| {

--- a/timely/src/dataflow/operators/reclock.rs
+++ b/timely/src/dataflow/operators/reclock.rs
@@ -2,7 +2,7 @@
 
 use crate::Container;
 use crate::order::PartialOrder;
-use crate::dataflow::{Scope, StreamCore};
+use crate::dataflow::{Scope, Stream};
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::operators::generic::operator::Operator;
 
@@ -45,11 +45,11 @@ pub trait Reclock<S: Scope> {
     /// assert_eq!(extracted[1], (5, vec![4,5]));
     /// assert_eq!(extracted[2], (8, vec![6,7,8]));
     /// ```
-    fn reclock<TC: Container<Item=()>>(&self, clock: &StreamCore<S, TC>) -> Self;
+    fn reclock<TC: Container<Item=()>>(&self, clock: &Stream<S, TC>) -> Self;
 }
 
-impl<S: Scope, C: Container> Reclock<S> for StreamCore<S, C> {
-    fn reclock<TC: Container<Item=()>>(&self, clock: &StreamCore<S, TC>) -> StreamCore<S, C> {
+impl<S: Scope, C: Container> Reclock<S> for Stream<S, C> {
+    fn reclock<TC: Container<Item=()>>(&self, clock: &Stream<S, TC>) -> Stream<S, C> {
 
         let mut stash = vec![];
 

--- a/timely/src/dataflow/operators/result.rs
+++ b/timely/src/dataflow/operators/result.rs
@@ -2,7 +2,7 @@
 
 use crate::Data;
 use crate::dataflow::operators::Map;
-use crate::dataflow::{Scope, Stream};
+use crate::dataflow::{Scope, StreamCore};
 
 /// Extension trait for `Stream`.
 pub trait ResultStream<S: Scope, T: Data, E: Data> {
@@ -18,7 +18,7 @@ pub trait ResultStream<S: Scope, T: Data, E: Data> {
     ///            .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn ok(&self) -> Stream<S, T>;
+    fn ok(&self) -> StreamCore<S, Vec<T>>;
 
     /// Returns a new instance of `self` containing only `err` records.
     ///
@@ -32,7 +32,7 @@ pub trait ResultStream<S: Scope, T: Data, E: Data> {
     ///            .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn err(&self) -> Stream<S, E>;
+    fn err(&self) -> StreamCore<S, Vec<E>>;
 
     /// Returns a new instance of `self` applying `logic` on all `Ok` records.
     ///
@@ -46,7 +46,7 @@ pub trait ResultStream<S: Scope, T: Data, E: Data> {
     ///            .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn map_ok<T2: Data, L: FnMut(T) -> T2 + 'static>(&self, logic: L) -> Stream<S, Result<T2, E>>;
+    fn map_ok<T2: Data, L: FnMut(T) -> T2 + 'static>(&self, logic: L) -> StreamCore<S, Vec<Result<T2, E>>>;
 
     /// Returns a new instance of `self` applying `logic` on all `Err` records.
     ///
@@ -60,7 +60,7 @@ pub trait ResultStream<S: Scope, T: Data, E: Data> {
     ///            .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn map_err<E2: Data, L: FnMut(E) -> E2 + 'static>(&self, logic: L) -> Stream<S, Result<T, E2>>;
+    fn map_err<E2: Data, L: FnMut(E) -> E2 + 'static>(&self, logic: L) -> StreamCore<S, Vec<Result<T, E2>>>;
 
     /// Returns a new instance of `self` applying `logic` on all `Ok` records, passes through `Err`
     /// records.
@@ -78,7 +78,7 @@ pub trait ResultStream<S: Scope, T: Data, E: Data> {
     fn and_then<T2: Data, L: FnMut(T) -> Result<T2, E> + 'static>(
         &self,
         logic: L,
-    ) -> Stream<S, Result<T2, E>>;
+    ) -> StreamCore<S, Vec<Result<T2, E>>>;
 
     /// Returns a new instance of `self` applying `logic` on all `Ok` records.
     ///
@@ -92,31 +92,31 @@ pub trait ResultStream<S: Scope, T: Data, E: Data> {
     ///            .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn unwrap_or_else<L: FnMut(E) -> T + 'static>(&self, logic: L) -> Stream<S, T>;
+    fn unwrap_or_else<L: FnMut(E) -> T + 'static>(&self, logic: L) -> StreamCore<S, Vec<T>>;
 }
 
-impl<S: Scope, T: Data, E: Data> ResultStream<S, T, E> for Stream<S, Result<T, E>> {
-    fn ok(&self) -> Stream<S, T> {
+impl<S: Scope, T: Data, E: Data> ResultStream<S, T, E> for StreamCore<S, Vec<Result<T, E>>> {
+    fn ok(&self) -> StreamCore<S, Vec<T>> {
         self.flat_map(Result::ok)
     }
 
-    fn err(&self) -> Stream<S, E> {
+    fn err(&self) -> StreamCore<S, Vec<E>> {
         self.flat_map(Result::err)
     }
 
-    fn map_ok<T2: Data, L: FnMut(T) -> T2 + 'static>(&self, mut logic: L) -> Stream<S, Result<T2, E>> {
+    fn map_ok<T2: Data, L: FnMut(T) -> T2 + 'static>(&self, mut logic: L) -> StreamCore<S, Vec<Result<T2, E>>> {
         self.map(move |r| r.map(|x| logic(x)))
     }
 
-    fn map_err<E2: Data, L: FnMut(E) -> E2 + 'static>(&self, mut logic: L) -> Stream<S, Result<T, E2>> {
+    fn map_err<E2: Data, L: FnMut(E) -> E2 + 'static>(&self, mut logic: L) -> StreamCore<S, Vec<Result<T, E2>>> {
         self.map(move |r| r.map_err(|x| logic(x)))
     }
 
-    fn and_then<T2: Data, L: FnMut(T) -> Result<T2, E> + 'static>(&self, mut logic: L) -> Stream<S, Result<T2, E>> {
+    fn and_then<T2: Data, L: FnMut(T) -> Result<T2, E> + 'static>(&self, mut logic: L) -> StreamCore<S, Vec<Result<T2, E>>> {
         self.map(move |r| r.and_then(|x| logic(x)))
     }
 
-    fn unwrap_or_else<L: FnMut(E) -> T + 'static>(&self, mut logic: L) -> Stream<S, T> {
+    fn unwrap_or_else<L: FnMut(E) -> T + 'static>(&self, mut logic: L) -> StreamCore<S, Vec<T>> {
         self.map(move |r| r.unwrap_or_else(|err| logic(err)))
     }
 }

--- a/timely/src/dataflow/operators/unordered_input.rs
+++ b/timely/src/dataflow/operators/unordered_input.rs
@@ -72,22 +72,19 @@ pub trait UnorderedInput<G: Scope> {
     ///     assert_eq!(extract[i], (i, vec![i]));
     /// }
     /// ```
-    fn new_unordered_input<D:Data>(&mut self) -> ((UnorderedHandle<G::Timestamp, D>, ActivateCapability<G::Timestamp>), Stream<G, Vec<D>>);
+    fn new_unordered_input<D:Data>(&mut self) -> ((UnorderedHandle<G::Timestamp, Vec<D>>, ActivateCapability<G::Timestamp>), Stream<G, Vec<D>>);
 }
 
 
 impl<G: Scope> UnorderedInput<G> for G {
-    fn new_unordered_input<D:Data>(&mut self) -> ((UnorderedHandle<G::Timestamp, D>, ActivateCapability<G::Timestamp>), Stream<G, Vec<D>>) {
+    fn new_unordered_input<D:Data>(&mut self) -> ((UnorderedHandle<G::Timestamp, Vec<D>>, ActivateCapability<G::Timestamp>), Stream<G, Vec<D>>) {
         self.new_unordered_input_core()
     }
 }
 
-/// An unordered handle specialized to vectors.
-pub type UnorderedHandle<T, D> = UnorderedHandleCore<T, Vec<D>>;
-
 /// Create a new `Stream` and `Handle` through which to supply input.
 pub trait UnorderedInputCore<G: Scope> {
-    /// Create a new capability-based [Stream] and [UnorderedHandleCore] through which to supply input. This
+    /// Create a new capability-based [Stream] and [UnorderedHandle] through which to supply input. This
     /// input supports multiple open epochs (timestamps) at the same time.
     ///
     /// The `new_unordered_input_core` method returns `((HandleCore, Capability), Stream)` where the `Stream` can be used
@@ -138,12 +135,12 @@ pub trait UnorderedInputCore<G: Scope> {
     ///     assert_eq!(extract[i], (i, vec![i]));
     /// }
     /// ```
-    fn new_unordered_input_core<D: Container>(&mut self) -> ((UnorderedHandleCore<G::Timestamp, D>, ActivateCapability<G::Timestamp>), Stream<G, D>);
+    fn new_unordered_input_core<D: Container>(&mut self) -> ((UnorderedHandle<G::Timestamp, D>, ActivateCapability<G::Timestamp>), Stream<G, D>);
 }
 
 
 impl<G: Scope> UnorderedInputCore<G> for G {
-    fn new_unordered_input_core<D: Container>(&mut self) -> ((UnorderedHandleCore<G::Timestamp, D>, ActivateCapability<G::Timestamp>), Stream<G, D>) {
+    fn new_unordered_input_core<D: Container>(&mut self) -> ((UnorderedHandle<G::Timestamp, D>, ActivateCapability<G::Timestamp>), Stream<G, D>) {
 
         let (output, registrar) = Tee::<G::Timestamp, D>::new();
         let internal = Rc::new(RefCell::new(ChangeBatch::new()));
@@ -159,7 +156,7 @@ impl<G: Scope> UnorderedInputCore<G> for G {
 
         let cap = ActivateCapability::new(cap, &address, self.activations());
 
-        let helper = UnorderedHandleCore::new(counter);
+        let helper = UnorderedHandle::new(counter);
 
         self.add_operator_with_index(Box::new(UnorderedOperator {
             name: "UnorderedInput".to_owned(),
@@ -211,13 +208,13 @@ impl<T:Timestamp> Operate<T> for UnorderedOperator<T> {
 
 /// A handle to an input [Stream], used to introduce data to a timely dataflow computation.
 #[derive(Debug)]
-pub struct UnorderedHandleCore<T: Timestamp, D: Container> {
+pub struct UnorderedHandle<T: Timestamp, D: Container> {
     buffer: PushBuffer<T, D, PushCounter<T, D, Tee<T, D>>>,
 }
 
-impl<T: Timestamp, D: Container> UnorderedHandleCore<T, D> {
-    fn new(pusher: PushCounter<T, D, Tee<T, D>>) -> UnorderedHandleCore<T, D> {
-        UnorderedHandleCore {
+impl<T: Timestamp, D: Container> UnorderedHandle<T, D> {
+    fn new(pusher: PushCounter<T, D, Tee<T, D>>) -> UnorderedHandle<T, D> {
+        Self {
             buffer: PushBuffer::new(pusher),
         }
     }

--- a/timely/src/dataflow/operators/unordered_input.rs
+++ b/timely/src/dataflow/operators/unordered_input.rs
@@ -13,7 +13,7 @@ use crate::progress::ChangeBatch;
 
 use crate::Data;
 use crate::dataflow::channels::pushers::{Counter as PushCounter, Tee};
-use crate::dataflow::channels::pushers::buffer::{Buffer as PushBuffer, AutoflushSessionCore};
+use crate::dataflow::channels::pushers::buffer::{Buffer as PushBuffer, AutoflushSession};
 
 use crate::dataflow::operators::{ActivateCapability, Capability};
 
@@ -223,7 +223,7 @@ impl<T: Timestamp, D: Container> UnorderedHandleCore<T, D> {
     }
 
     /// Allocates a new automatically flushing session based on the supplied capability.
-    pub fn session<'b>(&'b mut self, cap: ActivateCapability<T>) -> ActivateOnDrop<AutoflushSessionCore<'b, T, D, PushCounter<T, D, Tee<T, D>>>> {
+    pub fn session<'b>(&'b mut self, cap: ActivateCapability<T>) -> ActivateOnDrop<AutoflushSession<'b, T, D, PushCounter<T, D, Tee<T, D>>>> {
         ActivateOnDrop::new(self.buffer.autoflush_session(cap.capability.clone()), cap.address.clone(), cap.activations.clone())
     }
 }

--- a/timely/src/dataflow/operators/unordered_input.rs
+++ b/timely/src/dataflow/operators/unordered_input.rs
@@ -17,7 +17,7 @@ use crate::dataflow::channels::pushers::buffer::{BufferCore as PushBuffer, Autof
 
 use crate::dataflow::operators::{ActivateCapability, Capability};
 
-use crate::dataflow::{Stream, Scope, StreamCore};
+use crate::dataflow::{Scope, StreamCore};
 
 /// Create a new `Stream` and `Handle` through which to supply input.
 pub trait UnorderedInput<G: Scope> {
@@ -42,9 +42,7 @@ pub trait UnorderedInput<G: Scope> {
     ///
     /// use timely::*;
     /// use timely::dataflow::operators::*;
-    /// use timely::dataflow::operators::capture::Extract;
-    /// use timely::dataflow::Stream;
-    ///
+    /// use timely::dataflow::operators::capture::Extract;    ///     ///
     /// // get send and recv endpoints, wrap send to share
     /// let (send, recv) = ::std::sync::mpsc::channel();
     /// let send = Arc::new(Mutex::new(send));
@@ -74,12 +72,12 @@ pub trait UnorderedInput<G: Scope> {
     ///     assert_eq!(extract[i], (i, vec![i]));
     /// }
     /// ```
-    fn new_unordered_input<D:Data>(&mut self) -> ((UnorderedHandle<G::Timestamp, D>, ActivateCapability<G::Timestamp>), Stream<G, D>);
+    fn new_unordered_input<D:Data>(&mut self) -> ((UnorderedHandle<G::Timestamp, D>, ActivateCapability<G::Timestamp>), StreamCore<G, Vec<D>>);
 }
 
 
 impl<G: Scope> UnorderedInput<G> for G {
-    fn new_unordered_input<D:Data>(&mut self) -> ((UnorderedHandle<G::Timestamp, D>, ActivateCapability<G::Timestamp>), Stream<G, D>) {
+    fn new_unordered_input<D:Data>(&mut self) -> ((UnorderedHandle<G::Timestamp, D>, ActivateCapability<G::Timestamp>), StreamCore<G, Vec<D>>) {
         self.new_unordered_input_core()
     }
 }
@@ -110,9 +108,7 @@ pub trait UnorderedInputCore<G: Scope> {
     ///
     /// use timely::*;
     /// use timely::dataflow::operators::*;
-    /// use timely::dataflow::operators::capture::Extract;
-    /// use timely::dataflow::Stream;
-    ///
+    /// use timely::dataflow::operators::capture::Extract;    ///     ///
     /// // get send and recv endpoints, wrap send to share
     /// let (send, recv) = ::std::sync::mpsc::channel();
     /// let send = Arc::new(Mutex::new(send));

--- a/timely/src/dataflow/operators/unordered_input.rs
+++ b/timely/src/dataflow/operators/unordered_input.rs
@@ -11,7 +11,6 @@ use crate::progress::{Operate, operate::SharedProgress, Timestamp};
 use crate::progress::Source;
 use crate::progress::ChangeBatch;
 
-use crate::Data;
 use crate::dataflow::channels::pushers::{Counter as PushCounter, Tee};
 use crate::dataflow::channels::pushers::buffer::{Buffer as PushBuffer, AutoflushSession};
 

--- a/timely/src/dataflow/operators/unordered_input.rs
+++ b/timely/src/dataflow/operators/unordered_input.rs
@@ -13,7 +13,7 @@ use crate::progress::ChangeBatch;
 
 use crate::Data;
 use crate::dataflow::channels::pushers::{Counter as PushCounter, TeeCore};
-use crate::dataflow::channels::pushers::buffer::{BufferCore as PushBuffer, AutoflushSessionCore};
+use crate::dataflow::channels::pushers::buffer::{Buffer as PushBuffer, AutoflushSessionCore};
 
 use crate::dataflow::operators::{ActivateCapability, Capability};
 

--- a/timely/src/dataflow/operators/unordered_input.rs
+++ b/timely/src/dataflow/operators/unordered_input.rs
@@ -12,7 +12,7 @@ use crate::progress::Source;
 use crate::progress::ChangeBatch;
 
 use crate::Data;
-use crate::dataflow::channels::pushers::{CounterCore as PushCounter, TeeCore};
+use crate::dataflow::channels::pushers::{Counter as PushCounter, TeeCore};
 use crate::dataflow::channels::pushers::buffer::{BufferCore as PushBuffer, AutoflushSessionCore};
 
 use crate::dataflow::operators::{ActivateCapability, Capability};

--- a/timely/src/dataflow/operators/unordered_input.rs
+++ b/timely/src/dataflow/operators/unordered_input.rs
@@ -21,11 +21,11 @@ use crate::dataflow::{Scope, Stream};
 
 /// Create a new `Stream` and `Handle` through which to supply input.
 pub trait UnorderedInput<G: Scope> {
-    /// Create a new capability-based `Stream` and `Handle` through which to supply input. This
+    /// Create a new capability-based [Stream] and [UnorderedHandle] through which to supply input. This
     /// input supports multiple open epochs (timestamps) at the same time.
     ///
-    /// The `new_unordered_input` method returns `((Handle, Capability), Stream)` where the `Stream` can be used
-    /// immediately for timely dataflow construction, `Handle` and `Capability` are later used to introduce
+    /// The `new_unordered_input_core` method returns `((HandleCore, Capability), Stream)` where the `Stream` can be used
+    /// immediately for timely dataflow construction, `HandleCore` and `Capability` are later used to introduce
     /// data into the timely dataflow computation.
     ///
     /// The `Capability` returned is for the default value of the timestamp type in use. The
@@ -72,75 +72,12 @@ pub trait UnorderedInput<G: Scope> {
     ///     assert_eq!(extract[i], (i, vec![i]));
     /// }
     /// ```
-    fn new_unordered_input<D:Data>(&mut self) -> ((UnorderedHandle<G::Timestamp, Vec<D>>, ActivateCapability<G::Timestamp>), Stream<G, Vec<D>>);
+    fn new_unordered_input<D: Container>(&mut self) -> ((UnorderedHandle<G::Timestamp, D>, ActivateCapability<G::Timestamp>), Stream<G, D>);
 }
 
 
 impl<G: Scope> UnorderedInput<G> for G {
-    fn new_unordered_input<D:Data>(&mut self) -> ((UnorderedHandle<G::Timestamp, Vec<D>>, ActivateCapability<G::Timestamp>), Stream<G, Vec<D>>) {
-        self.new_unordered_input_core()
-    }
-}
-
-/// Create a new `Stream` and `Handle` through which to supply input.
-pub trait UnorderedInputCore<G: Scope> {
-    /// Create a new capability-based [Stream] and [UnorderedHandle] through which to supply input. This
-    /// input supports multiple open epochs (timestamps) at the same time.
-    ///
-    /// The `new_unordered_input_core` method returns `((HandleCore, Capability), Stream)` where the `Stream` can be used
-    /// immediately for timely dataflow construction, `HandleCore` and `Capability` are later used to introduce
-    /// data into the timely dataflow computation.
-    ///
-    /// The `Capability` returned is for the default value of the timestamp type in use. The
-    /// capability can be dropped to inform the system that the input has advanced beyond the
-    /// capability's timestamp. To retain the ability to send, a new capability at a later timestamp
-    /// should be obtained first, via the `delayed` function for `Capability`.
-    ///
-    /// To communicate the end-of-input drop all available capabilities.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::sync::{Arc, Mutex};
-    ///
-    /// use timely::*;
-    /// use timely::dataflow::operators::*;
-    /// use timely::dataflow::operators::capture::Extract;    ///     ///
-    /// // get send and recv endpoints, wrap send to share
-    /// let (send, recv) = ::std::sync::mpsc::channel();
-    /// let send = Arc::new(Mutex::new(send));
-    ///
-    /// timely::execute(Config::thread(), move |worker| {
-    ///
-    ///     // this is only to validate the output.
-    ///     let send = send.lock().unwrap().clone();
-    ///
-    ///     // create and capture the unordered input.
-    ///     let (mut input, mut cap) = worker.dataflow::<usize,_,_>(|scope| {
-    ///         let (input, stream) = scope.new_unordered_input_core();
-    ///         stream.capture_into(send);
-    ///         input
-    ///     });
-    ///
-    ///     // feed values 0..10 at times 0..10.
-    ///     for round in 0..10 {
-    ///         input.session(cap.clone()).give(round);
-    ///         cap = cap.delayed(&(round + 1));
-    ///         worker.step();
-    ///     }
-    /// }).unwrap();
-    ///
-    /// let extract = recv.extract();
-    /// for i in 0..10 {
-    ///     assert_eq!(extract[i], (i, vec![i]));
-    /// }
-    /// ```
-    fn new_unordered_input_core<D: Container>(&mut self) -> ((UnorderedHandle<G::Timestamp, D>, ActivateCapability<G::Timestamp>), Stream<G, D>);
-}
-
-
-impl<G: Scope> UnorderedInputCore<G> for G {
-    fn new_unordered_input_core<D: Container>(&mut self) -> ((UnorderedHandle<G::Timestamp, D>, ActivateCapability<G::Timestamp>), Stream<G, D>) {
+    fn new_unordered_input<D: Container>(&mut self) -> ((UnorderedHandle<G::Timestamp, D>, ActivateCapability<G::Timestamp>), Stream<G, D>) {
 
         let (output, registrar) = Tee::<G::Timestamp, D>::new();
         let internal = Rc::new(RefCell::new(ChangeBatch::new()));

--- a/timely/src/dataflow/scopes/mod.rs
+++ b/timely/src/dataflow/scopes/mod.rs
@@ -83,7 +83,7 @@ pub trait Scope: ScopeParent {
     /// timely::execute_from_args(std::env::args(), |worker| {
     ///     // must specify types as nothing else drives inference.
     ///     let input = worker.dataflow::<u64,_,_>(|child1| {
-    ///         let (input, stream) = child1.new_input::<String>();
+    ///         let (input, stream) = child1.new_input::<Vec<String>>();
     ///         let output = child1.scoped::<Product<u64,u32>,_,_>("ScopeName", |child2| {
     ///             stream.enter(child2).leave()
     ///         });
@@ -110,7 +110,7 @@ pub trait Scope: ScopeParent {
     /// timely::execute_from_args(std::env::args(), |worker| {
     ///     // must specify types as nothing else drives inference.
     ///     let input = worker.dataflow::<u64,_,_>(|child1| {
-    ///         let (input, stream) = child1.new_input::<String>();
+    ///         let (input, stream) = child1.new_input::<Vec<String>>();
     ///         let output = child1.iterative::<u32,_,_>(|child2| {
     ///             stream.enter(child2).leave()
     ///         });
@@ -140,7 +140,7 @@ pub trait Scope: ScopeParent {
     /// timely::execute_from_args(std::env::args(), |worker| {
     ///     // must specify types as nothing else drives inference.
     ///     let input = worker.dataflow::<u64,_,_>(|child1| {
-    ///         let (input, stream) = child1.new_input::<String>();
+    ///         let (input, stream) = child1.new_input::<Vec<String>>();
     ///         let output = child1.region(|child2| {
     ///             stream.enter(child2).leave()
     ///         });
@@ -172,7 +172,7 @@ pub trait Scope: ScopeParent {
     /// timely::execute_from_args(std::env::args(), |worker| {
     ///     // must specify types as nothing else drives inference.
     ///     let input = worker.dataflow::<u64,_,_>(|child1| {
-    ///         let (input, stream) = child1.new_input::<String>();
+    ///         let (input, stream) = child1.new_input::<Vec<String>>();
     ///         let output = child1.region_named("region", |child2| {
     ///             stream.enter(child2).leave()
     ///         });

--- a/timely/src/dataflow/stream.rs
+++ b/timely/src/dataflow/stream.rs
@@ -20,7 +20,7 @@ use crate::Container;
 /// Internally `Stream` maintains a list of data recipients who should be presented with data
 /// produced by the source of the stream.
 #[derive(Clone)]
-pub struct StreamCore<S: Scope, D> {
+pub struct Stream<S: Scope, D> {
     /// The progress identifier of the stream's data source.
     name: Source,
     /// The `Scope` containing the stream.
@@ -29,7 +29,7 @@ pub struct StreamCore<S: Scope, D> {
     ports: TeeHelper<S::Timestamp, D>,
 }
 
-impl<S: Scope, D: Container> StreamCore<S, D> {
+impl<S: Scope, D: Container> Stream<S, D> {
     /// Connects the stream to a destination.
     ///
     /// The destination is described both by a `Target`, for progress tracking information, and a `P: Push` where the
@@ -57,7 +57,7 @@ impl<S: Scope, D: Container> StreamCore<S, D> {
     pub fn scope(&self) -> S { self.scope.clone() }
 }
 
-impl<S, D> Debug for StreamCore<S, D>
+impl<S, D> Debug for Stream<S, D>
 where
     S: Scope,
 {

--- a/timely/src/dataflow/stream.rs
+++ b/timely/src/dataflow/stream.rs
@@ -29,9 +29,6 @@ pub struct StreamCore<S: Scope, D> {
     ports: TeeHelper<S::Timestamp, D>,
 }
 
-/// A stream batching data in vectors.
-pub type Stream<S, D> = StreamCore<S, Vec<D>>;
-
 impl<S: Scope, D: Container> StreamCore<S, D> {
     /// Connects the stream to a destination.
     ///

--- a/timely/src/dataflow/stream.rs
+++ b/timely/src/dataflow/stream.rs
@@ -9,7 +9,7 @@ use crate::progress::{Source, Target};
 use crate::communication::Push;
 use crate::dataflow::Scope;
 use crate::dataflow::channels::pushers::tee::TeeHelper;
-use crate::dataflow::channels::BundleCore;
+use crate::dataflow::channels::Bundle;
 use std::fmt::{self, Debug};
 use crate::Container;
 
@@ -34,7 +34,7 @@ impl<S: Scope, D: Container> Stream<S, D> {
     ///
     /// The destination is described both by a `Target`, for progress tracking information, and a `P: Push` where the
     /// records should actually be sent. The identifier is unique to the edge and is used only for logging purposes.
-    pub fn connect_to<P: Push<BundleCore<S::Timestamp, D>>+'static>(&self, target: Target, pusher: P, identifier: usize) {
+    pub fn connect_to<P: Push<Bundle<S::Timestamp, D>>+'static>(&self, target: Target, pusher: P, identifier: usize) {
 
         let mut logging = self.scope().logging();
         logging.as_mut().map(|l| l.log(crate::logging::ChannelsEvent {

--- a/timely/src/execute.rs
+++ b/timely/src/execute.rs
@@ -235,12 +235,12 @@ where
 
                 use ::std::net::TcpStream;
                 use crate::logging::BatchLogger;
-                use crate::dataflow::operators::capture::EventWriterCore;
+                use crate::dataflow::operators::capture::EventWriter;
 
                 eprintln!("enabled COMM logging to {}", addr);
 
                 if let Ok(stream) = TcpStream::connect(&addr) {
-                    let writer = EventWriterCore::new(stream);
+                    let writer = EventWriter::new(stream);
                     let mut logger = BatchLogger::new(writer);
                     result = Some(crate::logging_core::Logger::new(
                         ::std::time::Instant::now(),
@@ -269,10 +269,10 @@ where
 
             use ::std::net::TcpStream;
             use crate::logging::{BatchLogger, TimelyEvent};
-            use crate::dataflow::operators::capture::EventWriterCore;
+            use crate::dataflow::operators::capture::EventWriter;
 
             if let Ok(stream) = TcpStream::connect(&addr) {
-                let writer = EventWriterCore::new(stream);
+                let writer = EventWriter::new(stream);
                 let mut logger = BatchLogger::new(writer);
                 worker.log_register()
                     .insert::<TimelyEvent,_>("timely", move |time, data|

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -13,14 +13,14 @@ use std::time::Duration;
 use crate::dataflow::operators::capture::{Event, EventPusher};
 
 /// Logs events as a timely stream, with progress statements.
-pub struct BatchLogger<T, E, P> where P: EventPusher<Duration, (Duration, E, T)> {
+pub struct BatchLogger<T, E, P> where P: EventPusher<Duration, Vec<(Duration, E, T)>> {
     // None when the logging stream is closed
     time: Duration,
     event_pusher: P,
     _phantom: ::std::marker::PhantomData<(E, T)>,
 }
 
-impl<T, E, P> BatchLogger<T, E, P> where P: EventPusher<Duration, (Duration, E, T)> {
+impl<T, E, P> BatchLogger<T, E, P> where P: EventPusher<Duration, Vec<(Duration, E, T)>> {
     /// Creates a new batch logger.
     pub fn new(event_pusher: P) -> Self {
         BatchLogger {
@@ -42,7 +42,7 @@ impl<T, E, P> BatchLogger<T, E, P> where P: EventPusher<Duration, (Duration, E, 
         self.time = time;
     }
 }
-impl<T, E, P> Drop for BatchLogger<T, E, P> where P: EventPusher<Duration, (Duration, E, T)> {
+impl<T, E, P> Drop for BatchLogger<T, E, P> where P: EventPusher<Duration, Vec<(Duration, E, T)>> {
     fn drop(&mut self) {
         self.event_pusher.push(Event::Progress(vec![(self.time, -1)]));
     }

--- a/timely/src/synchronization/barrier.rs
+++ b/timely/src/synchronization/barrier.rs
@@ -6,7 +6,7 @@ use crate::worker::Worker;
 
 /// A re-usable barrier synchronization mechanism.
 pub struct Barrier<A: Allocate> {
-    input: InputHandle<usize, ()>,
+    input: InputHandle<usize, Vec<()>>,
     probe: ProbeHandle<usize>,
     worker: Worker<A>,
 }
@@ -51,4 +51,3 @@ impl<A: Allocate> Barrier<A> {
         !self.probe.less_than(self.input.time())
     }
 }
-

--- a/timely/src/synchronization/barrier.rs
+++ b/timely/src/synchronization/barrier.rs
@@ -17,7 +17,7 @@ impl<A: Allocate> Barrier<A> {
     pub fn new(worker: &mut Worker<A>) -> Self {
         use crate::dataflow::operators::{Input, Probe};
         let (input, probe) = worker.dataflow(|scope| {
-            let (handle, stream) = scope.new_input::<()>();
+            let (handle, stream) = scope.new_input::<Vec<()>>();
             (handle, stream.probe())
         });
         Barrier { input, probe, worker: worker.clone() }

--- a/timely/tests/barrier.rs
+++ b/timely/tests/barrier.rs
@@ -17,7 +17,7 @@ fn barrier_sync_helper(comm_config: ::timely::CommunicationConfig) {
     };
     timely::execute(config, move |worker| {
         worker.dataflow(move |scope| {
-            let (handle, stream) = scope.feedback::<u64>(1);
+            let (handle, stream) = scope.feedback::<Vec<u64>>(1);
             stream.unary_notify(
                 Pipeline,
                 "Barrier",


### PR DESCRIPTION
Warning: breaking changes up ahead!

Fixes #510 

This change removes the `Core` variants of types, traits, and functions that we introduced in #426. However, this means it introduces breaking changes, specifically where we used `Data` parameters in the past we now use `Container`. This is desirable because maintaining the old facade comes with a cognitive overhead. After this change, most places that previously specified individual elements now specify containers. All places that only apply to specific (mostly `Vec<_>`) containers are exepted.

The most notable breaking changes are in inputs, `to_stream`, and feedback, which now need to know the kind of container they produce. In the past, they were fixed to `Vec<_>`, but now the caller needs to be explicit about it.

The PR looks rather large, but most of the changes are purely mechanical. For wildly-used types, there is a commit that inlines the non-core variant, and a follow-up to rename the core-variant to the old name. This should make it explicit that each change has limited scope. Tests should pass after each individual change.
* 60ae900977ae8e1f03098f60a4696343cd77c0bb changes inputs to containers.
* 5987d4cfd4bab462a101f790093f5d468d752783 changes feedback to use containers.