### PR TITLE
Remove `EnterAt`, migrate `enterleave.rs`

### DIFF
--- a/timely/src/dataflow/operators/core/mod.rs
+++ b/timely/src/dataflow/operators/core/mod.rs
@@ -2,6 +2,7 @@
 //! are independent of specific container types.
 
 pub mod concat;
+pub mod enterleave;
 pub mod exchange;
 pub mod feedback;
 pub mod inspect;
@@ -10,6 +11,7 @@ pub mod rc;
 pub mod reclock;
 
 pub use concat::{Concat, Concatenate};
+pub use enterleave::{Enter, Leave};
 pub use exchange::Exchange;
 pub use feedback::{Feedback, LoopVariable, ConnectLoop};
 pub use inspect::{Inspect, InspectCore};

--- a/timely/src/dataflow/operators/mod.rs
+++ b/timely/src/dataflow/operators/mod.rs
@@ -8,7 +8,6 @@
 //! operators whose behavior can be supplied using closures accepting input and output handles.
 //! Most of the operators in this module are defined using these two general operators.
 
-pub use self::enterleave::{Enter, EnterAt, Leave};
 pub use self::input::Input;
 pub use self::unordered_input::{UnorderedInput, UnorderedInputCore};
 pub use self::partition::Partition;
@@ -32,7 +31,7 @@ pub use self::count::Accumulate;
 
 pub mod core;
 
-pub mod enterleave;
+pub use self::core::enterleave::{self, Enter, Leave};
 pub mod input;
 pub mod flow_controlled;
 pub mod unordered_input;


### PR DESCRIPTION
This PR removes `EnterAt` which was recently seen to be an antipattern in differential dataflow (its `delay` operator queues data unnecessarily), and migrates the now-`StreamCore`-only `enterleave.rs` to the `core` dataflow module.