### PR TITLE
Clone for Config and other improvements

### DIFF
--- a/communication/src/allocator/zero_copy/initialize.rs
+++ b/communication/src/allocator/zero_copy/initialize.rs
@@ -39,7 +39,7 @@ pub fn initialize_networking(
     my_index: usize,
     threads: usize,
     noisy: bool,
-    log_sender: Arc<Box<dyn Fn(CommunicationSetup)->Option<Logger<CommunicationEvent, CommunicationSetup>>+Send+Sync>>,
+    log_sender: Arc<dyn Fn(CommunicationSetup)->Option<Logger<CommunicationEvent, CommunicationSetup>>+Send+Sync>,
 )
 -> ::std::io::Result<(Vec<TcpBuilder<ProcessBuilder>>, CommsGuard)>
 {
@@ -58,7 +58,7 @@ pub fn initialize_networking_from_sockets<S: Stream + 'static>(
     mut sockets: Vec<Option<S>>,
     my_index: usize,
     threads: usize,
-    log_sender: Arc<Box<dyn Fn(CommunicationSetup)->Option<Logger<CommunicationEvent, CommunicationSetup>>+Send+Sync>>,
+    log_sender: Arc<dyn Fn(CommunicationSetup)->Option<Logger<CommunicationEvent, CommunicationSetup>>+Send+Sync>,
 )
 -> ::std::io::Result<(Vec<TcpBuilder<ProcessBuilder>>, CommsGuard)>
 {

--- a/communication/src/allocator/zero_copy/initialize.rs
+++ b/communication/src/allocator/zero_copy/initialize.rs
@@ -39,7 +39,8 @@ pub fn initialize_networking(
     my_index: usize,
     threads: usize,
     noisy: bool,
-    log_sender: Box<dyn Fn(CommunicationSetup)->Option<Logger<CommunicationEvent, CommunicationSetup>>+Send+Sync>)
+    log_sender: Arc<Box<dyn Fn(CommunicationSetup)->Option<Logger<CommunicationEvent, CommunicationSetup>>+Send+Sync>>,
+)
 -> ::std::io::Result<(Vec<TcpBuilder<ProcessBuilder>>, CommsGuard)>
 {
     let sockets = create_sockets(addresses, my_index, noisy)?;
@@ -57,7 +58,8 @@ pub fn initialize_networking_from_sockets<S: Stream + 'static>(
     mut sockets: Vec<Option<S>>,
     my_index: usize,
     threads: usize,
-    log_sender: Box<dyn Fn(CommunicationSetup)->Option<Logger<CommunicationEvent, CommunicationSetup>>+Send+Sync>)
+    log_sender: Arc<Box<dyn Fn(CommunicationSetup)->Option<Logger<CommunicationEvent, CommunicationSetup>>+Send+Sync>>,
+)
 -> ::std::io::Result<(Vec<TcpBuilder<ProcessBuilder>>, CommsGuard)>
 {
     // Sockets are expected to be blocking,
@@ -67,7 +69,6 @@ pub fn initialize_networking_from_sockets<S: Stream + 'static>(
         }
     }
 
-    let log_sender = Arc::new(log_sender);
     let processes = sockets.len();
 
     let process_allocators = crate::allocator::process::Process::new_vector(threads);

--- a/communication/src/initialize.rs
+++ b/communication/src/initialize.rs
@@ -39,7 +39,7 @@ pub enum Config {
         /// Verbosely report connection process
         report: bool,
         /// Closure to create a new logger for a communication thread
-        log_fn: Arc<Box<dyn Fn(CommunicationSetup) -> Option<Logger<CommunicationEvent, CommunicationSetup>> + Send + Sync>>,
+        log_fn: Arc<dyn Fn(CommunicationSetup) -> Option<Logger<CommunicationEvent, CommunicationSetup>> + Send + Sync>,
     }
 }
 
@@ -121,7 +121,7 @@ impl Config {
                 process,
                 addresses,
                 report,
-                log_fn: Arc::new(Box::new( | _ | None)),
+                log_fn: Arc::new(|_| None),
             })
         } else if threads > 1 {
             if zerocopy {

--- a/communication/src/initialize.rs
+++ b/communication/src/initialize.rs
@@ -20,6 +20,7 @@ use std::fmt::{Debug, Formatter};
 
 
 /// Possible configurations for the communication infrastructure.
+#[derive(Clone)]
 pub enum Config {
     /// Use one thread.
     Thread,
@@ -38,7 +39,7 @@ pub enum Config {
         /// Verbosely report connection process
         report: bool,
         /// Closure to create a new logger for a communication thread
-        log_fn: Box<dyn Fn(CommunicationSetup) -> Option<Logger<CommunicationEvent, CommunicationSetup>> + Send + Sync>,
+        log_fn: Arc<Box<dyn Fn(CommunicationSetup) -> Option<Logger<CommunicationEvent, CommunicationSetup>> + Send + Sync>>,
     }
 }
 
@@ -120,7 +121,7 @@ impl Config {
                 process,
                 addresses,
                 report,
-                log_fn: Box::new( | _ | None),
+                log_fn: Arc::new(Box::new( | _ | None)),
             })
         } else if threads > 1 {
             if zerocopy {


### PR DESCRIPTION
* Clone for timely and communication config. Forces the cluster log function to be wrapped in an Arc, which is what happens anyways, so a no-op change.
* Use `execute_from` in `execute` to deduplicate code.
* Remove weird logging code from `execute`.