### PR TITLE
ci: Update to `actions/checkout@v4`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: cargo install mdbook --version 0.4.36
       - run: cd mdbook && mdbook build
       - uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: rustup update 1.65 --no-self-update && rustup default 1.65
     - run: cargo build
     - name: test mdBook


### PR DESCRIPTION
This just updates to the current version which runs on a version of Node that GitHub hasn't deprecated.