### PR TITLE
Log frontiers in progress tracking

### DIFF
--- a/timely/examples/logging-send.rs
+++ b/timely/examples/logging-send.rs
@@ -29,13 +29,13 @@ fn main() {
                 println!("PROGRESS: {:?}", x);
                 let (_, _, ev) = x;
                 print!("PROGRESS: TYPED MESSAGES: ");
-                for (n, p, t, d) in ev.messages.iter() {
-                    print!("{:?}, ", (n, p, t.as_any().downcast_ref::<usize>(), d));
+                for (l, t, d) in ev.messages.iter() {
+                    print!("{:?}, ", (l, t.as_any().downcast_ref::<usize>(), d));
                 }
                 println!();
                 print!("PROGRESS: TYPED INTERNAL: ");
-                for (n, p, t, d) in ev.internal.iter() {
-                    print!("{:?}, ", (n, p, t.as_any().downcast_ref::<usize>(), d));
+                for (l, t, d) in ev.internal.iter() {
+                    print!("{:?}, ", (l, t.as_any().downcast_ref::<usize>(), d));
                 }
                 println!();
             })

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -11,6 +11,7 @@ pub type TimelyProgressLogger = Logger<TimelyProgressEvent>;
 
 use std::time::Duration;
 use crate::dataflow::operators::capture::{Event, EventPusher};
+use crate::progress::Location;
 
 /// Logs events as a timely stream, with progress statements.
 pub struct BatchLogger<T, E, P> where P: EventPusher<Duration, (Duration, E, T)> {
@@ -80,10 +81,15 @@ pub trait ProgressEventTimestamp: std::fmt::Debug + std::any::Any {
     ///
     /// # Example
     /// ```rust
-    /// let ts = vec![(0usize, 0usize, (23u64, 10u64), -4i64), (0usize, 0usize, (23u64, 11u64), 1i64)];
+    /// use timely::progress::Location;
+    ///
+    /// let ts = vec![
+    ///     (Location::new_target(0, 0), (23u64, 10u64), -4i64),
+    ///     (Location::new_target(0, 0), (23u64, 11u64), 1i64),
+    /// ];
     /// let ts: &timely::logging::ProgressEventTimestampVec = &ts;
-    /// for (n, p, t, d) in ts.iter() {
-    ///     print!("{:?}, ", (n, p, t.as_any().downcast_ref::<(u64, u64)>(), d));
+    /// for (l, t, d) in ts.iter() {
+    ///     print!("{:?}, ", (l, t.as_any().downcast_ref::<(u64, u64)>(), d));
     /// }
     /// println!();
     /// ```
@@ -114,14 +120,14 @@ impl<T: crate::Data + std::fmt::Debug + std::any::Any> ProgressEventTimestamp fo
 /// for each dynamically typed element).
 pub trait ProgressEventTimestampVec: std::fmt::Debug + std::any::Any {
     /// Iterate over the contents of the vector
-    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item=(&'a usize, &'a usize, &'a dyn ProgressEventTimestamp, &'a i64)>+'a>;
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item=(&'a Location, &'a dyn ProgressEventTimestamp, &'a i64)>+'a>;
 }
 
-impl<T: ProgressEventTimestamp> ProgressEventTimestampVec for Vec<(usize, usize, T, i64)> {
-    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item=(&'a usize, &'a usize, &'a dyn ProgressEventTimestamp, &'a i64)>+'a> {
-        Box::new(<[(usize, usize, T, i64)]>::iter(&self[..]).map(|(n, p, t, d)| {
+impl<T: ProgressEventTimestamp> ProgressEventTimestampVec for Vec<(Location, T, i64)> {
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item=(&'a Location, &'a dyn ProgressEventTimestamp, &'a i64)>+'a> {
+        Box::new(<[_]>::iter(&self[..]).map(|(l, t, d)| {
             let t: &dyn ProgressEventTimestamp = t;
-            (n, p, t, d)
+            (l, t, d)
         }))
     }
 }

--- a/timely/src/progress/broadcast.rs
+++ b/timely/src/progress/broadcast.rs
@@ -1,7 +1,7 @@
 //! Broadcasts progress information among workers.
 
 use crate::progress::{ChangeBatch, Timestamp};
-use crate::progress::{Location, Port};
+use crate::progress::Location;
 use crate::communication::{Message, Push, Pull};
 use crate::logging::TimelyLogger as Logger;
 use crate::logging::TimelyProgressLogger as ProgressLogger;
@@ -68,13 +68,10 @@ impl<T:Timestamp+Send> Progcaster<T> {
                 let mut internal = Box::new(Vec::with_capacity(changes.len()));
 
                 for ((location, time), diff) in changes.iter() {
-                    match location.port {
-                        Port::Target(port) => {
-                            messages.push((location.node, port, time.clone(), *diff))
-                        },
-                        Port::Source(port) => {
-                            internal.push((location.node, port, time.clone(), *diff))
-                        }
+                    if location.is_target() {
+                        messages.push((*location, time.clone(), *diff))
+                    } else {
+                        internal.push((*location, time.clone(), *diff))
                     }
                 }
 
@@ -137,14 +134,10 @@ impl<T:Timestamp+Send> Progcaster<T> {
                 let mut internal = Box::new(Vec::with_capacity(changes.len()));
 
                 for ((location, time), diff) in recv_changes.iter() {
-
-                    match location.port {
-                        Port::Target(port) => {
-                            messages.push((location.node, port, time.clone(), *diff))
-                        },
-                        Port::Source(port) => {
-                            internal.push((location.node, port, time.clone(), *diff))
-                        }
+                    if location.is_target() {
+                        messages.push((*location, time.clone(), *diff))
+                    } else {
+                        internal.push((*location, time.clone(), *diff))
                     }
                 }
 

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -459,10 +459,10 @@ where
         }
 
         // Propagate implications of progress changes.
-        self.pointstamp_tracker.propagate_all();
+        let updates = self.pointstamp_tracker.propagate_all();
 
         // Drain propagated information into shared progress structure.
-        for ((location, time), diff) in self.pointstamp_tracker.pushed().drain() {
+        for ((location, time), diff) in updates {
             self.maybe_shutdown.push(location.node);
             // Targets are actionable, sources are not.
             if let crate::progress::Port::Target(port) = location.port {


### PR DESCRIPTION
This PR adds logging of frontiers to the reachability tracker. This is in support of hydration progress tracking in Materialize, which would like to know the per-operator frontiers to know which ones have finished processing their snapshot inputs.

Look at the commit messages for more details. The actual logging change is in the second commit, commit 1 and 2 are supporting changes that try to limit the performance impact of the additional logging.

The performance impact of this change should be negligible (or even negative!) when reachability logging is disabled and small when reachability logging is enabled. I'm including microbenchmark results in [a comment below](https://github.com/TimelyDataflow/timely-dataflow/pull/539#issuecomment-1831663225).

The reason that commit 3 makes the code more performant is, I think, that is makes it possible to allocate the vec that's passed to `log_frontier_updates` with the correct size upfront, rather than having to geometrically grow two vecs of unknown final size. We can probably get a similar effect without changing how `TrackerEvent` looks, by counting the number of target and source changes while pushing to `pushed_changes`. I like the `TrackerEvent` change because it removes some duplication, but it's not a required one.