### PR TITLE
Mark drop_dataflow as stable

### DIFF
--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -672,9 +672,7 @@ impl<A: Allocate> Worker<A> {
     /// Drops an identified dataflow.
     ///
     /// This method removes the identified dataflow, which will no longer be scheduled.
-    /// Various other resources will be cleaned up, though the method is currently in
-    /// public beta rather than expected to work. Please report all crashes and unmet
-    /// expectations!
+    /// Various other resources will be cleaned up.
     pub fn drop_dataflow(&mut self, dataflow_identifier: usize) {
         if let Some(mut entry) = self.dataflows.borrow_mut().remove(&dataflow_identifier) {
             // Garbage collect channel_id to path information.


### PR DESCRIPTION
cc @teskje @antiguru @frankmcsherry 

Just wanted to queue this up since MaterializeInc/materialize#18442 is inching closer to completeness. If there are remaining concerns about stabilizing `drop_dataflow` (beyond 2673e8c), I figured this would be a good way to draw them out.

----

Between 2673e8c60 and ff516c81, drop_dataflow appears to be working well, based on testing in Materialize
(MaterializeInc/materialize#18442). So remove the "public beta" warning from the docstring.

Fix #306.

