### PR TITLE
Switch to serde's derive feature, update Rust to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ members = [
     "timely",
 ]
 
+resolver = "2"
+
+[workspace.package]
+edition = "2021"
+
 [profile.release]
 opt-level = 3
 debug = true

--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -3,7 +3,7 @@ name = "timely_communication"
 version = "0.12.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 description = "Communication layer for timely dataflow"
-edition = "2018"
+edition.workspace = true
 
 # These URLs point to more information about the repository
 
@@ -20,8 +20,7 @@ default = ["getopts"]
 getopts = { version = "0.2.14", optional = true }
 bincode = { version = "1.0" }
 byteorder = "1.5"
-serde_derive = "1.0"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 timely_bytes = { path = "../bytes", version = "0.12" }
 timely_logging = { path = "../logging", version = "0.12" }
 crossbeam-channel = "0.5.0"

--- a/container/Cargo.toml
+++ b/container/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "timely_container"
 version = "0.12.0"
-edition = "2018"
 description = "Container abstractions for Timely"
 license = "MIT"
+edition.workspace = true
 
 [dependencies]
 columnation = { git = "https://github.com/frankmcsherry/columnation" }
 flatcontainer = "0.5"
-serde = { version = "1.0"}
+serde = { version = "1.0", features = ["derive"] }

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -2,9 +2,8 @@
 name = "timely_logging"
 version = "0.12.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
-edition = "2018"
-
 description = "Common timely logging infrastructure"
+edition.workspace = true
 
 documentation = "https://docs.rs/timely/"
 homepage = "https://github.com/TimelyDataflow/timely-dataflow"

--- a/timely/Cargo.toml
+++ b/timely/Cargo.toml
@@ -4,8 +4,7 @@ name = "timely"
 version = "0.12.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 readme = "../README.md"
-edition = "2018"
-
+edition.workspace = true
 description = "A low-latency data-parallel dataflow system in Rust"
 
 # These URLs point to more information about the repository
@@ -22,8 +21,7 @@ getopts = ["getopts-dep", "timely_communication/getopts"]
 [dependencies]
 getopts-dep = { package = "getopts", version = "0.2.14", optional = true }
 bincode = { version = "1.0" }
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 timely_bytes = { path = "../bytes", version = "0.12" }
 timely_logging = { path = "../logging", version = "0.12" }
 timely_communication = { path = "../communication", version = "0.12", default-features = false }

--- a/timely/src/dataflow/channels/mod.rs
+++ b/timely/src/dataflow/channels/mod.rs
@@ -1,5 +1,6 @@
 //! Structured communication between timely dataflow operators.
 
+use serde::{Deserialize, Serialize};
 use crate::communication::Push;
 use crate::Container;
 

--- a/timely/src/dataflow/operators/core/capture/event.rs
+++ b/timely/src/dataflow/operators/core/capture/event.rs
@@ -4,6 +4,8 @@
 //! stream. There are two types of events, (i) the receipt of data and (ii) reports of progress
 //! of timestamps.
 
+use serde::{Deserialize, Serialize};
+
 /// Data and progress events of the captured stream.
 #[derive(Debug, Clone, Hash, Ord, PartialOrd, Eq, PartialEq, Deserialize, Serialize)]
 pub enum Event<T, C> {

--- a/timely/src/lib.rs
+++ b/timely/src/lib.rs
@@ -58,8 +58,6 @@
 
 extern crate bincode;
 extern crate serde;
-#[macro_use]
-extern crate serde_derive;
 extern crate timely_communication;
 extern crate timely_bytes;
 extern crate timely_logging;

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -10,6 +10,7 @@ pub type TimelyLogger = Logger<TimelyEvent>;
 pub type TimelyProgressLogger = Logger<TimelyProgressEvent>;
 
 use std::time::Duration;
+use serde::{Deserialize, Serialize};
 use crate::dataflow::operators::capture::{Event, EventPusher};
 
 /// Logs events as a timely stream, with progress statements.
@@ -81,7 +82,7 @@ pub trait ProgressEventTimestamp: std::fmt::Debug + std::any::Any {
     /// # Example
     /// ```rust
     /// let ts = vec![(0usize, 0usize, (23u64, 10u64), -4i64), (0usize, 0usize, (23u64, 11u64), 1i64)];
-    /// let ts: &timely::logging::ProgressEventTimestampVec = &ts;
+    /// let ts: &dyn timely::logging::ProgressEventTimestampVec = &ts;
     /// for (n, p, t, d) in ts.iter() {
     ///     print!("{:?}, ", (n, p, t.as_any().downcast_ref::<(u64, u64)>(), d));
     /// }

--- a/timely/src/order.rs
+++ b/timely/src/order.rs
@@ -61,6 +61,7 @@ pub use product::flatcontainer::ProductRegion as FlatProductRegion;
 /// A pair of timestamps, partially ordered by the product order.
 mod product {
     use std::fmt::{Formatter, Error, Debug};
+    use serde::{Deserialize, Serialize};
 
     use crate::container::columnation::{Columnation, Region};
     use crate::order::{Empty, TotalOrder};

--- a/timely/src/progress/change_batch.rs
+++ b/timely/src/progress/change_batch.rs
@@ -1,5 +1,6 @@
 //! A collection of updates of the form `(T, i64)`.
 
+use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 /// A collection of updates of the form `(T, i64)`.

--- a/timely/src/progress/frontier.rs
+++ b/timely/src/progress/frontier.rs
@@ -1,5 +1,6 @@
 //! Tracks minimal sets of mutually incomparable elements of a partial order.
 
+use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 use crate::progress::ChangeBatch;

--- a/timely/src/progress/mod.rs
+++ b/timely/src/progress/mod.rs
@@ -1,5 +1,6 @@
 //! Progress tracking mechanisms to support notification in timely dataflow
 
+use serde::{Deserialize, Serialize};
 pub use self::operate::Operate;
 pub use self::subgraph::{Subgraph, SubgraphBuilder};
 pub use self::timestamp::{Timestamp, PathSummary};


### PR DESCRIPTION
As the title says, no behavior changes otherwise.

Fixes #584.