### PR TITLE
Make `std::time::Instant` optional

### DIFF
--- a/timely/examples/logging-send.rs
+++ b/timely/examples/logging-send.rs
@@ -17,14 +17,14 @@ fn main() {
         let mut probe = ProbeHandle::new();
 
         // Register timely worker logging.
-        worker.log_register().insert::<TimelyEvent,_>("timely", |_time, data|
+        worker.log_register().unwrap().insert::<TimelyEvent,_>("timely", |_time, data|
             data.iter().for_each(|x| println!("LOG1: {:?}", x))
         );
 
         // Register timely progress logging.
         // Less generally useful: intended for debugging advanced custom operators or timely
         // internals.
-        worker.log_register().insert::<TimelyProgressEvent,_>("timely/progress", |_time, data|
+        worker.log_register().unwrap().insert::<TimelyProgressEvent,_>("timely/progress", |_time, data|
             data.iter().for_each(|x| {
                 println!("PROGRESS: {:?}", x);
                 let (_, _, ev) = x;
@@ -50,7 +50,7 @@ fn main() {
         });
 
         // Register timely worker logging.
-        worker.log_register().insert::<TimelyEvent,_>("timely", |_time, data|
+        worker.log_register().unwrap().insert::<TimelyEvent,_>("timely", |_time, data|
             data.iter().for_each(|x| println!("LOG2: {:?}", x))
         );
 
@@ -63,13 +63,13 @@ fn main() {
         });
 
         // Register user-level logging.
-        worker.log_register().insert::<(),_>("input", |_time, data|
+        worker.log_register().unwrap().insert::<(),_>("input", |_time, data|
             for element in data.iter() {
                 println!("Round tick at: {:?}", element.0);
             }
         );
 
-        let input_logger = worker.log_register().get::<()>("input").expect("Input logger absent");
+        let input_logger = worker.log_register().unwrap().get::<()>("input").expect("Input logger absent");
 
         let timer = std::time::Instant::now();
 

--- a/timely/examples/threadless.rs
+++ b/timely/examples/threadless.rs
@@ -8,7 +8,7 @@ fn main() {
 
     // create a naked single-threaded worker.
     let allocator = timely::communication::allocator::Thread::new();
-    let mut worker = timely::worker::Worker::new(WorkerConfig::default(), allocator);
+    let mut worker = timely::worker::Worker::new(WorkerConfig::default(), allocator, None);
 
     // create input and probe handles.
     let mut input = InputHandle::new();

--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -67,7 +67,7 @@ where
     fn new_identifier(&mut self) -> usize {
         self.parent.new_identifier()
     }
-    fn log_register(&self) -> ::std::cell::RefMut<crate::logging_core::Registry<crate::logging::WorkerIdentifier>> {
+    fn log_register(&self) -> Option<::std::cell::RefMut<crate::logging_core::Registry<crate::logging::WorkerIdentifier>>> {
         self.parent.log_register()
     }
 }

--- a/timely/src/execute.rs
+++ b/timely/src/execute.rs
@@ -154,7 +154,7 @@ where
     F: FnOnce(&mut Worker<crate::communication::allocator::thread::Thread>)->T+Send+Sync+'static
 {
     let alloc = crate::communication::allocator::thread::Thread::new();
-    let mut worker = crate::worker::Worker::new(WorkerConfig::default(), alloc);
+    let mut worker = crate::worker::Worker::new(WorkerConfig::default(), alloc, Some(std::time::Instant::now()));
     let result = func(&mut worker);
     while worker.has_dataflows() {
         worker.step_or_park(None);
@@ -320,7 +320,7 @@ where
     T: Send+'static,
     F: Fn(&mut Worker<<A as AllocateBuilder>::Allocator>)->T+Send+Sync+'static {
     initialize_from(builders, others, move |allocator| {
-        let mut worker = Worker::new(worker_config.clone(), allocator);
+        let mut worker = Worker::new(worker_config.clone(), allocator, Some(std::time::Instant::now()));
         let result = func(&mut worker);
         while worker.has_dataflows() {
             worker.step_or_park(None);

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -177,8 +177,11 @@ where
         let path = self.path.clone();
         let reachability_logging =
         worker.log_register()
-            .get::<reachability::logging::TrackerEvent>("timely/reachability")
-            .map(|logger| reachability::logging::TrackerLogger::new(path, logger));
+            .as_ref()
+            .and_then(|l| 
+                l.get::<reachability::logging::TrackerEvent>("timely/reachability")
+                .map(|logger| reachability::logging::TrackerLogger::new(path, logger))
+            );
         let (tracker, scope_summary) = builder.build(reachability_logging);
 
         let progcaster = Progcaster::new(worker, &self.path, self.logging.clone(), self.progress_logging.clone());


### PR DESCRIPTION
Ah, sort of what the title says. Many uses of `Instant` have become `Option<Instant>` with the intent that an absent instant reflects execution in an environment without time. It a more complicated world we might swap in a generic to replace `Instant`, but threading that through everywhere seemed complicated, and making the instant optional and various behavior locked behind having a `Some` instant seemed like a good first dip of toes in the water.

cc: @oli-w