### PR TITLE
Allow viewing of next dataflow-unique identifier

### DIFF
--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -67,6 +67,9 @@ where
     fn new_identifier(&mut self) -> usize {
         self.parent.new_identifier()
     }
+    fn peek_identifier(&self) -> usize {
+        self.parent.peek_identifier()
+    }
     fn log_register(&self) -> ::std::cell::RefMut<crate::logging_core::Registry<crate::logging::WorkerIdentifier>> {
         self.parent.log_register()
     }

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -200,6 +200,8 @@ pub trait AsWorker : Scheduler {
 
     /// Allocates a new worker-unique identifier.
     fn new_identifier(&mut self) -> usize;
+    /// The next worker-unique identifier to be allocated.
+    fn peek_identifier(&self) -> usize;
     /// Provides access to named logging streams.
     fn log_register(&self) -> ::std::cell::RefMut<crate::logging_core::Registry<crate::logging::WorkerIdentifier>>;
     /// Provides access to the timely logging stream.
@@ -247,6 +249,7 @@ impl<A: Allocate> AsWorker for Worker<A> {
     }
 
     fn new_identifier(&mut self) -> usize { self.new_identifier() }
+    fn peek_identifier(&self) -> usize { self.peek_identifier() }
     fn log_register(&self) -> RefMut<crate::logging_core::Registry<crate::logging::WorkerIdentifier>> {
         self.log_register()
     }
@@ -524,6 +527,11 @@ impl<A: Allocate> Worker<A> {
     pub fn new_identifier(&mut self) -> usize {
         *self.identifiers.borrow_mut() += 1;
         *self.identifiers.borrow() - 1
+    }
+
+    /// The next worker-unique identifier to be allocated.
+    pub fn peek_identifier(&self) -> usize {
+        *self.identifiers.borrow()
     }
 
     /// Access to named loggers.


### PR DESCRIPTION
This PR adds a simple method that allows one to view the next dataflow-unique identifier that will be allocated. The intended use is for folks who want to correlate spans in rendering code with spans of constructed operators and channels. One can view the identifier before and after a block of rendering code, and the resulting span of identifiers should align with the logged identifiers for created operators and channels.

@mgree