### PR TITLE
PartialOrder with Rhs type parameter

### DIFF
--- a/timely/src/progress/frontier.rs
+++ b/timely/src/progress/frontier.rs
@@ -69,6 +69,32 @@ impl<T: PartialOrder> Antichain<T> {
         }
     }
 
+    /// Updates the `Antichain` if the element is not greater than or equal to some present element.
+    /// If the antichain needs updating, it uses the `to_owned` closure to convert the element into
+    /// a `T`.
+    ///
+    /// Returns true if element is added to the set
+    ///
+    /// # Examples
+    ///
+    ///```
+    /// use timely::progress::frontier::Antichain;
+    ///
+    /// let mut frontier = Antichain::new();
+    /// assert!(frontier.insert_or_else(&2, |x| *x));
+    /// assert!(!frontier.insert(3));
+    ///```
+    pub fn insert_or_else<O: PartialOrder<T>, F: FnOnce(&O) -> T>(&mut self, element: &O, to_owned: F) -> bool where T: Clone + PartialOrder<O> {
+        if !self.elements.iter().any(|x| x.less_equal(element)) {
+            self.elements.retain(|x| !element.less_equal(x));
+            self.elements.push(to_owned(element));
+            true
+        }
+        else {
+            false
+        }
+    }
+
     /// Reserves capacity for at least additional more elements to be inserted in the given `Antichain`
     pub fn reserve(&mut self, additional: usize) {
         self.elements.reserve(additional);
@@ -450,9 +476,10 @@ impl<T> MutableAntichain<T> {
     /// assert!(frontier.less_than(&2));
     ///```
     #[inline]
-    pub fn less_than(&self, time: &T) -> bool
+    pub fn less_than<O>(&self, time: &O) -> bool
     where
-        T: PartialOrder,
+        O: PartialOrder<T>,
+        T: PartialOrder<O>,
     {
         self.frontier().less_than(time)
     }
@@ -470,9 +497,10 @@ impl<T> MutableAntichain<T> {
     /// assert!(frontier.less_equal(&2));
     ///```
     #[inline]
-    pub fn less_equal(&self, time: &T) -> bool
+    pub fn less_equal<O>(&self, time: &O) -> bool
     where
-        T: PartialOrder,
+        O: PartialOrder<T>,
+        T: PartialOrder<O>,
     {
         self.frontier().less_equal(time)
     }
@@ -549,9 +577,9 @@ impl<T> MutableAntichain<T> {
     }
 
     /// Reports the count for a queried time.
-    pub fn count_for(&self, query_time: &T) -> i64
+    pub fn count_for<O>(&self, query_time: &O) -> i64
     where
-        T: Ord,
+        T: PartialEq<O>,
     {
         self.updates
             .unstable_internal_updates()
@@ -679,7 +707,7 @@ impl<'a, T: 'a> AntichainRef<'a, T> {
     }
 }
 
-impl<'a, T: 'a+PartialOrder> AntichainRef<'a, T> {
+impl<T> AntichainRef<'_, T> {
 
     /// Returns true if any item in the `AntichainRef` is strictly less than the argument.
     ///
@@ -694,7 +722,7 @@ impl<'a, T: 'a+PartialOrder> AntichainRef<'a, T> {
     /// assert!(frontier.less_than(&2));
     ///```
     #[inline]
-    pub fn less_than(&self, time: &T) -> bool {
+    pub fn less_than<O>(&self, time: &O) -> bool where T: PartialOrder<O> {
         self.iter().any(|x| x.less_than(time))
     }
 
@@ -711,7 +739,7 @@ impl<'a, T: 'a+PartialOrder> AntichainRef<'a, T> {
     /// assert!(frontier.less_equal(&1));
     /// assert!(frontier.less_equal(&2));
     ///```
-    pub fn less_equal(&self, time: &T) -> bool {
+    pub fn less_equal<O>(&self, time: &O) -> bool where T: PartialOrder<O> {
         self.iter().any(|x| x.less_equal(time))
     }
 }

--- a/timely/src/progress/frontier.rs
+++ b/timely/src/progress/frontier.rs
@@ -81,10 +81,10 @@ impl<T: PartialOrder> Antichain<T> {
     /// use timely::progress::frontier::Antichain;
     ///
     /// let mut frontier = Antichain::new();
-    /// assert!(frontier.insert_or_else(&2, |x| *x));
+    /// assert!(frontier.insert_with(&2, |x| *x));
     /// assert!(!frontier.insert(3));
     ///```
-    pub fn insert_or_else<O: PartialOrder<T>, F: FnOnce(&O) -> T>(&mut self, element: &O, to_owned: F) -> bool where T: Clone + PartialOrder<O> {
+    pub fn insert_with<O: PartialOrder<T>, F: FnOnce(&O) -> T>(&mut self, element: &O, to_owned: F) -> bool where T: PartialOrder<O> {
         if !self.elements.iter().any(|x| x.less_equal(element)) {
             self.elements.retain(|x| !element.less_equal(x));
             self.elements.push(to_owned(element));
@@ -478,7 +478,6 @@ impl<T> MutableAntichain<T> {
     #[inline]
     pub fn less_than<O>(&self, time: &O) -> bool
     where
-        O: PartialOrder<T>,
         T: PartialOrder<O>,
     {
         self.frontier().less_than(time)
@@ -499,7 +498,6 @@ impl<T> MutableAntichain<T> {
     #[inline]
     pub fn less_equal<O>(&self, time: &O) -> bool
     where
-        O: PartialOrder<T>,
         T: PartialOrder<O>,
     {
         self.frontier().less_equal(time)


### PR DESCRIPTION
Add a `Rhs` parameter to `PartialOrder`, to allow comparison between different types. This helps to compare types stored in containers in a different form than their original structure.
