### PR TITLE
Drop implementation for Tracker

### DIFF
--- a/timely/src/progress/frontier.rs
+++ b/timely/src/progress/frontier.rs
@@ -528,6 +528,17 @@ impl<T> MutableAntichain<T> {
             .map(|td| td.1)
             .sum()
     }
+
+    /// Reports the updates that form the frontier. Returns an iterator of timestamps and their frequency.
+    ///
+    /// Rebuilds the internal representation before revealing times and frequencies.
+    pub fn updates(&mut self) -> impl Iterator<Item=&(T, i64)>
+    where
+        T: Clone + PartialOrder + Ord,
+    {
+        self.rebuild();
+        self.updates.iter()
+    }
 }
 
 impl<T> Default for MutableAntichain<T> {


### PR DESCRIPTION
This allows the tracker to log reachability information when dropping dataflows. Not much tested.