### PR TITLE
communication: treat channel bounds like frontiers

### DIFF
--- a/communication/src/allocator/zero_copy/allocator.rs
+++ b/communication/src/allocator/zero_copy/allocator.rs
@@ -105,7 +105,7 @@ impl<A: AllocateBuilder> TcpBuilder<A> {
             index: self.index,
             peers: self.peers,
             canaries: Rc::new(RefCell::new(Vec::new())),
-            channel_id_bound: None,
+            channel_id_upper: 0,
             staged: Vec::new(),
             sends,
             recvs,
@@ -125,7 +125,7 @@ pub struct TcpAllocator<A: Allocate> {
     staged:     Vec<Bytes>,                         // staging area for incoming Bytes
     canaries:   Rc<RefCell<Vec<usize>>>,
 
-    channel_id_bound: Option<usize>,
+    channel_id_upper: usize,
 
     // sending, receiving, and responding to binary buffers.
     sends:      Vec<Rc<RefCell<SendEndpoint<MergeQueue>>>>,     // sends[x] -> goes to process x.
@@ -139,10 +139,8 @@ impl<A: Allocate> Allocate for TcpAllocator<A> {
     fn allocate<T: Data>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<Message<T>>>>, Box<dyn Pull<Message<T>>>) {
 
         // Assume and enforce in-order identifier allocation.
-        if let Some(bound) = self.channel_id_bound {
-            assert!(bound < identifier);
-        }
-        self.channel_id_bound = Some(identifier);
+        assert!(self.channel_id_upper <= identifier);
+        self.channel_id_upper = identifier + 1;
 
         // Result list of boxed pushers.
         let mut pushes = Vec::<Box<dyn Push<Message<T>>>>::new();
@@ -235,7 +233,7 @@ impl<A: Allocate> Allocate for TcpAllocator<A> {
                     match self.to_local.entry(header.channel) {
                         Entry::Vacant(entry) => {
                             // We may receive data before allocating, and shouldn't block.
-                            if self.channel_id_bound.map(|b| b < header.channel).unwrap_or(true) {
+                            if self.channel_id_upper <= header.channel {
                                 entry.insert(Rc::new(RefCell::new(VecDeque::new())))
                                     .borrow_mut()
                                     .push_back(peel);


### PR DESCRIPTION
This doesn't change anything in the logic but seems more timely-esque to be thinking about upper bounds as frontiers.