### PR TITLE
Remove worker identifier from logging

### DIFF
--- a/communication/src/allocator/zero_copy/initialize.rs
+++ b/communication/src/allocator/zero_copy/initialize.rs
@@ -39,7 +39,7 @@ pub fn initialize_networking(
     my_index: usize,
     threads: usize,
     noisy: bool,
-    log_sender: Arc<dyn Fn(CommunicationSetup)->Option<Logger<CommunicationEvent, CommunicationSetup>>+Send+Sync>,
+    log_sender: Arc<dyn Fn(CommunicationSetup)->Option<Logger<CommunicationEvent>>+Send+Sync>,
 )
 -> ::std::io::Result<(Vec<TcpBuilder<ProcessBuilder>>, CommsGuard)>
 {
@@ -58,7 +58,7 @@ pub fn initialize_networking_from_sockets<S: Stream + 'static>(
     mut sockets: Vec<Option<S>>,
     my_index: usize,
     threads: usize,
-    log_sender: Arc<dyn Fn(CommunicationSetup)->Option<Logger<CommunicationEvent, CommunicationSetup>>+Send+Sync>,
+    log_sender: Arc<dyn Fn(CommunicationSetup)->Option<Logger<CommunicationEvent>>+Send+Sync>,
 )
 -> ::std::io::Result<(Vec<TcpBuilder<ProcessBuilder>>, CommsGuard)>
 {

--- a/communication/src/allocator/zero_copy/tcp.rs
+++ b/communication/src/allocator/zero_copy/tcp.rs
@@ -11,7 +11,7 @@ use super::stream::Stream;
 
 use timely_logging::Logger;
 
-use crate::logging::{CommunicationEvent, CommunicationSetup, MessageEvent, StateEvent};
+use crate::logging::{CommunicationEvent, MessageEvent, StateEvent};
 
 fn tcp_panic(context: &'static str, cause: io::Error) -> ! {
     // NOTE: some downstream crates sniff out "timely communication error:" from
@@ -35,7 +35,7 @@ pub fn recv_loop<S>(
     worker_offset: usize,
     process: usize,
     remote: usize,
-    mut logger: Option<Logger<CommunicationEvent, CommunicationSetup>>)
+    mut logger: Option<Logger<CommunicationEvent>>)
 where
     S: Stream,
 {
@@ -134,7 +134,7 @@ pub fn send_loop<S: Stream>(
     sources: Vec<Sender<MergeQueue>>,
     process: usize,
     remote: usize,
-    mut logger: Option<Logger<CommunicationEvent, CommunicationSetup>>)
+    mut logger: Option<Logger<CommunicationEvent>>)
 {
 
     // Log the send thread's start.

--- a/communication/src/initialize.rs
+++ b/communication/src/initialize.rs
@@ -39,7 +39,7 @@ pub enum Config {
         /// Verbosely report connection process
         report: bool,
         /// Closure to create a new logger for a communication thread
-        log_fn: Arc<dyn Fn(CommunicationSetup) -> Option<Logger<CommunicationEvent, CommunicationSetup>> + Send + Sync>,
+        log_fn: Arc<dyn Fn(CommunicationSetup) -> Option<Logger<CommunicationEvent>> + Send + Sync>,
     }
 }
 
@@ -183,62 +183,62 @@ impl Config {
 /// # Examples
 /// ```
 /// use timely_communication::{Allocate, Bytesable};
-/// 
+///
 /// /// A wrapper that indicates the serialization/deserialization strategy.
 /// pub struct Message {
 ///     /// Text contents.
 ///     pub payload: String,
 /// }
-/// 
+///
 /// impl Bytesable for Message {
 ///     fn from_bytes(bytes: timely_bytes::arc::Bytes) -> Self {
 ///         Message { payload: std::str::from_utf8(&bytes[..]).unwrap().to_string() }
 ///     }
-/// 
+///
 ///     fn length_in_bytes(&self) -> usize {
 ///         self.payload.len()
 ///     }
-/// 
+///
 ///     fn into_bytes<W: ::std::io::Write>(&self, writer: &mut W) {
 ///         writer.write_all(self.payload.as_bytes()).unwrap();
 ///     }
 /// }
-/// 
+///
 /// fn main() {
-/// 
+///
 ///     // extract the configuration from user-supplied arguments, initialize the computation.
 ///     let config = timely_communication::Config::from_args(std::env::args()).unwrap();
 ///     let guards = timely_communication::initialize(config, |mut allocator| {
-/// 
+///
 ///         println!("worker {} of {} started", allocator.index(), allocator.peers());
-/// 
+///
 ///         // allocates a pair of senders list and one receiver.
 ///         let (mut senders, mut receiver) = allocator.allocate(0);
-/// 
+///
 ///         // send typed data along each channel
 ///         for i in 0 .. allocator.peers() {
 ///             senders[i].send(Message { payload: format!("hello, {}", i)});
 ///             senders[i].done();
 ///         }
-/// 
+///
 ///         // no support for termination notification,
 ///         // we have to count down ourselves.
 ///         let mut received = 0;
 ///         while received < allocator.peers() {
-/// 
+///
 ///             allocator.receive();
-/// 
+///
 ///             if let Some(message) = receiver.recv() {
 ///                 println!("worker {}: received: <{}>", allocator.index(), message.payload);
 ///                 received += 1;
 ///             }
-/// 
+///
 ///             allocator.release();
 ///         }
-/// 
+///
 ///         allocator.index()
 ///     });
-/// 
+///
 ///     // computation runs until guards are joined or dropped.
 ///     if let Ok(guards) = guards {
 ///         for guard in guards.join() {
@@ -279,62 +279,62 @@ pub fn initialize<T:Send+'static, F: Fn(Generic)->T+Send+Sync+'static>(
 /// # Examples
 /// ```
 /// use timely_communication::{Allocate, Bytesable};
-/// 
+///
 /// /// A wrapper that indicates `bincode` as the serialization/deserialization strategy.
 /// pub struct Message {
 ///     /// Text contents.
 ///     pub payload: String,
 /// }
-/// 
+///
 /// impl Bytesable for Message {
 ///     fn from_bytes(bytes: timely_bytes::arc::Bytes) -> Self {
 ///         Message { payload: std::str::from_utf8(&bytes[..]).unwrap().to_string() }
 ///     }
-/// 
+///
 ///     fn length_in_bytes(&self) -> usize {
 ///         self.payload.len()
 ///     }
-/// 
+///
 ///     fn into_bytes<W: ::std::io::Write>(&self, writer: &mut W) {
 ///         writer.write_all(self.payload.as_bytes()).unwrap();
 ///     }
 /// }
-/// 
+///
 /// fn main() {
-/// 
+///
 ///     // extract the configuration from user-supplied arguments, initialize the computation.
 ///     let config = timely_communication::Config::from_args(std::env::args()).unwrap();
 ///     let guards = timely_communication::initialize(config, |mut allocator| {
-/// 
+///
 ///         println!("worker {} of {} started", allocator.index(), allocator.peers());
-/// 
+///
 ///         // allocates a pair of senders list and one receiver.
 ///         let (mut senders, mut receiver) = allocator.allocate(0);
-/// 
+///
 ///         // send typed data along each channel
 ///         for i in 0 .. allocator.peers() {
 ///             senders[i].send(Message { payload: format!("hello, {}", i)});
 ///             senders[i].done();
 ///         }
-/// 
+///
 ///         // no support for termination notification,
 ///         // we have to count down ourselves.
 ///         let mut received = 0;
 ///         while received < allocator.peers() {
-/// 
+///
 ///             allocator.receive();
-/// 
+///
 ///             if let Some(message) = receiver.recv() {
 ///                 println!("worker {}: received: <{}>", allocator.index(), message.payload);
 ///                 received += 1;
 ///             }
-/// 
+///
 ///             allocator.release();
 ///         }
-/// 
+///
 ///         allocator.index()
 ///     });
-/// 
+///
 ///     // computation runs until guards are joined or dropped.
 ///     if let Ok(guards) = guards {
 ///         for guard in guards.join() {

--- a/communication/src/logging.rs
+++ b/communication/src/logging.rs
@@ -20,6 +20,8 @@ pub enum CommunicationEvent {
     Message(MessageEvent),
     /// A state transition.
     State(StateEvent),
+    /// Setup event
+    Setup(CommunicationSetup)
 }
 
 /// An observed message.

--- a/timely/examples/logging-send.rs
+++ b/timely/examples/logging-send.rs
@@ -25,7 +25,7 @@ fn main() {
         worker.log_register().insert::<TimelyProgressEvent,_>("timely/progress", |_time, data|
             data.iter().for_each(|x| {
                 println!("PROGRESS: {:?}", x);
-                let (_, _, ev) = x;
+                let (_, ev) = x;
                 print!("PROGRESS: TYPED MESSAGES: ");
                 for (n, p, t, d) in ev.messages.iter() {
                     print!("{:?}, ", (n, p, t.as_any().downcast_ref::<usize>(), d));

--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -70,7 +70,7 @@ where
     fn peek_identifier(&self) -> usize {
         self.parent.peek_identifier()
     }
-    fn log_register(&self) -> ::std::cell::RefMut<crate::logging_core::Registry<crate::logging::WorkerIdentifier>> {
+    fn log_register(&self) -> ::std::cell::RefMut<crate::logging_core::Registry> {
         self.parent.log_register()
     }
 }

--- a/timely/src/execute.rs
+++ b/timely/src/execute.rs
@@ -1,5 +1,6 @@
 //! Starts a timely dataflow execution from configuration information and per-worker logic.
 
+use timely_communication::logging::CommunicationEvent;
 use crate::communication::{initialize_from, Allocator, allocator::AllocateBuilder, WorkerGuards};
 use crate::dataflow::scopes::Child;
 use crate::worker::Worker;

--- a/timely/src/execute.rs
+++ b/timely/src/execute.rs
@@ -1,6 +1,5 @@
 //! Starts a timely dataflow execution from configuration information and per-worker logic.
 
-use timely_communication::logging::CommunicationEvent;
 use crate::communication::{initialize_from, Allocator, allocator::AllocateBuilder, WorkerGuards};
 use crate::dataflow::scopes::Child;
 use crate::worker::Worker;

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -21,7 +21,7 @@ pub struct BatchLogger<T, P> where P: EventPusher<Duration, Vec<(Duration, T)>> 
     _phantom: ::std::marker::PhantomData<T>,
 }
 
-impl<T, E, P> BatchLogger<T, P> where P: EventPusher<Duration, Vec<(Duration, T)>> {
+impl<T, P> BatchLogger<T, P> where P: EventPusher<Duration, Vec<(Duration, T)>> {
     /// Creates a new batch logger.
     pub fn new(event_pusher: P) -> Self {
         BatchLogger {
@@ -43,7 +43,7 @@ impl<T, E, P> BatchLogger<T, P> where P: EventPusher<Duration, Vec<(Duration, T)
         self.time = time;
     }
 }
-impl<T, P> Drop for BatchLogger<T, P> where P: EventPusher<Duration, Vec<(Duration, E, T)>> {
+impl<T, P> Drop for BatchLogger<T, P> where P: EventPusher<Duration, Vec<(Duration, T)>> {
     fn drop(&mut self) {
         self.event_pusher.push(Event::Progress(vec![(self.time, -1)]));
     }

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -3,7 +3,7 @@
 /// Type alias for logging timely events.
 pub type WorkerIdentifier = usize;
 /// Logger type for worker-local logging.
-pub type Logger<Event> = crate::logging_core::Logger<Event, WorkerIdentifier>;
+pub type Logger<Event> = crate::logging_core::Logger<Event>;
 /// Logger for timely dataflow system events.
 pub type TimelyLogger = Logger<TimelyEvent>;
 /// Logger for timely dataflow progress events (the "timely/progress" log stream).
@@ -14,14 +14,14 @@ use serde::{Deserialize, Serialize};
 use crate::dataflow::operators::capture::{Event, EventPusher};
 
 /// Logs events as a timely stream, with progress statements.
-pub struct BatchLogger<T, E, P> where P: EventPusher<Duration, Vec<(Duration, E, T)>> {
+pub struct BatchLogger<T, P> where P: EventPusher<Duration, Vec<(Duration, T)>> {
     // None when the logging stream is closed
     time: Duration,
     event_pusher: P,
-    _phantom: ::std::marker::PhantomData<(E, T)>,
+    _phantom: ::std::marker::PhantomData<T>,
 }
 
-impl<T, E, P> BatchLogger<T, E, P> where P: EventPusher<Duration, Vec<(Duration, E, T)>> {
+impl<T, E, P> BatchLogger<T, P> where P: EventPusher<Duration, Vec<(Duration, T)>> {
     /// Creates a new batch logger.
     pub fn new(event_pusher: P) -> Self {
         BatchLogger {
@@ -31,7 +31,7 @@ impl<T, E, P> BatchLogger<T, E, P> where P: EventPusher<Duration, Vec<(Duration,
         }
     }
     /// Publishes a batch of logged events and advances the capability.
-    pub fn publish_batch(&mut self, &time: &Duration, data: &mut Vec<(Duration, E, T)>) {
+    pub fn publish_batch(&mut self, &time: &Duration, data: &mut Vec<(Duration, T)>) {
         if !data.is_empty() {
             self.event_pusher.push(Event::Messages(self.time, std::mem::take(data)));
         }
@@ -43,7 +43,7 @@ impl<T, E, P> BatchLogger<T, E, P> where P: EventPusher<Duration, Vec<(Duration,
         self.time = time;
     }
 }
-impl<T, E, P> Drop for BatchLogger<T, E, P> where P: EventPusher<Duration, Vec<(Duration, E, T)>> {
+impl<T, P> Drop for BatchLogger<T, P> where P: EventPusher<Duration, Vec<(Duration, E, T)>> {
     fn drop(&mut self) {
         self.event_pusher.push(Event::Progress(vec![(self.time, -1)]));
     }

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -198,7 +198,7 @@ pub trait AsWorker : Scheduler {
     /// The next worker-unique identifier to be allocated.
     fn peek_identifier(&self) -> usize;
     /// Provides access to named logging streams.
-    fn log_register(&self) -> ::std::cell::RefMut<crate::logging_core::Registry<crate::logging::WorkerIdentifier>>;
+    fn log_register(&self) -> ::std::cell::RefMut<crate::logging_core::Registry>;
     /// Provides access to the timely logging stream.
     fn logging(&self) -> Option<crate::logging::TimelyLogger> { self.log_register().get("timely") }
 }
@@ -214,7 +214,7 @@ pub struct Worker<A: Allocate> {
     // dataflows: Rc<RefCell<Vec<Wrapper>>>,
     dataflows: Rc<RefCell<HashMap<usize, Wrapper>>>,
     dataflow_counter: Rc<RefCell<usize>>,
-    logging: Rc<RefCell<crate::logging_core::Registry<crate::logging::WorkerIdentifier>>>,
+    logging: Rc<RefCell<crate::logging_core::Registry>>,
 
     activations: Rc<RefCell<Activations>>,
     active_dataflows: Vec<usize>,
@@ -245,7 +245,7 @@ impl<A: Allocate> AsWorker for Worker<A> {
 
     fn new_identifier(&mut self) -> usize { self.new_identifier() }
     fn peek_identifier(&self) -> usize { self.peek_identifier() }
-    fn log_register(&self) -> RefMut<crate::logging_core::Registry<crate::logging::WorkerIdentifier>> {
+    fn log_register(&self) -> RefMut<crate::logging_core::Registry> {
         self.log_register()
     }
 }
@@ -260,7 +260,6 @@ impl<A: Allocate> Worker<A> {
     /// Allocates a new `Worker` bound to a channel allocator.
     pub fn new(config: Config, c: A) -> Worker<A> {
         let now = Instant::now();
-        let index = c.index();
         Worker {
             config,
             timer: now,
@@ -269,7 +268,7 @@ impl<A: Allocate> Worker<A> {
             identifiers:  Default::default(),
             dataflows: Default::default(),
             dataflow_counter:  Default::default(),
-            logging: Rc::new(RefCell::new(crate::logging_core::Registry::new(now, index))),
+            logging: Rc::new(RefCell::new(crate::logging_core::Registry::new(now))),
             activations: Rc::new(RefCell::new(Activations::new(now))),
             active_dataflows: Default::default(),
             temp_channel_ids:  Default::default(),
@@ -542,7 +541,7 @@ impl<A: Allocate> Worker<A> {
     ///           );
     /// });
     /// ```
-    pub fn log_register(&self) -> ::std::cell::RefMut<crate::logging_core::Registry<crate::logging::WorkerIdentifier>> {
+    pub fn log_register(&self) -> ::std::cell::RefMut<crate::logging_core::Registry> {
         self.logging.borrow_mut()
     }
 


### PR DESCRIPTION
This changes the data received from logging from (Duration, Id, Data) to
(Duration, Data), saving the space for Id. In most cases, the Id can be
derived from the context where the log data is processed.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>