### PR TITLE
input handles: give empty containers to operators

### DIFF
--- a/timely/src/dataflow/channels/pullers/counter.rs
+++ b/timely/src/dataflow/channels/pullers/counter.rs
@@ -46,15 +46,12 @@ impl<T:Ord+Clone+'static, D: Container, P: Pull<BundleCore<T, D>>> Counter<T, D,
     #[inline]
     pub(crate) fn next_guarded(&mut self) -> Option<(ConsumedGuard<T>, &mut BundleCore<T, D>)> {
         if let Some(message) = self.pullable.pull() {
-            if message.data.len() > 0 {
-                let guard = ConsumedGuard {
-                    consumed: Rc::clone(&self.consumed),
-                    time: Some(message.time.clone()),
-                    len: message.data.len(),
-                };
-                Some((guard, message))
-            }
-            else { None }
+            let guard = ConsumedGuard {
+                consumed: Rc::clone(&self.consumed),
+                time: Some(message.time.clone()),
+                len: message.data.len(),
+            };
+            Some((guard, message))
         }
         else { None }
     }


### PR DESCRIPTION
The current code tried to be helpful by ignoring any messages with zero length, but that made it impossible for the caller to differentiate between "There was an empty container message" vs "There are no more messages".

In the presence of empty containers in the channels this can lead operators to prematurely yield back to timely without fully processing their inputs, which in turn can lead to the whole dataflow not making progress since timely won't re-activate operators that have leftover events in their channels.

This PR removes this check and always forwards the containers to the operators, exactly as they were sent.

Fixes #523