### PR TITLE
Remove an unused dependency on clap

### DIFF
--- a/kafkaesque/Cargo.toml
+++ b/kafkaesque/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Frank McSherry <fmcsherry@me.com>"]
 edition = "2018"
 
 [dependencies]
-clap="*"
 abomonation="0.7"
 timely = { path = "../timely" }
 


### PR DESCRIPTION
This prevents building Timely in CI because recent versions of clap require a newer version of Rust than what we use in CI.