### PR TITLE
Container GATs, improve traits

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - run: cargo install mdbook --version 0.4.27
+      - run: cargo install mdbook --version 0.4.36
       - run: cd mdbook && mdbook build
       - uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    - run: rustup update 1.64 --no-self-update && rustup default 1.64
+    - run: rustup update 1.65 --no-self-update && rustup default 1.65
     - run: cargo build
     - name: test mdBook
       # rustdoc doesn't build dependencies, so it needs to run after `cargo build`,

--- a/timely/src/dataflow/channels/pact.rs
+++ b/timely/src/dataflow/channels/pact.rs
@@ -8,18 +8,16 @@
 //! The progress tracking logic assumes that this number is independent of the pact used.
 
 use std::{fmt::{self, Debug}, marker::PhantomData};
-use timely_container::PushPartitioned;
 
-use crate::communication::{Push, Pull, Data};
-use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
 use crate::Container;
-
-use crate::worker::AsWorker;
+use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
+use crate::communication::{Push, Pull, Data};
+use crate::container::PushPartitioned;
 use crate::dataflow::channels::pushers::Exchange as ExchangePusher;
-use super::{BundleCore, Message};
-
+use crate::dataflow::channels::{BundleCore, Message};
 use crate::logging::{TimelyLogger as Logger, MessagesEvent};
 use crate::progress::Timestamp;
+use crate::worker::AsWorker;
 
 /// A `ParallelizationContractCore` allocates paired `Push` and `Pull` implementors.
 pub trait ParallelizationContractCore<T, D> {
@@ -53,14 +51,18 @@ impl<T: 'static, D: Container> ParallelizationContractCore<T, D> for Pipeline {
 }
 
 /// An exchange between multiple observers by data
-pub struct ExchangeCore<C, D, F> { hash_func: F, phantom: PhantomData<(C, D)> }
+pub struct ExchangeCore<C, F> { hash_func: F, phantom: PhantomData<C> }
 
 /// [ExchangeCore] specialized to vector-based containers.
-pub type Exchange<D, F> = ExchangeCore<Vec<D>, D, F>;
+pub type Exchange<D, F> = ExchangeCore<Vec<D>, F>;
 
-impl<C, D, F: FnMut(&D)->u64+'static> ExchangeCore<C, D, F> {
+impl<C, F> ExchangeCore<C, F>
+where
+    C: PushPartitioned,
+    for<'a> F: FnMut(&C::Item<'a>)->u64
+{
     /// Allocates a new `Exchange` pact from a distribution function.
-    pub fn new(func: F) -> ExchangeCore<C, D, F> {
+    pub fn new(func: F) -> ExchangeCore<C, F> {
         ExchangeCore {
             hash_func:  func,
             phantom:    PhantomData,
@@ -69,11 +71,12 @@ impl<C, D, F: FnMut(&D)->u64+'static> ExchangeCore<C, D, F> {
 }
 
 // Exchange uses a `Box<Pushable>` because it cannot know what type of pushable will return from the allocator.
-impl<T: Timestamp, C, D: Data+Clone, F: FnMut(&D)->u64+'static> ParallelizationContractCore<T, C> for ExchangeCore<C, D, F>
+impl<T: Timestamp, C, H: 'static> ParallelizationContractCore<T, C> for ExchangeCore<C, H>
 where
-    C: Data + Container + PushPartitioned<Item=D>,
+    C: Data + PushPartitioned,
+    for<'a> H: FnMut(&C::Item<'a>) -> u64
 {
-    type Pusher = ExchangePusher<T, C, D, LogPusher<T, C, Box<dyn Push<BundleCore<T, C>>>>, F>;
+    type Pusher = ExchangePusher<T, C, LogPusher<T, C, Box<dyn Push<BundleCore<T, C>>>>, H>;
     type Puller = LogPuller<T, C, Box<dyn Pull<BundleCore<T, C>>>>;
 
     fn connect<A: AsWorker>(self, allocator: &mut A, identifier: usize, address: &[usize], logging: Option<Logger>) -> (Self::Pusher, Self::Puller) {
@@ -83,7 +86,7 @@ where
     }
 }
 
-impl<C, D, F> Debug for ExchangeCore<C, D, F> {
+impl<C, F> Debug for ExchangeCore<C, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Exchange").finish()
     }

--- a/timely/src/dataflow/channels/pushers/buffer.rs
+++ b/timely/src/dataflow/channels/pushers/buffer.rs
@@ -125,19 +125,26 @@ impl<'a, T, C: Container, P: Push<BundleCore<T, C>>+'a> Session<'a, T, C, P>  wh
     }
 }
 
