### PR TITLE
Activate only by channel ID

### DIFF
--- a/communication/src/allocator/counters.rs
+++ b/communication/src/allocator/counters.rs
@@ -2,7 +2,6 @@
 
 use std::rc::Rc;
 use std::cell::RefCell;
-use std::collections::VecDeque;
 
 use crate::{Push, Pull};
 use crate::allocator::Event;
@@ -11,14 +10,14 @@ use crate::allocator::Event;
 pub struct Pusher<T, P: Push<T>> {
     index: usize,
     // count: usize,
-    events: Rc<RefCell<VecDeque<(usize, Event)>>>,
+    events: Rc<RefCell<Vec<usize>>>,
     pusher: P,
     phantom: ::std::marker::PhantomData<T>,
 }
 
 impl<T, P: Push<T>>  Pusher<T, P> {
     /// Wraps a pusher with a message counter.
-    pub fn new(pusher: P, index: usize, events: Rc<RefCell<VecDeque<(usize, Event)>>>) -> Self {
+    pub fn new(pusher: P, index: usize, events: Rc<RefCell<Vec<usize>>>) -> Self {
         Pusher {
             index,
             // count: 0,
@@ -36,7 +35,7 @@ impl<T, P: Push<T>> Push<T> for Pusher<T, P> {
         //     if self.count != 0 {
         //         self.events
         //             .borrow_mut()
-        //             .push_back((self.index, Event::Pushed(self.count)));
+        //             .push_back(self.index);
         //         self.count = 0;
         //     }
         // }
@@ -47,7 +46,7 @@ impl<T, P: Push<T>> Push<T> for Pusher<T, P> {
         //       moving information along. Better, but needs cooperation.
         self.events
             .borrow_mut()
-            .push_back((self.index, Event::Pushed(1)));
+            .push(self.index);
 
         self.pusher.push(element)
     }
@@ -110,14 +109,14 @@ impl<T, P: Push<T>> Push<T> for ArcPusher<T, P> {
 pub struct Puller<T, P: Pull<T>> {
     index: usize,
     count: usize,
-    events: Rc<RefCell<VecDeque<(usize, Event)>>>,
+    events: Rc<RefCell<Vec<usize>>>,
     puller: P,
     phantom: ::std::marker::PhantomData<T>,
 }
 
 impl<T, P: Pull<T>>  Puller<T, P> {
     /// Wraps a puller with a message counter.
-    pub fn new(puller: P, index: usize, events: Rc<RefCell<VecDeque<(usize, Event)>>>) -> Self {
+    pub fn new(puller: P, index: usize, events: Rc<RefCell<Vec<usize>>>) -> Self {
         Puller {
             index,
             count: 0,
@@ -135,7 +134,7 @@ impl<T, P: Pull<T>> Pull<T> for Puller<T, P> {
             if self.count != 0 {
                 self.events
                     .borrow_mut()
-                    .push_back((self.index, Event::Pulled(self.count)));
+                    .push(self.index);
                 self.count = 0;
             }
         }

--- a/communication/src/allocator/generic.rs
+++ b/communication/src/allocator/generic.rs
@@ -5,11 +5,10 @@
 
 use std::rc::Rc;
 use std::cell::RefCell;
-use std::collections::VecDeque;
 
 use crate::allocator::thread::ThreadBuilder;
 use crate::allocator::process::ProcessBuilder as TypedProcessBuilder;
-use crate::allocator::{Allocate, AllocateBuilder, Event, Thread, Process};
+use crate::allocator::{Allocate, AllocateBuilder, Thread, Process};
 use crate::allocator::zero_copy::allocator_process::{ProcessBuilder, ProcessAllocator};
 use crate::allocator::zero_copy::allocator::{TcpBuilder, TcpAllocator};
 
@@ -74,7 +73,7 @@ impl Generic {
             Generic::ZeroCopy(z) => z.release(),
         }
     }
-    fn events(&self) -> &Rc<RefCell<VecDeque<(usize, Event)>>> {
+    fn events(&self) -> &Rc<RefCell<Vec<usize>>> {
         match self {
             Generic::Thread(ref t) => t.events(),
             Generic::Process(ref p) => p.events(),
@@ -93,7 +92,7 @@ impl Allocate for Generic {
 
     fn receive(&mut self) { self.receive(); }
     fn release(&mut self) { self.release(); }
-    fn events(&self) -> &Rc<RefCell<VecDeque<(usize, Event)>>> { self.events() }
+    fn events(&self) -> &Rc<RefCell<Vec<usize>>> { self.events() }
     fn await_events(&self, _duration: Option<std::time::Duration>) {
         match self {
             Generic::Thread(t) => t.await_events(_duration),

--- a/communication/src/allocator/mod.rs
+++ b/communication/src/allocator/mod.rs
@@ -91,11 +91,3 @@ pub trait Allocate {
         thread::Thread::new_from(identifier, self.events().clone())
     }
 }
-
-/// A communication channel event.
-pub enum Event {
-    /// A number of messages pushed into the channel.
-    Pushed(usize),
-    /// A number of messages pulled from the channel.
-    Pulled(usize),
-}

--- a/communication/src/allocator/mod.rs
+++ b/communication/src/allocator/mod.rs
@@ -3,7 +3,6 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::time::Duration;
-use std::collections::VecDeque;
 
 pub use self::thread::Thread;
 pub use self::process::Process;
@@ -50,7 +49,7 @@ pub trait Allocate {
     /// drain these events in order to drive their computation. If they
     /// fail to do so the event queue may become quite large, and turn
     /// into a performance problem.
-    fn events(&self) -> &Rc<RefCell<VecDeque<(usize, Event)>>>;
+    fn events(&self) -> &Rc<RefCell<Vec<usize>>>;
 
     /// Awaits communication events.
     ///

--- a/communication/src/allocator/process.rs
+++ b/communication/src/allocator/process.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
 use std::any::Any;
 use std::time::Duration;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap};
 use crossbeam_channel::{Sender, Receiver};
 
 use crate::allocator::thread::{ThreadBuilder};
@@ -174,7 +174,7 @@ impl Allocate for Process {
         (sends, recv)
     }
 
-    fn events(&self) -> &Rc<RefCell<VecDeque<(usize, Event)>>> {
+    fn events(&self) -> &Rc<RefCell<Vec<usize>>> {
         self.inner.events()
     }
 
@@ -184,8 +184,8 @@ impl Allocate for Process {
 
     fn receive(&mut self) {
         let mut events = self.inner.events().borrow_mut();
-        while let Ok((index, event)) = self.counters_recv.try_recv() {
-            events.push_back((index, event));
+        while let Ok((index, _event)) = self.counters_recv.try_recv() {
+            events.push(index);
         }
     }
 }

--- a/communication/src/allocator/zero_copy/allocator.rs
+++ b/communication/src/allocator/zero_copy/allocator.rs
@@ -10,7 +10,6 @@ use crate::networking::MessageHeader;
 
 use crate::{Allocate, Message, Data, Push, Pull};
 use crate::allocator::AllocateBuilder;
-use crate::allocator::Event;
 use crate::allocator::canary::Canary;
 
 use super::bytes_exchange::{BytesPull, SendEndpoint, MergeQueue};
@@ -229,7 +228,7 @@ impl<A: Allocate> Allocate for TcpAllocator<A> {
 
                     // Increment message count for channel.
                     // Safe to do this even if the channel has been dropped.
-                    events.push_back((header.channel, Event::Pushed(1)));
+                    events.push(header.channel);
 
                     // Ensure that a queue exists.
                     match self.to_local.entry(header.channel) {
@@ -269,7 +268,7 @@ impl<A: Allocate> Allocate for TcpAllocator<A> {
         //     }
         // }
     }
-    fn events(&self) -> &Rc<RefCell<VecDeque<(usize, Event)>>> {
+    fn events(&self) -> &Rc<RefCell<Vec<usize>>> {
         self.inner.events()
     }
     fn await_events(&self, duration: Option<std::time::Duration>) {

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -338,7 +338,9 @@ impl<A: Allocate> Worker<A> {
             let events = allocator.events().clone();
             let mut borrow = events.borrow_mut();
             let paths = self.paths.borrow();
-            for (channel, _event) in borrow.drain(..) {
+            borrow.sort_unstable();
+            borrow.dedup();
+            for channel in borrow.drain(..) {
                 // TODO: Pay more attent to `_event`.
                 // Consider tracking whether a channel
                 // in non-empty, and only activating

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -341,7 +341,6 @@ impl<A: Allocate> Worker<A> {
             borrow.sort_unstable();
             borrow.dedup();
             for channel in borrow.drain(..) {
-                // TODO: Pay more attent to `_event`.
                 // Consider tracking whether a channel
                 // in non-empty, and only activating
                 // on the basis of non-empty channels.


### PR DESCRIPTION
This changes activation to avoid an associated event, which is currently not used anymore. It also switches to a `Vec` to contain the activations, and deduplicates before activating operators.

This improves performance in edge cases:
```
➜  timely-dataflow git:(activation_no_event) time taskset 1 target/release/examples/pingpong $((2**20)) 64
taskset 1 target/release/examples/pingpong $((2**20)) 64  3.63s user 0.00s system 99% cpu 3.638 total
➜  timely-dataflow-master git:(master) time taskset 1 target/release/examples/pingpong $((2**20)) 64
taskset 1 target/release/examples/pingpong $((2**20)) 64  3.32s user 0.78s system 99% cpu 4.106 total
```