### PR TITLE
Add support for release-plz

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates every Monday
+    schedule:
+      interval: "weekly"
+

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,4 +24,4 @@ jobs:
         uses: MarcoIeni/release-plz-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.RELEASE_PLZ_CARGO_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,27 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/container/Cargo.toml
+++ b/container/Cargo.toml
@@ -6,6 +6,6 @@ license = "MIT"
 edition.workspace = true
 
 [dependencies]
-columnation = { git = "https://github.com/frankmcsherry/columnation" }
+columnation = "0.1"
 flatcontainer = "0.5"
 serde = { version = "1.0", features = ["derive"] }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,10 @@
+[workspace]
+# disable the changelog for all packages
+changelog_update = false
+
+[[package]]
+name = "timely"
+# enable the changelog for this package
+changelog_update = true
+# set the path of the changelog to the root of the repository
+changelog_path = "./CHANGELOG.md"


### PR DESCRIPTION
This adds initial support for release-plz and configures it to only produce a changelog for the timely crate.

It adds the following files:
* `.github/dependabot.yml`: Check that we're running recent versions of github actions. It doesn't check for crate updates, that'd add a lot of noise.
* `.github/workflows/release-plz.yml`: The action to enable [release-plz](https://release-plz.ieni.dev/). Pretty much the most basic variant I can imagine.
* `release-plz.toml`: Configure release-plz to only produce changelogs for the `timely` crate. We could think about disabling the changelog entirely. (While it maintains a release PR, it's easy to manually edit the changelog before merging.)
