### PR TITLE
give_container: Only push if message non-empty

### DIFF
--- a/timely/src/dataflow/channels/pushers/buffer.rs
+++ b/timely/src/dataflow/channels/pushers/buffer.rs
@@ -71,11 +71,13 @@ impl<T, C: Container, P: Push<BundleCore<T, C>>> BufferCore<T, C, P> where T: Eq
 
     // Gives an entire container at a specific time.
     fn give_container(&mut self, vector: &mut C) {
-        // flush to ensure fifo-ness
-        self.flush();
+        if !vector.is_empty() {
+            // flush to ensure fifo-ness
+            self.flush();
 
-        let time = self.time.as_ref().expect("Buffer::give_container(): time is None.").clone();
-        Message::push_at(vector, time, &mut self.pusher);
+            let time = self.time.as_ref().expect("Buffer::give_container(): time is None.").clone();
+            Message::push_at(vector, time, &mut self.pusher);
+        }
     }
 }
 

--- a/timely/tests/gh_523.rs
+++ b/timely/tests/gh_523.rs
@@ -1,0 +1,41 @@
+use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::{Exchange, Input, Operator, Probe};
+use timely::dataflow::InputHandle;
+use timely::Config;
+
+#[test]
+fn gh_523() {
+    timely::execute(Config::thread(), |worker| {
+        let mut input = InputHandle::new();
+        let mut buf = Vec::new();
+        let probe = worker.dataflow::<u64, _, _>(|scope| {
+            scope
+                .input_from(&mut input)
+                .unary(Pipeline, "Test", move |_, _| {
+                    move |input, output| {
+                        input.for_each(|cap, data| {
+                            data.swap(&mut buf);
+                            let mut session = output.session(&cap);
+                            session.give_container(&mut Vec::new());
+                            session.give_container(&mut buf);
+                        });
+                    }
+                })
+                .exchange(|x| *x)
+                .probe()
+        });
+
+        for round in 0..2 {
+            input.send(round);
+            input.advance_to(round + 1);
+        }
+        input.close();
+
+        while !probe.done() {
+            worker.step();
+        }
+
+        println!("worker {} complete", worker.index());
+    })
+    .unwrap();
+}


### PR DESCRIPTION
This fixes #523. The reason for the error is that guarded messages are only emitted when the message is non-empty. In this case however, the message was empty, recording that a message was sent, but never recording that the message was received. The fix makes sure to only send within `give_container` when the message is non-empty. This solves this particular problem, but the requirements around empty messages are still somewhat implicit.