### PR TITLE
Bump dependency versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - run: cargo install mdbook --version 0.4.27
+      - run: cargo install mdbook --version 0.4.36
       - run: cd mdbook && mdbook build
       - uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    - run: rustup update 1.64 --no-self-update && rustup default 1.64
+    - run: rustup update 1.65 --no-self-update && rustup default 1.65
     - run: cargo build
     - name: test mdBook
       # rustdoc doesn't build dependencies, so it needs to run after `cargo build`,


### PR DESCRIPTION
Update dependencies to more recent versions. This is support to enable GATs, which are part of Rust 1.65.