-impl<'a, T, D: Data, P: Push<BundleCore<T, Vec<D>>>+'a> Session<'a, T, Vec<D>, P>  where T: Eq+Clone+'a, D: 'a {
+impl<'a, T, C, P: Push<BundleCore<T, C>>+'a> Session<'a, T, C, P>
+where
+    T: Eq+Clone+'a,
+    C: 'a + PushContainer,
+{
     /// Provides one record at the time specified by the `Session`.
     #[inline]
-    pub fn give(&mut self, data: D) {
+    pub fn give<D: PushInto<C>>(&mut self, data: D) {
         self.buffer.give(data);
     }
     /// Provides an iterator of records at the time specified by the `Session`.
     #[inline]
-    pub fn give_iterator<I: Iterator<Item=D>>(&mut self, iter: I) {
+    pub fn give_iterator<I: Iterator<Item=D>, D: PushInto<C>>(&mut self, iter: I) {
         for item in iter {
             self.give(item);
         }
     }
+}
+
+impl<'a, T, D: Data, P: Push<BundleCore<T, Vec<D>>>+'a> Session<'a, T, Vec<D>, P>  where T: Eq+Clone+'a, D: 'a {
     /// Provides a fully formed `Content<D>` message for senders which can use this type.
     ///
     /// The `Content` type is the backing memory for communication in timely, and it can

--- a/timely/src/dataflow/operators/core/inspect.rs
+++ b/timely/src/dataflow/operators/core/inspect.rs
@@ -1,9 +1,6 @@
 //! Extension trait and implementation for observing and action on streamed data.
 
-use std::rc::Rc;
-use timely_container::columnation::{Columnation, TimelyStack};
 use crate::Container;
-use crate::Data;
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::{Scope, StreamCore};
 use crate::dataflow::operators::generic::Operator;
@@ -21,7 +18,10 @@ pub trait Inspect<G: Scope, C: Container>: InspectCore<G, C> + Sized {
     ///            .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn inspect(&self, mut func: impl FnMut(&C::Item)+'static) -> Self {
+    fn inspect<F: 'static>(&self, mut func: F) -> Self
+    where
+        for<'a> F: FnMut(C::ItemRef<'a>)
+    {
         self.inspect_batch(move |_, data| {
             for datum in data.iter() { func(datum); }
         })
@@ -38,10 +38,13 @@ pub trait Inspect<G: Scope, C: Container>: InspectCore<G, C> + Sized {
     ///            .inspect_time(|t, x| println!("seen at: {:?}\t{:?}", t, x));
     /// });
     /// ```
-    fn inspect_time(&self, mut func: impl FnMut(&G::Timestamp, &C::Item)+'static) -> Self {
+    fn inspect_time<F: 'static>(&self, mut func: F) -> Self
+    where
+        for <'a> F: FnMut(&G::Timestamp, C::ItemRef<'a>),
+    {
         self.inspect_batch(move |time, data| {
             for datum in data.iter() {
-                func(&time, &datum);
+                func(&time, datum);
             }
         })
     }
@@ -57,7 +60,7 @@ pub trait Inspect<G: Scope, C: Container>: InspectCore<G, C> + Sized {
     ///            .inspect_batch(|t,xs| println!("seen at: {:?}\t{:?} records", t, xs.len()));
     /// });
     /// ```
-    fn inspect_batch(&self, mut func: impl FnMut(&G::Timestamp, &[C::Item])+'static) -> Self {
+    fn inspect_batch(&self, mut func: impl FnMut(&G::Timestamp, &C)+'static) -> Self {
         self.inspect_core(move |event| {
             if let Ok((time, data)) = event {
                 func(time, data);
@@ -84,26 +87,12 @@ pub trait Inspect<G: Scope, C: Container>: InspectCore<G, C> + Sized {
     ///             });
     /// });
     /// ```
-    fn inspect_core<F>(&self, func: F) -> Self where F: FnMut(Result<(&G::Timestamp, &[C::Item]), &[G::Timestamp]>)+'static;
+    fn inspect_core<F>(&self, func: F) -> Self where F: FnMut(Result<(&G::Timestamp, &C), &[G::Timestamp]>)+'static;
 }
 
-impl<G: Scope, D: Data> Inspect<G, Vec<D>> for StreamCore<G, Vec<D>> {
-    fn inspect_core<F>(&self, mut func: F) -> Self where F: FnMut(Result<(&G::Timestamp, &[D]), &[G::Timestamp]>) + 'static {
-        self.inspect_container(move |r| func(r.map(|(t, c)| (t, &c[..]))))
-    }
-}
-
-impl<G: Scope, D: Data+Columnation> Inspect<G, TimelyStack<D>> for StreamCore<G, TimelyStack<D>> {
-    fn inspect_core<F>(&self, mut func: F) -> Self where F: FnMut(Result<(&G::Timestamp, &[D]), &[G::Timestamp]>) + 'static {
-        self.inspect_container(move |r| func(r.map(|(t, c)| (t, &c[..]))))
-    }
-}
-
-impl<G: Scope, C: Container> Inspect<G, Rc<C>> for StreamCore<G, Rc<C>>
-    where C: AsRef<[C::Item]>
-{
-    fn inspect_core<F>(&self, mut func: F) -> Self where F: FnMut(Result<(&G::Timestamp, &[C::Item]), &[G::Timestamp]>) + 'static {
-        self.inspect_container(move |r| func(r.map(|(t, c)| (t, c.as_ref().as_ref()))))
+impl<G: Scope, C: Container> Inspect<G, C> for StreamCore<G, C> {
+    fn inspect_core<F>(&self, mut func: F) -> Self where F: FnMut(Result<(&G::Timestamp, &C), &[G::Timestamp]>) + 'static {
+        self.inspect_container(move |r| func(r))
     }
 }
 

--- a/timely/src/dataflow/operators/core/mod.rs
+++ b/timely/src/dataflow/operators/core/mod.rs
@@ -1,0 +1,10 @@
+//! Extension traits for `Stream` implementing various operators that
+//! are independent of specific container types.
+
+pub mod exchange;
+pub mod inspect;
+pub mod reclock;
+
+pub use exchange::Exchange;
+pub use inspect::{Inspect, InspectCore};
+pub use reclock::Reclock;

--- a/timely/src/dataflow/operators/core/reclock.rs
+++ b/timely/src/dataflow/operators/core/reclock.rs
@@ -45,11 +45,11 @@ pub trait Reclock<S: Scope> {
     /// assert_eq!(extracted[1], (5, vec![4,5]));
     /// assert_eq!(extracted[2], (8, vec![6,7,8]));
     /// ```
-    fn reclock<TC: Container<Item=()>>(&self, clock: &StreamCore<S, TC>) -> Self;
+    fn reclock<TC: Container>(&self, clock: &StreamCore<S, TC>) -> Self;
 }
 
 impl<S: Scope, C: Container> Reclock<S> for StreamCore<S, C> {
-    fn reclock<TC: Container<Item=()>>(&self, clock: &StreamCore<S, TC>) -> StreamCore<S, C> {
+    fn reclock<TC: Container>(&self, clock: &StreamCore<S, TC>) -> StreamCore<S, C> {
 
         let mut stash = vec![];
 

--- a/timely/src/dataflow/operators/mod.rs
+++ b/timely/src/dataflow/operators/mod.rs
@@ -33,6 +33,8 @@ pub use self::generic::{Notificator, FrontierNotificator};
 pub use self::reclock::Reclock;
 pub use self::count::Accumulate;
 
+pub mod core;
+
 pub mod enterleave;
 pub mod input;
 pub mod flow_controlled;
@@ -41,10 +43,10 @@ pub mod feedback;
 pub mod concat;
 pub mod partition;
 pub mod map;
-pub mod inspect;
+pub use self::core::inspect;
 pub mod filter;
 pub mod delay;
-pub mod exchange;
+pub use self::core::exchange;
 pub mod broadcast;
 pub mod probe;
 pub mod to_stream;
@@ -57,7 +59,7 @@ pub mod result;
 pub mod aggregation;
 pub mod generic;
 
-pub mod reclock;
+pub use self::core::reclock;
 pub mod count;
 
 // keep "mint" module-private


### PR DESCRIPTION
Cleanup the `Container::Item` type, move it to `PushPartitioned` and make it a GAT. Similarly, split the `Map` trait in two (`Map`, `MapInPlace`) and support GATs in the `Map` trait.

This has the benefit that Timely becomes less opinionated about the interface provided by containers, for example by allowing non-owned data when calling `stream.map`.