### PR TITLE
Introduce `SmallVec` for small allocations

### DIFF
--- a/timely/Cargo.toml
+++ b/timely/Cargo.toml
@@ -31,6 +31,7 @@ timely_logging = { path = "../logging", version = "0.12" }
 timely_communication = { path = "../communication", version = "0.12", default-features = false }
 timely_container = { path = "../container", version = "0.12" }
 crossbeam-channel = "0.5.0"
+smallvec = { version = "1.13.2", features = ["serde", "const_generics"] }
 
 [dev-dependencies]
 # timely_sort="0.1.6"

--- a/timely/src/dataflow/operators/core/capture/capture.rs
+++ b/timely/src/dataflow/operators/core/capture/capture.rs
@@ -131,7 +131,7 @@ impl<S: Scope, C: Container> Capture<S::Timestamp, C> for StreamCore<S, C> {
                 if !progress.frontiers[0].is_empty() {
                     // transmit any frontier progress.
                     let to_send = ::std::mem::replace(&mut progress.frontiers[0], ChangeBatch::new());
-                    event_pusher.push(Event::Progress(to_send.into_inner()));
+                    event_pusher.push(Event::Progress(to_send.into_inner().to_vec()));
                 }
 
                 use crate::communication::message::RefOrMut;

--- a/timely/src/progress/broadcast.rs
+++ b/timely/src/progress/broadcast.rs
@@ -103,7 +103,7 @@ impl<T:Timestamp+Send> Progcaster<T> {
                     self.to_push = Some(Message::from_typed((
                         self.source,
                         self.counter,
-                        changes.clone().into_inner(),
+                        changes.clone().into_inner().to_vec(),
                     )));
                 }
 


### PR DESCRIPTION
This PR introduce the use of `SmallVec` for allocations backing `ChangeBatch` and `Antichain`. These often have at most two and one, respectively, elements in them. I made `ChangeBatch` itself generic, and `Antichain` not. Probably best to unify these. 

It takes a modified `event_driven.rs` from 
```
cargo run --example event_driven --release -- 1000 1000 no  5.31s user 0.59s system 96% cpu 6.124 total
```
to
```
cargo run --example event_driven --release -- 1000 1000 no  4.56s user 0.59s system 95% cpu 5.382 total
```
Some noise is these measurements, but the relative improvement seems consistent.