### PR TITLE
Add reborrow functions to Container

### DIFF
--- a/container/src/columnation.rs
+++ b/container/src/columnation.rs
@@ -366,6 +366,16 @@ mod container {
         fn drain(&mut self) -> Self::DrainIter<'_> {
             (*self).iter()
         }
+
+        #[inline(always)]
+        fn reborrow<'b, 'a: 'b>(item: Self::Item<'a>) -> Self::Item<'b> where Self: 'a {
+            item
+        }
+
+        #[inline(always)]
+        fn reborrow_ref<'b, 'a: 'b>(item: Self::ItemRef<'a>) -> Self::ItemRef<'b> where Self: 'a {
+            item
+        }
     }
 
     impl<T: Columnation + 'static> SizableContainer for TimelyStack<T> {

--- a/container/src/flatcontainer.rs
+++ b/container/src/flatcontainer.rs
@@ -26,6 +26,16 @@ impl<R: Region + Clone + 'static> Container for FlatStack<R> {
     fn drain<'a>(&'a mut self) -> Self::DrainIter<'a> {
         IntoIterator::into_iter(&*self)
     }
+
+    #[inline(always)]
+    fn reborrow<'b, 'a: 'b>(item: Self::Item<'a>) -> Self::Item<'b> where Self: 'a {
+        R::reborrow(item)
+    }
+
+    #[inline(always)]
+    fn reborrow_ref<'b, 'a: 'b>(item: Self::ItemRef<'a>) -> Self::ItemRef<'b> where Self: 'a {
+        R::reborrow(item)
+    }
 }
 
 impl<R: Region + Clone + 'static> SizableContainer for FlatStack<R> {


### PR DESCRIPTION
Add `reborrow` and `reborrow_ref` functions to `Container` to shorten the lifetime of the GATs.