### PR TITLE
Change generic variable for containers from `D` to `C`

### DIFF
--- a/timely/src/dataflow/channels/mod.rs
+++ b/timely/src/dataflow/channels/mod.rs
@@ -11,39 +11,39 @@ pub mod pullers;
 pub mod pact;
 
 /// The input to and output from timely dataflow communication channels.
-pub type Bundle<T, D> = crate::communication::Message<Message<T, D>>;
+pub type Bundle<T, C> = crate::communication::Message<Message<T, C>>;
 
 /// A serializable representation of timestamped data.
 #[derive(Clone, Abomonation, Serialize, Deserialize)]
-pub struct Message<T, D> {
+pub struct Message<T, C> {
     /// The timestamp associated with the message.
     pub time: T,
     /// The data in the message.
-    pub data: D,
+    pub data: C,
     /// The source worker.
     pub from: usize,
     /// A sequence number for this worker-to-worker stream.
     pub seq: usize,
 }
 
-impl<T, D> Message<T, D> {
+impl<T, C> Message<T, C> {
     /// Default buffer size.
     #[deprecated = "Use timely::buffer::default_capacity instead"]
     pub fn default_length() -> usize {
-        crate::container::buffer::default_capacity::<D>()
+        crate::container::buffer::default_capacity::<C>()
     }
 }
 
-impl<T, D: Container> Message<T, D> {
+impl<T, C: Container> Message<T, C> {
     /// Creates a new message instance from arguments.
-    pub fn new(time: T, data: D, from: usize, seq: usize) -> Self {
+    pub fn new(time: T, data: C, from: usize, seq: usize) -> Self {
         Message { time, data, from, seq }
     }
 
     /// Forms a message, and pushes contents at `pusher`. Replaces `buffer` with what the pusher
     /// leaves in place, or the container's default element.
     #[inline]
-    pub fn push_at<P: Push<Bundle<T, D>>>(buffer: &mut D, time: T, pusher: &mut P) {
+    pub fn push_at<P: Push<Bundle<T, C>>>(buffer: &mut C, time: T, pusher: &mut P) {
 
         let data = ::std::mem::take(buffer);
         let message = Message::new(time, data, 0, 0);

--- a/timely/src/dataflow/channels/pullers/counter.rs
+++ b/timely/src/dataflow/channels/pullers/counter.rs
@@ -9,10 +9,10 @@ use crate::communication::Pull;
 use crate::Container;
 
 /// A wrapper which accounts records pulled past in a shared count map.
-pub struct Counter<T: Ord+Clone+'static, D, P: Pull<Bundle<T, D>>> {
+pub struct Counter<T: Ord+Clone+'static, C, P: Pull<Bundle<T, C>>> {
     pullable: P,
     consumed: Rc<RefCell<ChangeBatch<T>>>,
-    phantom: ::std::marker::PhantomData<D>,
+    phantom: ::std::marker::PhantomData<C>,
 }
 
 /// A guard type that updates the change batch counts on drop
@@ -36,15 +36,15 @@ impl<T:Ord+Clone+'static> Drop for ConsumedGuard<T> {
     }
 }
 
-impl<T:Ord+Clone+'static, D: Container, P: Pull<Bundle<T, D>>> Counter<T, D, P> {
+impl<T:Ord+Clone+'static, C: Container, P: Pull<Bundle<T, C>>> Counter<T, C, P> {
     /// Retrieves the next timestamp and batch of data.
     #[inline]
-    pub fn next(&mut self) -> Option<&mut Bundle<T, D>> {
+    pub fn next(&mut self) -> Option<&mut Bundle<T, C>> {
         self.next_guarded().map(|(_guard, bundle)| bundle)
     }
 
     #[inline]
-    pub(crate) fn next_guarded(&mut self) -> Option<(ConsumedGuard<T>, &mut Bundle<T, D>)> {
+    pub(crate) fn next_guarded(&mut self) -> Option<(ConsumedGuard<T>, &mut Bundle<T, C>)> {
         if let Some(message) = self.pullable.pull() {
             let guard = ConsumedGuard {
                 consumed: Rc::clone(&self.consumed),
@@ -57,7 +57,7 @@ impl<T:Ord+Clone+'static, D: Container, P: Pull<Bundle<T, D>>> Counter<T, D, P> 
     }
 }
 
-impl<T:Ord+Clone+'static, D, P: Pull<Bundle<T, D>>> Counter<T, D, P> {
+impl<T:Ord+Clone+'static, C, P: Pull<Bundle<T, C>>> Counter<T, C, P> {
     /// Allocates a new `Counter` from a boxed puller.
     pub fn new(pullable: P) -> Self {
         Counter {

--- a/timely/src/dataflow/channels/pushers/buffer.rs
+++ b/timely/src/dataflow/channels/pushers/buffer.rs
@@ -13,11 +13,11 @@ use crate::{Container, Data};
 /// The `Buffer` type should be used by calling `session` with a time, which checks whether
 /// data must be flushed and creates a `Session` object which allows sending at the given time.
 #[derive(Debug)]
-pub struct Buffer<T, D: Container, P: Push<Bundle<T, D>>> {
+pub struct Buffer<T, C: Container, P: Push<Bundle<T, C>>> {
     /// the currently open time, if it is open
     time: Option<T>,
     /// a buffer for records, to send at self.time
-    buffer: D,
+    buffer: C,
     pusher: P,
 }
 

--- a/timely/src/dataflow/channels/pushers/counter.rs
+++ b/timely/src/dataflow/channels/pushers/counter.rs
@@ -11,15 +11,15 @@ use crate::Container;
 
 /// A wrapper which updates shared `produced` based on the number of records pushed.
 #[derive(Debug)]
-pub struct Counter<T, D, P: Push<Bundle<T, D>>> {
+pub struct Counter<T, C, P: Push<Bundle<T, C>>> {
     pushee: P,
     produced: Rc<RefCell<ChangeBatch<T>>>,
-    phantom: PhantomData<D>,
+    phantom: PhantomData<C>,
 }
 
-impl<T: Timestamp, D: Container, P> Push<Bundle<T, D>> for Counter<T, D, P> where P: Push<Bundle<T, D>> {
+impl<T: Timestamp, C: Container, P> Push<Bundle<T, C>> for Counter<T, C, P> where P: Push<Bundle<T, C>> {
     #[inline]
-    fn push(&mut self, message: &mut Option<Bundle<T, D>>) {
+    fn push(&mut self, message: &mut Option<Bundle<T, C>>) {
         if let Some(message) = message {
             self.produced.borrow_mut().update(message.time.clone(), message.data.len() as i64);
         }
@@ -31,9 +31,9 @@ impl<T: Timestamp, D: Container, P> Push<Bundle<T, D>> for Counter<T, D, P> wher
     }
 }
 
-impl<T, D, P: Push<Bundle<T, D>>> Counter<T, D, P> where T : Ord+Clone+'static {
+impl<T, C, P: Push<Bundle<T, C>>> Counter<T, C, P> where T : Ord+Clone+'static {
     /// Allocates a new `Counter` from a pushee and shared counts.
-    pub fn new(pushee: P) -> Counter<T, D, P> {
+    pub fn new(pushee: P) -> Counter<T, C, P> {
         Counter {
             pushee,
             produced: Rc::new(RefCell::new(ChangeBatch::new())),

--- a/timely/src/dataflow/operators/capture/capture.rs
+++ b/timely/src/dataflow/operators/capture/capture.rs
@@ -17,7 +17,7 @@ use crate::progress::Timestamp;
 use super::{EventCore, EventPusherCore};
 
 /// Capture a stream of timestamped data for later replay.
-pub trait Capture<T: Timestamp, D: Container> {
+pub trait Capture<T: Timestamp, C: Container> {
     /// Captures a stream of timestamped data for later replay.
     ///
     /// # Examples
@@ -103,18 +103,18 @@ pub trait Capture<T: Timestamp, D: Container> {
     ///
     /// assert_eq!(recv0.extract()[0].1, (0..10).collect::<Vec<_>>());
     /// ```
-    fn capture_into<P: EventPusherCore<T, D>+'static>(&self, pusher: P);
+    fn capture_into<P: EventPusherCore<T, C>+'static>(&self, pusher: P);
 
     /// Captures a stream using Rust's MPSC channels.
-    fn capture(&self) -> ::std::sync::mpsc::Receiver<EventCore<T, D>> {
+    fn capture(&self) -> ::std::sync::mpsc::Receiver<EventCore<T, C>> {
         let (send, recv) = ::std::sync::mpsc::channel();
         self.capture_into(send);
         recv
     }
 }
 
-impl<S: Scope, D: Container> Capture<S::Timestamp, D> for StreamCore<S, D> {
-    fn capture_into<P: EventPusherCore<S::Timestamp, D>+'static>(&self, mut event_pusher: P) {
+impl<S: Scope, C: Container> Capture<S::Timestamp, C> for StreamCore<S, C> {
+    fn capture_into<P: EventPusherCore<S::Timestamp, C>+'static>(&self, mut event_pusher: P) {
 
         let mut builder = OperatorBuilder::new("Capture".to_owned(), self.scope());
         let mut input = PullCounter::new(builder.new_input(self, Pipeline));

--- a/timely/src/dataflow/operators/concat.rs
+++ b/timely/src/dataflow/operators/concat.rs
@@ -6,7 +6,7 @@ use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::{StreamCore, Scope};
 
 /// Merge the contents of two streams.
-pub trait Concat<G: Scope, D: Container> {
+pub trait Concat<G: Scope, C: Container> {
     /// Merge the contents of two streams.
     ///
     /// # Examples
@@ -20,17 +20,17 @@ pub trait Concat<G: Scope, D: Container> {
     ///           .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn concat(&self, _: &StreamCore<G, D>) -> StreamCore<G, D>;
+    fn concat(&self, _: &StreamCore<G, C>) -> StreamCore<G, C>;
 }
 
-impl<G: Scope, D: Container> Concat<G, D> for StreamCore<G, D> {
-    fn concat(&self, other: &StreamCore<G, D>) -> StreamCore<G, D> {
+impl<G: Scope, C: Container> Concat<G, C> for StreamCore<G, C> {
+    fn concat(&self, other: &StreamCore<G, C>) -> StreamCore<G, C> {
         self.scope().concatenate([self.clone(), other.clone()])
     }
 }
 
 /// Merge the contents of multiple streams.
-pub trait Concatenate<G: Scope, D: Container> {
+pub trait Concatenate<G: Scope, C: Container> {
     /// Merge the contents of multiple streams.
     ///
     /// # Examples
@@ -47,25 +47,25 @@ pub trait Concatenate<G: Scope, D: Container> {
     ///          .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn concatenate<I>(&self, sources: I) -> StreamCore<G, D>
+    fn concatenate<I>(&self, sources: I) -> StreamCore<G, C>
     where
-        I: IntoIterator<Item=StreamCore<G, D>>;
+        I: IntoIterator<Item=StreamCore<G, C>>;
 }
 
-impl<G: Scope, D: Container> Concatenate<G, D> for StreamCore<G, D> {
-    fn concatenate<I>(&self, sources: I) -> StreamCore<G, D>
+impl<G: Scope, C: Container> Concatenate<G, C> for StreamCore<G, C> {
+    fn concatenate<I>(&self, sources: I) -> StreamCore<G, C>
     where
-        I: IntoIterator<Item=StreamCore<G, D>>
+        I: IntoIterator<Item=StreamCore<G, C>>
     {
         let clone = self.clone();
         self.scope().concatenate(Some(clone).into_iter().chain(sources))
     }
 }
 
-impl<G: Scope, D: Container> Concatenate<G, D> for G {
-    fn concatenate<I>(&self, sources: I) -> StreamCore<G, D>
+impl<G: Scope, C: Container> Concatenate<G, C> for G {
+    fn concatenate<I>(&self, sources: I) -> StreamCore<G, C>
     where
-        I: IntoIterator<Item=StreamCore<G, D>>
+        I: IntoIterator<Item=StreamCore<G, C>>
     {
 
         // create an operator builder.

--- a/timely/src/dataflow/operators/feedback.rs
+++ b/timely/src/dataflow/operators/feedback.rs
@@ -59,7 +59,7 @@ pub trait Feedback<G: Scope> {
     ///            .connect_loop(handle);
     /// });
     /// ```
-    fn feedback_core<D: Container>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (HandleCore<G, D>, StreamCore<G, D>);
+    fn feedback_core<C: Container>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (HandleCore<G, C>, StreamCore<G, C>);
 }
 
 /// Creates a `Stream` and a `Handle` to later bind the source of that `Stream`.
@@ -87,7 +87,7 @@ pub trait LoopVariable<'a, G: Scope, T: Timestamp> {
     ///     });
     /// });
     /// ```
-    fn loop_variable<D: Container>(&mut self, summary: T::Summary) -> (HandleCore<Iterative<'a, G, T>, D>, StreamCore<Iterative<'a, G, T>, D>);
+    fn loop_variable<C: Container>(&mut self, summary: T::Summary) -> (HandleCore<Iterative<'a, G, T>, C>, StreamCore<Iterative<'a, G, T>, C>);
 }
 
 impl<G: Scope> Feedback<G> for G {
@@ -95,7 +95,7 @@ impl<G: Scope> Feedback<G> for G {
         self.feedback_core(summary)
     }
 
-    fn feedback_core<D: Container>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (HandleCore<G, D>, StreamCore<G, D>) {
+    fn feedback_core<C: Container>(&mut self, summary: <G::Timestamp as Timestamp>::Summary) -> (HandleCore<G, C>, StreamCore<G, C>) {
 
         let mut builder = OperatorBuilder::new("Feedback".to_owned(), self.clone());
         let (output, stream) = builder.new_output();
@@ -105,13 +105,13 @@ impl<G: Scope> Feedback<G> for G {
 }
 
 impl<'a, G: Scope, T: Timestamp> LoopVariable<'a, G, T> for Iterative<'a, G, T> {
-    fn loop_variable<D: Container>(&mut self, summary: T::Summary) -> (HandleCore<Iterative<'a, G, T>, D>, StreamCore<Iterative<'a, G, T>, D>) {
+    fn loop_variable<C: Container>(&mut self, summary: T::Summary) -> (HandleCore<Iterative<'a, G, T>, C>, StreamCore<Iterative<'a, G, T>, C>) {
         self.feedback_core(Product::new(Default::default(), summary))
     }
 }
 
 /// Connect a `Stream` to the input of a loop variable.
-pub trait ConnectLoop<G: Scope, D: Container> {
+pub trait ConnectLoop<G: Scope, C: Container> {
     /// Connect a `Stream` to be the input of a loop variable.
     ///
     /// # Examples
@@ -129,11 +129,11 @@ pub trait ConnectLoop<G: Scope, D: Container> {
     ///            .connect_loop(handle);
     /// });
     /// ```
-    fn connect_loop(&self, _: HandleCore<G, D>);
+    fn connect_loop(&self, _: HandleCore<G, C>);
 }
 
-impl<G: Scope, D: Container> ConnectLoop<G, D> for StreamCore<G, D> {
-    fn connect_loop(&self, helper: HandleCore<G, D>) {
+impl<G: Scope, C: Container> ConnectLoop<G, C> for StreamCore<G, C> {
+    fn connect_loop(&self, helper: HandleCore<G, C>) {
 
         let mut builder = helper.builder;
         let summary = helper.summary;
@@ -159,10 +159,10 @@ impl<G: Scope, D: Container> ConnectLoop<G, D> for StreamCore<G, D> {
 
 /// A handle used to bind the source of a loop variable.
 #[derive(Debug)]
-pub struct HandleCore<G: Scope, D: Container> {
+pub struct HandleCore<G: Scope, C: Container> {
     builder: OperatorBuilder<G>,
     summary: <G::Timestamp as Timestamp>::Summary,
-    output: OutputWrapper<G::Timestamp, D, Tee<G::Timestamp, D>>,
+    output: OutputWrapper<G::Timestamp, C, Tee<G::Timestamp, C>>,
 }
 
 /// A `HandleCore` specialized for using `Vec` as container

--- a/timely/src/dataflow/operators/generic/builder_raw.rs
+++ b/timely/src/dataflow/operators/generic/builder_raw.rs
@@ -105,17 +105,17 @@ impl<G: Scope> OperatorBuilder<G> {
     }
 
     /// Adds a new input to a generic operator builder, returning the `Pull` implementor to use.
-    pub fn new_input<D: Container, P>(&mut self, stream: &StreamCore<G, D>, pact: P) -> P::Puller
+    pub fn new_input<C: Container, P>(&mut self, stream: &StreamCore<G, C>, pact: P) -> P::Puller
         where
-            P: ParallelizationContract<G::Timestamp, D> {
+            P: ParallelizationContract<G::Timestamp, C> {
         let connection = vec![Antichain::from_elem(Default::default()); self.shape.outputs];
         self.new_input_connection(stream, pact, connection)
     }
 
     /// Adds a new input to a generic operator builder, returning the `Pull` implementor to use.
-    pub fn new_input_connection<D: Container, P>(&mut self, stream: &StreamCore<G, D>, pact: P, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> P::Puller
+    pub fn new_input_connection<C: Container, P>(&mut self, stream: &StreamCore<G, C>, pact: P, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> P::Puller
     where
-        P: ParallelizationContract<G::Timestamp, D> {
+        P: ParallelizationContract<G::Timestamp, C> {
 
         let channel_id = self.scope.new_identifier();
         let logging = self.scope.logging();
@@ -131,16 +131,16 @@ impl<G: Scope> OperatorBuilder<G> {
     }
 
     /// Adds a new output to a generic operator builder, returning the `Push` implementor to use.
-    pub fn new_output<D: Container>(&mut self) -> (Tee<G::Timestamp, D>, StreamCore<G, D>) {
+    pub fn new_output<C: Container>(&mut self) -> (Tee<G::Timestamp, C>, StreamCore<G, C>) {
 
         let connection = vec![Antichain::from_elem(Default::default()); self.shape.inputs];
         self.new_output_connection(connection)
     }
 
     /// Adds a new output to a generic operator builder, returning the `Push` implementor to use.
-    pub fn new_output_connection<D: Container>(&mut self, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> (Tee<G::Timestamp, D>, StreamCore<G, D>) {
+    pub fn new_output_connection<C: Container>(&mut self, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> (Tee<G::Timestamp, C>, StreamCore<G, C>) {
 
-        let (targets, registrar) = Tee::<G::Timestamp,D>::new();
+        let (targets, registrar) = Tee::<G::Timestamp,C>::new();
         let source = Source::new(self.index, self.shape.outputs);
         let stream = StreamCore::new(source, registrar, self.scope.clone());
 

--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -59,9 +59,9 @@ impl<G: Scope> OperatorBuilder<G> {
     }
 
     /// Adds a new input to a generic operator builder, returning the `Pull` implementor to use.
-    pub fn new_input<D: Container, P>(&mut self, stream: &StreamCore<G, D>, pact: P) -> InputHandleCore<G::Timestamp, D, P::Puller>
+    pub fn new_input<C: Container, P>(&mut self, stream: &StreamCore<G, C>, pact: P) -> InputHandleCore<G::Timestamp, C, P::Puller>
     where
-        P: ParallelizationContract<G::Timestamp, D> {
+        P: ParallelizationContract<G::Timestamp, C> {
 
         let connection = vec![Antichain::from_elem(Default::default()); self.builder.shape().outputs()];
         self.new_input_connection(stream, pact, connection)
@@ -75,9 +75,9 @@ impl<G: Scope> OperatorBuilder<G> {
     ///
     /// Commonly the connections are either the unit summary, indicating the same timestamp might be produced as output, or an empty
     /// antichain indicating that there is no connection from the input to the output.
-    pub fn new_input_connection<D: Container, P>(&mut self, stream: &StreamCore<G, D>, pact: P, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> InputHandleCore<G::Timestamp, D, P::Puller>
+    pub fn new_input_connection<C: Container, P>(&mut self, stream: &StreamCore<G, C>, pact: P, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> InputHandleCore<G::Timestamp, C, P::Puller>
         where
-            P: ParallelizationContract<G::Timestamp, D> {
+            P: ParallelizationContract<G::Timestamp, C> {
 
         let puller = self.builder.new_input_connection(stream, pact, connection.clone());
 
@@ -92,7 +92,7 @@ impl<G: Scope> OperatorBuilder<G> {
     }
 
     /// Adds a new output to a generic operator builder, returning the `Push` implementor to use.
-    pub fn new_output<D: Container>(&mut self) -> (OutputWrapper<G::Timestamp, D, Tee<G::Timestamp, D>>, StreamCore<G, D>) {
+    pub fn new_output<C: Container>(&mut self) -> (OutputWrapper<G::Timestamp, C, Tee<G::Timestamp, C>>, StreamCore<G, C>) {
         let connection = vec![Antichain::from_elem(Default::default()); self.builder.shape().inputs()];
         self.new_output_connection(connection)
     }
@@ -105,7 +105,7 @@ impl<G: Scope> OperatorBuilder<G> {
     ///
     /// Commonly the connections are either the unit summary, indicating the same timestamp might be produced as output, or an empty
     /// antichain indicating that there is no connection from the input to the output.
-    pub fn new_output_connection<D: Container>(&mut self, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> (OutputWrapper<G::Timestamp, D, Tee<G::Timestamp, D>>, StreamCore<G, D>) {
+    pub fn new_output_connection<C: Container>(&mut self, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> (OutputWrapper<G::Timestamp, C, Tee<G::Timestamp, C>>, StreamCore<G, C>) {
 
         let (tee, stream) = self.builder.new_output_connection(connection.clone());
 

--- a/timely/src/dataflow/operators/generic/operator.rs
+++ b/timely/src/dataflow/operators/generic/operator.rs
@@ -15,7 +15,7 @@ use crate::dataflow::operators::generic::notificator::{Notificator, FrontierNoti
 use crate::Container;
 
 /// Methods to construct generic streaming and blocking operators.
-pub trait Operator<G: Scope, D1: Container> {
+pub trait Operator<G: Scope, C1: Container> {
     /// Creates a new dataflow operator that partitions its input stream by a parallelization
     /// strategy `pact`, and repeatedly invokes `logic`, the function returned by the function passed as `constructor`.
     /// `logic` can read from the input stream, write to the output stream, and inspect the frontier at the input.
@@ -55,13 +55,13 @@ pub trait Operator<G: Scope, D1: Container> {
     ///     });
     /// }
     /// ```
-    fn unary_frontier<D2, B, L, P>(&self, pact: P, name: &str, constructor: B) -> StreamCore<G, D2>
+    fn unary_frontier<C2, B, L, P>(&self, pact: P, name: &str, constructor: B) -> StreamCore<G, C2>
     where
-        D2: Container,
+        C2: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
-        L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, D1, P::Puller>,
-                 &mut OutputHandleCore<G::Timestamp, D2, Tee<G::Timestamp, D2>>)+'static,
-        P: ParallelizationContract<G::Timestamp, D1>;
+        L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, C1, P::Puller>,
+                 &mut OutputHandleCore<G::Timestamp, C2, Tee<G::Timestamp, C2>>)+'static,
+        P: ParallelizationContract<G::Timestamp, C1>;
 
     /// Creates a new dataflow operator that partitions its input stream by a parallelization
     /// strategy `pact`, and repeatedly invokes `logic`, the function returned by the function passed as `constructor`.
@@ -92,12 +92,12 @@ pub trait Operator<G: Scope, D1: Container> {
     ///     });
     /// }
     /// ```
-    fn unary_notify<D2: Container,
-            L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P::Puller>,
-                     &mut OutputHandleCore<G::Timestamp, D2, Tee<G::Timestamp, D2>>,
+    fn unary_notify<C2: Container,
+            L: FnMut(&mut InputHandleCore<G::Timestamp, C1, P::Puller>,
+                     &mut OutputHandleCore<G::Timestamp, C2, Tee<G::Timestamp, C2>>,
                      &mut Notificator<G::Timestamp>)+'static,
-             P: ParallelizationContract<G::Timestamp, D1>>
-             (&self, pact: P, name: &str, init: impl IntoIterator<Item=G::Timestamp>, logic: L) -> StreamCore<G, D2>;
+             P: ParallelizationContract<G::Timestamp, C1>>
+             (&self, pact: P, name: &str, init: impl IntoIterator<Item=G::Timestamp>, logic: L) -> StreamCore<G, C2>;
 
     /// Creates a new dataflow operator that partitions its input stream by a parallelization
     /// strategy `pact`, and repeatedly invokes `logic`, the function returned by the function passed as `constructor`.
@@ -127,13 +127,13 @@ pub trait Operator<G: Scope, D1: Container> {
     ///         });
     /// });
     /// ```
-    fn unary<D2, B, L, P>(&self, pact: P, name: &str, constructor: B) -> StreamCore<G, D2>
+    fn unary<C2, B, L, P>(&self, pact: P, name: &str, constructor: B) -> StreamCore<G, C2>
     where
-        D2: Container,
+        C2: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
-        L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P::Puller>,
-                 &mut OutputHandleCore<G::Timestamp, D2, Tee<G::Timestamp, D2>>)+'static,
-        P: ParallelizationContract<G::Timestamp, D1>;
+        L: FnMut(&mut InputHandleCore<G::Timestamp, C1, P::Puller>,
+                 &mut OutputHandleCore<G::Timestamp, C2, Tee<G::Timestamp, C2>>)+'static,
+        P: ParallelizationContract<G::Timestamp, C1>;
 
     /// Creates a new dataflow operator that partitions its input streams by a parallelization
     /// strategy `pact`, and repeatedly invokes `logic`, the function returned by the function passed as `constructor`.
@@ -185,16 +185,16 @@ pub trait Operator<G: Scope, D1: Container> {
     ///    }
     /// }).unwrap();
     /// ```
-    fn binary_frontier<D2, D3, B, L, P1, P2>(&self, other: &StreamCore<G, D2>, pact1: P1, pact2: P2, name: &str, constructor: B) -> StreamCore<G, D3>
+    fn binary_frontier<C2, C3, B, L, P1, P2>(&self, other: &StreamCore<G, C2>, pact1: P1, pact2: P2, name: &str, constructor: B) -> StreamCore<G, C3>
     where
-        D2: Container,
-        D3: Container,
+        C2: Container,
+        C3: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
-        L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, D1, P1::Puller>,
-                 &mut FrontieredInputHandleCore<G::Timestamp, D2, P2::Puller>,
-                 &mut OutputHandleCore<G::Timestamp, D3, Tee<G::Timestamp, D3>>)+'static,
-        P1: ParallelizationContract<G::Timestamp, D1>,
-        P2: ParallelizationContract<G::Timestamp, D2>;
+        L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, C1, P1::Puller>,
+                 &mut FrontieredInputHandleCore<G::Timestamp, C2, P2::Puller>,
+                 &mut OutputHandleCore<G::Timestamp, C3, Tee<G::Timestamp, C3>>)+'static,
+        P1: ParallelizationContract<G::Timestamp, C1>,
+        P2: ParallelizationContract<G::Timestamp, C2>;
 
     /// Creates a new dataflow operator that partitions its input streams by a parallelization
     /// strategy `pact`, and repeatedly invokes `logic`, the function returned by the function passed as `constructor`.
@@ -241,15 +241,15 @@ pub trait Operator<G: Scope, D1: Container> {
     ///    }
     /// }).unwrap();
     /// ```
-    fn binary_notify<D2: Container,
-              D3: Container,
-              L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P1::Puller>,
-                       &mut InputHandleCore<G::Timestamp, D2, P2::Puller>,
-                       &mut OutputHandleCore<G::Timestamp, D3, Tee<G::Timestamp, D3>>,
+    fn binary_notify<C2: Container,
+              C3: Container,
+              L: FnMut(&mut InputHandleCore<G::Timestamp, C1, P1::Puller>,
+                       &mut InputHandleCore<G::Timestamp, C2, P2::Puller>,
+                       &mut OutputHandleCore<G::Timestamp, C3, Tee<G::Timestamp, C3>>,
                        &mut Notificator<G::Timestamp>)+'static,
-              P1: ParallelizationContract<G::Timestamp, D1>,
-              P2: ParallelizationContract<G::Timestamp, D2>>
-            (&self, other: &StreamCore<G, D2>, pact1: P1, pact2: P2, name: &str, init: impl IntoIterator<Item=G::Timestamp>, logic: L) -> StreamCore<G, D3>;
+              P1: ParallelizationContract<G::Timestamp, C1>,
+              P2: ParallelizationContract<G::Timestamp, C2>>
+            (&self, other: &StreamCore<G, C2>, pact1: P1, pact2: P2, name: &str, init: impl IntoIterator<Item=G::Timestamp>, logic: L) -> StreamCore<G, C3>;
 
     /// Creates a new dataflow operator that partitions its input streams by a parallelization
     /// strategy `pact`, and repeatedly invokes `logic`, the function returned by the function passed as `constructor`.
@@ -285,16 +285,16 @@ pub trait Operator<G: Scope, D1: Container> {
     ///         }).inspect(|x| println!("{:?}", x));
     /// });
     /// ```
-    fn binary<D2, D3, B, L, P1, P2>(&self, other: &StreamCore<G, D2>, pact1: P1, pact2: P2, name: &str, constructor: B) -> StreamCore<G, D3>
+    fn binary<C2, C3, B, L, P1, P2>(&self, other: &StreamCore<G, C2>, pact1: P1, pact2: P2, name: &str, constructor: B) -> StreamCore<G, C3>
     where
-        D2: Container,
-        D3: Container,
+        C2: Container,
+        C3: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
-        L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P1::Puller>,
-                 &mut InputHandleCore<G::Timestamp, D2, P2::Puller>,
-                 &mut OutputHandleCore<G::Timestamp, D3, Tee<G::Timestamp, D3>>)+'static,
-        P1: ParallelizationContract<G::Timestamp, D1>,
-        P2: ParallelizationContract<G::Timestamp, D2>;
+        L: FnMut(&mut InputHandleCore<G::Timestamp, C1, P1::Puller>,
+                 &mut InputHandleCore<G::Timestamp, C2, P2::Puller>,
+                 &mut OutputHandleCore<G::Timestamp, C3, Tee<G::Timestamp, C3>>)+'static,
+        P1: ParallelizationContract<G::Timestamp, C1>,
+        P2: ParallelizationContract<G::Timestamp, C2>;
 
     /// Creates a new dataflow operator that partitions its input stream by a parallelization
     /// strategy `pact`, and repeatedly invokes the function `logic` which can read from the input stream
@@ -321,19 +321,19 @@ pub trait Operator<G: Scope, D1: Container> {
     /// ```
     fn sink<L, P>(&self, pact: P, name: &str, logic: L)
     where
-        L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, D1, P::Puller>)+'static,
-        P: ParallelizationContract<G::Timestamp, D1>;
+        L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, C1, P::Puller>)+'static,
+        P: ParallelizationContract<G::Timestamp, C1>;
 }
 
-impl<G: Scope, D1: Container> Operator<G, D1> for StreamCore<G, D1> {
+impl<G: Scope, C1: Container> Operator<G, C1> for StreamCore<G, C1> {
 
-    fn unary_frontier<D2, B, L, P>(&self, pact: P, name: &str, constructor: B) -> StreamCore<G, D2>
+    fn unary_frontier<C2, B, L, P>(&self, pact: P, name: &str, constructor: B) -> StreamCore<G, C2>
     where
-        D2: Container,
+        C2: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
-        L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, D1, P::Puller>,
-                 &mut OutputHandleCore<G::Timestamp, D2, Tee<G::Timestamp, D2>>)+'static,
-        P: ParallelizationContract<G::Timestamp, D1> {
+        L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, C1, P::Puller>,
+                 &mut OutputHandleCore<G::Timestamp, C2, Tee<G::Timestamp, C2>>)+'static,
+        P: ParallelizationContract<G::Timestamp, C1> {
 
         let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
         let operator_info = builder.operator_info();
@@ -355,12 +355,12 @@ impl<G: Scope, D1: Container> Operator<G, D1> for StreamCore<G, D1> {
         stream
     }
 
-    fn unary_notify<D2: Container,
-            L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P::Puller>,
-                     &mut OutputHandleCore<G::Timestamp, D2, Tee<G::Timestamp, D2>>,
+    fn unary_notify<C2: Container,
+            L: FnMut(&mut InputHandleCore<G::Timestamp, C1, P::Puller>,
+                     &mut OutputHandleCore<G::Timestamp, C2, Tee<G::Timestamp, C2>>,
                      &mut Notificator<G::Timestamp>)+'static,
-             P: ParallelizationContract<G::Timestamp, D1>>
-             (&self, pact: P, name: &str, init: impl IntoIterator<Item=G::Timestamp>, mut logic: L) -> StreamCore<G, D2> {
+             P: ParallelizationContract<G::Timestamp, C1>>
+             (&self, pact: P, name: &str, init: impl IntoIterator<Item=G::Timestamp>, mut logic: L) -> StreamCore<G, C2> {
 
         self.unary_frontier(pact, name, move |capability, _info| {
             let mut notificator = FrontierNotificator::new();
@@ -377,13 +377,13 @@ impl<G: Scope, D1: Container> Operator<G, D1> for StreamCore<G, D1> {
         })
     }
 
-    fn unary<D2, B, L, P>(&self, pact: P, name: &str, constructor: B) -> StreamCore<G, D2>
+    fn unary<C2, B, L, P>(&self, pact: P, name: &str, constructor: B) -> StreamCore<G, C2>
     where
-        D2: Container,
+        C2: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
-        L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P::Puller>,
-                 &mut OutputHandleCore<G::Timestamp, D2, Tee<G::Timestamp, D2>>)+'static,
-        P: ParallelizationContract<G::Timestamp, D1> {
+        L: FnMut(&mut InputHandleCore<G::Timestamp, C1, P::Puller>,
+                 &mut OutputHandleCore<G::Timestamp, C2, Tee<G::Timestamp, C2>>)+'static,
+        P: ParallelizationContract<G::Timestamp, C1> {
 
         let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
         let operator_info = builder.operator_info();
@@ -405,16 +405,16 @@ impl<G: Scope, D1: Container> Operator<G, D1> for StreamCore<G, D1> {
         stream
     }
 
-    fn binary_frontier<D2, D3, B, L, P1, P2>(&self, other: &StreamCore<G, D2>, pact1: P1, pact2: P2, name: &str, constructor: B) -> StreamCore<G, D3>
+    fn binary_frontier<C2, C3, B, L, P1, P2>(&self, other: &StreamCore<G, C2>, pact1: P1, pact2: P2, name: &str, constructor: B) -> StreamCore<G, C3>
     where
-        D2: Container,
-        D3: Container,
+        C2: Container,
+        C3: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
-        L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, D1, P1::Puller>,
-                 &mut FrontieredInputHandleCore<G::Timestamp, D2, P2::Puller>,
-                 &mut OutputHandleCore<G::Timestamp, D3, Tee<G::Timestamp, D3>>)+'static,
-        P1: ParallelizationContract<G::Timestamp, D1>,
-        P2: ParallelizationContract<G::Timestamp, D2> {
+        L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, C1, P1::Puller>,
+                 &mut FrontieredInputHandleCore<G::Timestamp, C2, P2::Puller>,
+                 &mut OutputHandleCore<G::Timestamp, C3, Tee<G::Timestamp, C3>>)+'static,
+        P1: ParallelizationContract<G::Timestamp, C1>,
+        P2: ParallelizationContract<G::Timestamp, C2> {
 
         let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
         let operator_info = builder.operator_info();
@@ -438,15 +438,15 @@ impl<G: Scope, D1: Container> Operator<G, D1> for StreamCore<G, D1> {
         stream
     }
 
-    fn binary_notify<D2: Container,
-              D3: Container,
-              L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P1::Puller>,
-                       &mut InputHandleCore<G::Timestamp, D2, P2::Puller>,
-                       &mut OutputHandleCore<G::Timestamp, D3, Tee<G::Timestamp, D3>>,
+    fn binary_notify<C2: Container,
+              C3: Container,
+              L: FnMut(&mut InputHandleCore<G::Timestamp, C1, P1::Puller>,
+                       &mut InputHandleCore<G::Timestamp, C2, P2::Puller>,
+                       &mut OutputHandleCore<G::Timestamp, C3, Tee<G::Timestamp, C3>>,
                        &mut Notificator<G::Timestamp>)+'static,
-              P1: ParallelizationContract<G::Timestamp, D1>,
-              P2: ParallelizationContract<G::Timestamp, D2>>
-            (&self, other: &StreamCore<G, D2>, pact1: P1, pact2: P2, name: &str, init: impl IntoIterator<Item=G::Timestamp>, mut logic: L) -> StreamCore<G, D3> {
+              P1: ParallelizationContract<G::Timestamp, C1>,
+              P2: ParallelizationContract<G::Timestamp, C2>>
+            (&self, other: &StreamCore<G, C2>, pact1: P1, pact2: P2, name: &str, init: impl IntoIterator<Item=G::Timestamp>, mut logic: L) -> StreamCore<G, C3> {
 
         self.binary_frontier(other, pact1, pact2, name, |capability, _info| {
             let mut notificator = FrontierNotificator::new();
@@ -465,16 +465,16 @@ impl<G: Scope, D1: Container> Operator<G, D1> for StreamCore<G, D1> {
     }
 
 
-    fn binary<D2, D3, B, L, P1, P2>(&self, other: &StreamCore<G, D2>, pact1: P1, pact2: P2, name: &str, constructor: B) -> StreamCore<G, D3>
+    fn binary<C2, C3, B, L, P1, P2>(&self, other: &StreamCore<G, C2>, pact1: P1, pact2: P2, name: &str, constructor: B) -> StreamCore<G, C3>
     where
-        D2: Container,
-        D3: Container,
+        C2: Container,
+        C3: Container,
         B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
-        L: FnMut(&mut InputHandleCore<G::Timestamp, D1, P1::Puller>,
-                 &mut InputHandleCore<G::Timestamp, D2, P2::Puller>,
-                 &mut OutputHandleCore<G::Timestamp, D3, Tee<G::Timestamp, D3>>)+'static,
-        P1: ParallelizationContract<G::Timestamp, D1>,
-        P2: ParallelizationContract<G::Timestamp, D2> {
+        L: FnMut(&mut InputHandleCore<G::Timestamp, C1, P1::Puller>,
+                 &mut InputHandleCore<G::Timestamp, C2, P2::Puller>,
+                 &mut OutputHandleCore<G::Timestamp, C3, Tee<G::Timestamp, C3>>)+'static,
+        P1: ParallelizationContract<G::Timestamp, C1>,
+        P2: ParallelizationContract<G::Timestamp, C2> {
 
         let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
         let operator_info = builder.operator_info();
@@ -499,8 +499,8 @@ impl<G: Scope, D1: Container> Operator<G, D1> for StreamCore<G, D1> {
 
     fn sink<L, P>(&self, pact: P, name: &str, mut logic: L)
     where
-        L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, D1, P::Puller>)+'static,
-        P: ParallelizationContract<G::Timestamp, D1> {
+        L: FnMut(&mut FrontieredInputHandleCore<G::Timestamp, C1, P::Puller>)+'static,
+        P: ParallelizationContract<G::Timestamp, C1> {
 
         let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
         let mut input = builder.new_input(self, pact);
@@ -555,11 +555,11 @@ impl<G: Scope, D1: Container> Operator<G, D1> for StreamCore<G, D1> {
 ///     .inspect(|x| println!("number: {:?}", x));
 /// });
 /// ```
-pub fn source<G: Scope, D, B, L>(scope: &G, name: &str, constructor: B) -> StreamCore<G, D>
+pub fn source<G: Scope, C, B, L>(scope: &G, name: &str, constructor: B) -> StreamCore<G, C>
 where
-    D: Container,
+    C: Container,
     B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
-    L: FnMut(&mut OutputHandleCore<G::Timestamp, D, Tee<G::Timestamp, D>>)+'static {
+    L: FnMut(&mut OutputHandleCore<G::Timestamp, C, Tee<G::Timestamp, C>>)+'static {
 
     let mut builder = OperatorBuilder::new(name.to_owned(), scope.clone());
     let operator_info = builder.operator_info();
@@ -599,7 +599,7 @@ where
 ///
 /// });
 /// ```
-pub fn empty<G: Scope, D: Container>(scope: &G) -> StreamCore<G, D> {
+pub fn empty<G: Scope, C: Container>(scope: &G) -> StreamCore<G, C> {
     source(scope, "Empty", |_capability, _info| |_output| {
         // drop capability, do nothing
     })

--- a/timely/src/dataflow/operators/probe.rs
+++ b/timely/src/dataflow/operators/probe.rs
@@ -16,7 +16,7 @@ use crate::dataflow::{StreamCore, Scope};
 use crate::Container;
 
 /// Monitors progress at a `Stream`.
-pub trait Probe<G: Scope, D: Container> {
+pub trait Probe<G: Scope, C: Container> {
     /// Constructs a progress probe which indicates which timestamps have elapsed at the operator.
     ///
     /// # Examples
@@ -76,10 +76,10 @@ pub trait Probe<G: Scope, D: Container> {
     ///     }
     /// }).unwrap();
     /// ```
-    fn probe_with(&self, handle: &Handle<G::Timestamp>) -> StreamCore<G, D>;
+    fn probe_with(&self, handle: &Handle<G::Timestamp>) -> StreamCore<G, C>;
 }
 
-impl<G: Scope, D: Container> Probe<G, D> for StreamCore<G, D> {
+impl<G: Scope, C: Container> Probe<G, C> for StreamCore<G, C> {
     fn probe(&self) -> Handle<G::Timestamp> {
 
         // the frontier is shared state; scope updates, handle reads.
@@ -87,7 +87,7 @@ impl<G: Scope, D: Container> Probe<G, D> for StreamCore<G, D> {
         self.probe_with(&mut handle);
         handle
     }
-    fn probe_with(&self, handle: &Handle<G::Timestamp>) -> StreamCore<G, D> {
+    fn probe_with(&self, handle: &Handle<G::Timestamp>) -> StreamCore<G, C> {
 
         let mut builder = OperatorBuilder::new("Probe".to_owned(), self.scope());
         let mut input = PullCounter::new(builder.new_input(self, Pipeline));

--- a/timely/src/dataflow/operators/unordered_input.rs
+++ b/timely/src/dataflow/operators/unordered_input.rs
@@ -142,14 +142,14 @@ pub trait UnorderedInputCore<G: Scope> {
     ///     assert_eq!(extract[i], (i, vec![i]));
     /// }
     /// ```
-    fn new_unordered_input_core<D: Container>(&mut self) -> ((UnorderedHandleCore<G::Timestamp, D>, ActivateCapability<G::Timestamp>), StreamCore<G, D>);
+    fn new_unordered_input_core<C: Container>(&mut self) -> ((UnorderedHandleCore<G::Timestamp, C>, ActivateCapability<G::Timestamp>), StreamCore<G, C>);
 }
 
 
 impl<G: Scope> UnorderedInputCore<G> for G {
-    fn new_unordered_input_core<D: Container>(&mut self) -> ((UnorderedHandleCore<G::Timestamp, D>, ActivateCapability<G::Timestamp>), StreamCore<G, D>) {
+    fn new_unordered_input_core<C: Container>(&mut self) -> ((UnorderedHandleCore<G::Timestamp, C>, ActivateCapability<G::Timestamp>), StreamCore<G, C>) {
 
-        let (output, registrar) = Tee::<G::Timestamp, D>::new();
+        let (output, registrar) = Tee::<G::Timestamp, C>::new();
         let internal = Rc::new(RefCell::new(ChangeBatch::new()));
         // let produced = Rc::new(RefCell::new(ChangeBatch::new()));
         let cap = Capability::new(G::Timestamp::minimum(), internal.clone());
@@ -215,19 +215,19 @@ impl<T:Timestamp> Operate<T> for UnorderedOperator<T> {
 
 /// A handle to an input [StreamCore], used to introduce data to a timely dataflow computation.
 #[derive(Debug)]
-pub struct UnorderedHandleCore<T: Timestamp, D: Container> {
-    buffer: PushBuffer<T, D, PushCounter<T, D, Tee<T, D>>>,
+pub struct UnorderedHandleCore<T: Timestamp, C: Container> {
+    buffer: PushBuffer<T, C, PushCounter<T, C, Tee<T, C>>>,
 }
 
-impl<T: Timestamp, D: Container> UnorderedHandleCore<T, D> {
-    fn new(pusher: PushCounter<T, D, Tee<T, D>>) -> UnorderedHandleCore<T, D> {
+impl<T: Timestamp, C: Container> UnorderedHandleCore<T, C> {
+    fn new(pusher: PushCounter<T, C, Tee<T, C>>) -> UnorderedHandleCore<T, C> {
         UnorderedHandleCore {
             buffer: PushBuffer::new(pusher),
         }
     }
 
     /// Allocates a new automatically flushing session based on the supplied capability.
-    pub fn session<'b>(&'b mut self, cap: ActivateCapability<T>) -> ActivateOnDrop<AutoflushSessionCore<'b, T, D, PushCounter<T, D, Tee<T, D>>>> {
+    pub fn session<'b>(&'b mut self, cap: ActivateCapability<T>) -> ActivateOnDrop<AutoflushSessionCore<'b, T, C, PushCounter<T, C, Tee<T, C>>>> {
         ActivateOnDrop::new(self.buffer.autoflush_session(cap.capability.clone()), cap.address.clone(), cap.activations.clone())
     }
 }

--- a/timely/src/dataflow/stream.rs
+++ b/timely/src/dataflow/stream.rs
@@ -15,29 +15,29 @@ use crate::Container;
 
 // use dataflow::scopes::root::loggers::CHANNELS_Q;
 
-/// Abstraction of a stream of `D: Container` records timestamped with `S::Timestamp`.
+/// Abstraction of a stream of `C: Container` records timestamped with `S::Timestamp`.
 ///
 /// Internally `Stream` maintains a list of data recipients who should be presented with data
 /// produced by the source of the stream.
 #[derive(Clone)]
-pub struct StreamCore<S: Scope, D> {
+pub struct StreamCore<S: Scope, C> {
     /// The progress identifier of the stream's data source.
     name: Source,
     /// The `Scope` containing the stream.
     scope: S,
-    /// Maintains a list of Push<Bundle<T, Vec<D>>> interested in the stream's output.
-    ports: TeeHelper<S::Timestamp, D>,
+    /// Maintains a list of Push<Bundle<T, C>> interested in the stream's output.
+    ports: TeeHelper<S::Timestamp, C>,
 }
 
 /// A stream batching data in vectors.
 pub type Stream<S, D> = StreamCore<S, Vec<D>>;
 
-impl<S: Scope, D: Container> StreamCore<S, D> {
+impl<S: Scope, C: Container> StreamCore<S, C> {
     /// Connects the stream to a destination.
     ///
     /// The destination is described both by a `Target`, for progress tracking information, and a `P: Push` where the
     /// records should actually be sent. The identifier is unique to the edge and is used only for logging purposes.
-    pub fn connect_to<P: Push<Bundle<S::Timestamp, D>>+'static>(&self, target: Target, pusher: P, identifier: usize) {
+    pub fn connect_to<P: Push<Bundle<S::Timestamp, C>>+'static>(&self, target: Target, pusher: P, identifier: usize) {
 
         let mut logging = self.scope().logging();
         logging.as_mut().map(|l| l.log(crate::logging::ChannelsEvent {
@@ -51,7 +51,7 @@ impl<S: Scope, D: Container> StreamCore<S, D> {
         self.ports.add_pusher(pusher);
     }
     /// Allocates a `Stream` from a supplied `Source` name and rendezvous point.
-    pub fn new(source: Source, output: TeeHelper<S::Timestamp, D>, scope: S) -> Self {
+    pub fn new(source: Source, output: TeeHelper<S::Timestamp, C>, scope: S) -> Self {
         Self { name: source, ports: output, scope }
     }
     /// The name of the stream's source operator.
@@ -60,7 +60,7 @@ impl<S: Scope, D: Container> StreamCore<S, D> {
     pub fn scope(&self) -> S { self.scope.clone() }
 }
 
-impl<S, D> Debug for StreamCore<S, D>
+impl<S, C> Debug for StreamCore<S, C>
 where
     S: Scope,
 {


### PR DESCRIPTION
I think out of prior ease we left various metasyntactic variables as `D` when we shifted from speaking about data to speaking about containers. This PR swaps those over, and generally anything that looks like `_Core<_` should have a `C` somewhere after it rather than `D`.