### PR TITLE
Simplify communication `Message` type

### DIFF
--- a/communication/src/message.rs
+++ b/communication/src/message.rs
@@ -5,8 +5,6 @@ use crate::Data;
 
 /// Either an immutable or mutable reference.
 pub enum RefOrMut<'a, T> where T: 'a {
-    /// An immutable reference.
-    Ref(&'a T),
     /// A mutable reference.
     Mut(&'a mut T),
 }
@@ -15,7 +13,6 @@ impl<'a, T: 'a> ::std::ops::Deref for RefOrMut<'a, T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         match self {
-            RefOrMut::Ref(reference) => reference,
             RefOrMut::Mut(reference) => reference,
         }
     }
@@ -24,7 +21,6 @@ impl<'a, T: 'a> ::std::ops::Deref for RefOrMut<'a, T> {
 impl<'a, T: 'a> ::std::borrow::Borrow<T> for RefOrMut<'a, T> {
     fn borrow(&self) -> &T {
         match self {
-            RefOrMut::Ref(reference) => reference,
             RefOrMut::Mut(reference) => reference,
         }
     }
@@ -36,7 +32,6 @@ impl<'a, T: Clone+'a> RefOrMut<'a, T> {
     /// This consumes `self` because its contents are now in an unknown state.
     pub fn swap<'b>(self, element: &'b mut T) {
         match self {
-            RefOrMut::Ref(reference) => element.clone_from(reference),
             RefOrMut::Mut(reference) => ::std::mem::swap(reference, element),
         };
     }

--- a/communication/src/message.rs
+++ b/communication/src/message.rs
@@ -3,57 +3,6 @@
 use bytes::arc::Bytes;
 use crate::Data;
 
-/// Either an immutable or mutable reference.
-pub enum RefOrMut<'a, T> where T: 'a {
-    /// A mutable reference.
-    Mut(&'a mut T),
-}
-
-impl<'a, T: 'a> ::std::ops::Deref for RefOrMut<'a, T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        match self {
-            RefOrMut::Mut(reference) => reference,
-        }
-    }
-}
-
-impl<'a, T: 'a> ::std::borrow::Borrow<T> for RefOrMut<'a, T> {
-    fn borrow(&self) -> &T {
-        match self {
-            RefOrMut::Mut(reference) => reference,
-        }
-    }
-}
-
-impl<'a, T: Clone+'a> RefOrMut<'a, T> {
-    /// Extracts the contents of `self`, either by cloning or swapping.
-    ///
-    /// This consumes `self` because its contents are now in an unknown state.
-    pub fn swap<'b>(self, element: &'b mut T) {
-        match self {
-            RefOrMut::Mut(reference) => ::std::mem::swap(reference, element),
-        };
-    }
-    /// Extracts the contents of `self`, either by cloning or swapping.
-    ///
-    /// This consumes `self` because its contents are now in an unknown state.
-    pub fn replace(self, mut element: T) -> T {
-        self.swap(&mut element);
-        element
-    }
-
-    /// Extracts the contents of `self`, either by cloning, or swapping and leaving a default
-    /// element in place.
-    ///
-    /// This consumes `self` because its contents are now in an unknown state.
-    pub fn take(self) -> T where T: Default {
-        let mut element = Default::default();
-        self.swap(&mut element);
-        element
-    }
-}
-
 /// A wrapped message which may be either typed or binary data.
 pub struct Message<T> {
     payload: T,
@@ -71,14 +20,6 @@ impl<T> Message<T> {
     /// Returns a mutable reference, if typed.
     pub fn if_mut(&mut self) -> Option<&mut T> {
         Some(&mut self.payload)
-    }
-    /// Returns an immutable or mutable typed reference.
-    ///
-    /// This method returns a mutable reference if the underlying data are typed Rust
-    /// instances, which admit mutation, and it returns an immutable reference if the
-    /// data are serialized binary data.
-    pub fn as_ref_or_mut(&mut self) -> RefOrMut<T> {
-        RefOrMut::Mut(&mut self.payload)
     }
 }
 

--- a/communication/src/message.rs
+++ b/communication/src/message.rs
@@ -3,23 +3,16 @@
 use bytes::arc::Bytes;
 use crate::Data;
 
-/// A wrapped message which may be either typed or binary data.
+/// A wrapped message which supports serialization and deserialization.
 pub struct Message<T> {
-    payload: T,
+    /// Message contents.
+    pub payload: T,
 }
 
 impl<T> Message<T> {
     /// Wrap a typed item as a message.
     pub fn from_typed(typed: T) -> Self {
         Message { payload: typed }
-    }
-    /// Destructures and returns any typed data.
-    pub fn if_typed(self) -> Option<T> {
-        Some(self.payload)
-    }
-    /// Returns a mutable reference, if typed.
-    pub fn if_mut(&mut self) -> Option<&mut T> {
-        Some(&mut self.payload)
     }
 }
 
@@ -45,16 +38,5 @@ impl<T> ::std::ops::Deref for Message<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.payload
-    }
-}
-
-impl<T: Clone> Message<T> {
-    /// Produces a typed instance of the wrapped element.
-    pub fn into_typed(self) -> T {
-        self.payload
-    }
-    /// Ensures the message is typed data and returns a mutable reference to it.
-    pub fn as_mut(&mut self) -> &mut T {
-        &mut self.payload
     }
 }

--- a/mdbook/src/chapter_2/chapter_2_4.md
+++ b/mdbook/src/chapter_2/chapter_2_4.md
@@ -19,12 +19,10 @@ fn main() {
             .to_stream(scope)
             .unary(Pipeline, "increment", |capability, info| {
 
-                let mut vector = Vec::new();
                 move |input, output| {
                     while let Some((time, data)) = input.next() {
-                        data.swap(&mut vector);
                         let mut session = output.session(&time);
-                        for datum in vector.drain(..) {
+                        for datum in data.drain(..) {
                             session.give(datum + 1);
                         }
                     }
@@ -136,13 +134,11 @@ fn main() {
             .unary(Pipeline, "increment", |capability, info| {
 
                 let mut maximum = 0;    // define this here; use in the closure
-                let mut vector = Vec::new();
 
                 move |input, output| {
                     while let Some((time, data)) = input.next() {
-                        data.swap(&mut vector);
                         let mut session = output.session(&time);
-                        for datum in vector.drain(..) {
+                        for datum in data.drain(..) {
                             if datum > maximum {
                                 session.give(datum + 1);
                                 maximum = datum;

--- a/mdbook/src/chapter_2/chapter_2_4.md
+++ b/mdbook/src/chapter_2/chapter_2_4.md
@@ -191,13 +191,13 @@ fn main() {
                 while let Some((time, data)) = input1.next() {
                     stash.entry(time.time().clone())
                          .or_insert(Vec::new())
-                         .push(data.replace(Vec::new()));
+                         .push(std::mem::take(data));
                     notificator.notify_at(time.retain());
                 }
                 while let Some((time, data)) = input2.next() {
                     stash.entry(time.time().clone())
                          .or_insert(Vec::new())
-                         .push(data.replace(Vec::new()));
+                         .push(std::mem::take(data));
                     notificator.notify_at(time.retain());
                 }
 
@@ -242,12 +242,12 @@ fn main() {
                 while let Some((time, data)) = input1.next() {
                     stash.entry(time.retain())
                          .or_insert(Vec::new())
-                         .push(data.replace(Vec::new()));
+                         .push(std::mem::take(data));
                 }
                 while let Some((time, data)) = input2.next() {
                     stash.entry(time.retain())
                          .or_insert(Vec::new())
-                         .push(data.replace(Vec::new()));
+                         .push(std::mem::take(data));
                 }
 
                 // consider sending everything in `stash`.

--- a/mdbook/src/chapter_2/chapter_2_5.md
+++ b/mdbook/src/chapter_2/chapter_2_5.md
@@ -212,7 +212,7 @@ As before, I'm just going to show you the new code, which now lives just after `
                         while let Some((time, data)) = input.next() {
                             queues.entry(time.retain())
                                   .or_insert(Vec::new())
-                                  .extend(data.replace(Vec::new()));
+                                  .extend(std::mem::take(data));
                         }
 
                         // enable each stashed time if ready.
@@ -297,7 +297,7 @@ Inside the closure, we do two things: (i) read inputs and (ii) update counts and
         while let Some((time, data)) = input.next() {
             queues.entry(time.retain())
                   .or_insert(Vec::new())
-                  .extend(data.replace(Vec::new()));
+                  .extend(std::mem::take(data));
         }
 ```
 

--- a/mdbook/src/chapter_4/chapter_4_3.md
+++ b/mdbook/src/chapter_4/chapter_4_3.md
@@ -78,16 +78,13 @@ fn main() {
             // Buffer records until all prior timestamps have completed.
             .binary_frontier(&cycle, Pipeline, Pipeline, "Buffer", move |capability, info| {
 
-                let mut vector = Vec::new();
-
                 move |input1, input2, output| {
 
                     // Stash received data.
                     input1.for_each(|time, data| {
-                        data.swap(&mut vector);
                         stash.entry(time.retain())
                              .or_insert(Vec::new())
-                             .extend(vector.drain(..));
+                             .extend(data.drain(..));
                     });
 
                     // Consider sending stashed data.

--- a/timely/examples/bfs.rs
+++ b/timely/examples/bfs.rs
@@ -58,7 +58,7 @@ fn main() {
                     // receive edges, start to sort them
                     input1.for_each(|time, data| {
                         notify.notify_at(time.retain());
-                        edge_list.push(data.replace(Vec::new()));
+                        edge_list.push(std::mem::take(data));
                     });
 
                     // receive (node, worker) pairs, note any new ones.
@@ -68,7 +68,7 @@ fn main() {
                                       notify.notify_at(time.retain());
                                       Vec::new()
                                   })
-                                  .push(data.replace(Vec::new()));
+                                  .push(std::mem::take(data));
                     });
 
                     notify.for_each(|time, _num, _notify| {

--- a/timely/examples/flatcontainer.rs
+++ b/timely/examples/flatcontainer.rs
@@ -52,7 +52,7 @@ fn main() {
                                 queues
                                     .entry(time.retain())
                                     .or_insert(Vec::new())
-                                    .push(data.take());
+                                    .push(std::mem::take(data));
                             }
 
                             for (key, val) in queues.iter_mut() {

--- a/timely/examples/hashjoin.rs
+++ b/timely/examples/hashjoin.rs
@@ -40,16 +40,12 @@ fn main() {
                     let mut map1 = HashMap::<u64, Vec<u64>>::new();
                     let mut map2 = HashMap::<u64, Vec<u64>>::new();
 
-                    let mut vector1 = Vec::new();
-                    let mut vector2 = Vec::new();
-
                     move |input1, input2, output| {
 
                         // Drain first input, check second map, update first map.
                         input1.for_each(|time, data| {
-                            data.swap(&mut vector1);
                             let mut session = output.session(&time);
-                            for (key, val1) in vector1.drain(..) {
+                            for (key, val1) in data.drain(..) {
                                 if let Some(values) = map2.get(&key) {
                                     for val2 in values.iter() {
                                         session.give((val1.clone(), val2.clone()));
@@ -62,9 +58,8 @@ fn main() {
 
                         // Drain second input, check first map, update second map.
                         input2.for_each(|time, data| {
-                            data.swap(&mut vector2);
                             let mut session = output.session(&time);
-                            for (key, val2) in vector2.drain(..) {
+                            for (key, val2) in data.drain(..) {
                                 if let Some(values) = map1.get(&key) {
                                     for val1 in values.iter() {
                                         session.give((val1.clone(), val2.clone()));

--- a/timely/examples/pagerank.rs
+++ b/timely/examples/pagerank.rs
@@ -42,23 +42,18 @@ fn main() {
                     let mut diffs = Vec::new(); // for received but un-acted upon deltas.
                     let mut delta = Vec::new();
 
-                    let mut edge_vec = Vec::new();
-                    let mut rank_vec = Vec::new();
-
                     let timer = ::std::time::Instant::now();
 
                     move |input1, input2, output| {
 
                         // hold on to edge changes until it is time.
                         input1.for_each(|time, data| {
-                            data.swap(&mut edge_vec);
-                            edge_stash.entry(time.retain()).or_insert(Vec::new()).extend(edge_vec.drain(..));
+                            edge_stash.entry(time.retain()).or_insert(Vec::new()).extend(data.drain(..));
                         });
 
                         // hold on to rank changes until it is time.
                         input2.for_each(|time, data| {
-                            data.swap(&mut rank_vec);
-                            rank_stash.entry(time.retain()).or_insert(Vec::new()).extend(rank_vec.drain(..));
+                            rank_stash.entry(time.retain()).or_insert(Vec::new()).extend(data.drain(..));
                         });
 
                         let frontiers = &[input1.frontier(), input2.frontier()];

--- a/timely/examples/wordcount.rs
+++ b/timely/examples/wordcount.rs
@@ -35,7 +35,7 @@ fn main() {
                         while let Some((time, data)) = input.next() {
                             queues.entry(time.retain())
                                   .or_insert(Vec::new())
-                                  .push(data.replace(Vec::new()));
+                                  .push(std::mem::take(data));
                         }
 
                         for (key, val) in queues.iter_mut() {

--- a/timely/src/dataflow/channels/mod.rs
+++ b/timely/src/dataflow/channels/mod.rs
@@ -53,10 +53,8 @@ impl<T, C: Container> Message<T, C> {
         pusher.push(&mut bundle);
 
         if let Some(message) = bundle {
-            if let Some(message) = message.if_typed() {
-                *buffer = message.data;
-                buffer.clear();
-            }
+            *buffer = message.payload.data;
+            buffer.clear();
         }
     }
 }

--- a/timely/src/dataflow/channels/pact.rs
+++ b/timely/src/dataflow/channels/pact.rs
@@ -121,10 +121,8 @@ impl<T, C: Container, P: Push<Bundle<T, C>>> Push<Bundle<T, C>> for LogPusher<T,
 
             // Stamp the sequence number and source.
             // FIXME: Awkward moment/logic.
-            if let Some(message) = bundle.if_mut() {
-                message.seq = self.counter - 1;
-                message.from = self.source;
-            }
+            bundle.payload.seq = self.counter - 1;
+            bundle.payload.from = self.source;
 
             if let Some(logger) = self.logging.as_ref() {
                 logger.log(MessagesEvent {

--- a/timely/src/dataflow/channels/pushers/exchange.rs
+++ b/timely/src/dataflow/channels/pushers/exchange.rs
@@ -57,9 +57,8 @@ where
         }
         else if let Some(message) = message {
 
-            let message = message.as_mut();
-            let time = &message.time;
-            let data = &mut message.data;
+            let time = &message.payload.time;
+            let data = &mut message.payload.data;
 
             // if the time isn't right, flush everything.
             if self.current.as_ref().map_or(false, |x| x != time) {

--- a/timely/src/dataflow/operators/aggregation/aggregate.rs
+++ b/timely/src/dataflow/operators/aggregation/aggregate.rs
@@ -76,14 +76,12 @@ impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> Aggregate<S, K, V> for 
         hash: H) -> Stream<S, R> where S::Timestamp: Eq {
 
         let mut aggregates = HashMap::new();
-        let mut vector = Vec::new();
         self.unary_notify(Exchange::new(move |&(ref k, _)| hash(k)), "Aggregate", vec![], move |input, output, notificator| {
 
             // read each input, fold into aggregates
             input.for_each(|time, data| {
-                data.swap(&mut vector);
                 let agg_time = aggregates.entry(time.time().clone()).or_insert_with(HashMap::new);
-                for (key, val) in vector.drain(..) {
+                for (key, val) in data.drain(..) {
                     let agg = agg_time.entry(key.clone()).or_insert_with(Default::default);
                     fold(&key, val, agg);
                 }

--- a/timely/src/dataflow/operators/aggregation/state_machine.rs
+++ b/timely/src/dataflow/operators/aggregation/state_machine.rs
@@ -66,8 +66,6 @@ impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> StateMachine<S, K, V> f
         let mut pending: HashMap<_, Vec<(K, V)>> = HashMap::new();   // times -> (keys -> state)
         let mut states = HashMap::new();    // keys -> state
 
-        let mut vector = Vec::new();
-
         self.unary_notify(Exchange::new(move |&(ref k, _)| hash(k)), "StateMachine", vec![], move |input, output, notificator| {
 
             // go through each time with data, process each (key, val) pair.
@@ -88,17 +86,15 @@ impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> StateMachine<S, K, V> f
             // stash each input and request a notification when ready
             input.for_each(|time, data| {
 
-                data.swap(&mut vector);
-
                 // stash if not time yet
                 if notificator.frontier(0).less_than(time.time()) {
-                    pending.entry(time.time().clone()).or_insert_with(Vec::new).extend(vector.drain(..));
+                    pending.entry(time.time().clone()).or_insert_with(Vec::new).extend(data.drain(..));
                     notificator.notify_at(time.retain());
                 }
                 else {
                     // else we can process immediately
                     let mut session = output.session(&time);
-                    for (key, val) in vector.drain(..) {
+                    for (key, val) in data.drain(..) {
                         let (remove, output) = {
                             let state = states.entry(key.clone()).or_insert_with(Default::default);
                             fold(&key, val, state)

--- a/timely/src/dataflow/operators/branch.rs
+++ b/timely/src/dataflow/operators/branch.rs
@@ -46,16 +46,14 @@ impl<S: Scope, D: Data> Branch<S, D> for Stream<S, D> {
         let (mut output2, stream2) = builder.new_output();
 
         builder.build(move |_| {
-            let mut vector = Vec::new();
             move |_frontiers| {
                 let mut output1_handle = output1.activate();
                 let mut output2_handle = output2.activate();
 
                 input.for_each(|time, data| {
-                    data.swap(&mut vector);
                     let mut out1 = output1_handle.session(&time);
                     let mut out2 = output2_handle.session(&time);
-                    for datum in vector.drain(..) {
+                    for datum in data.drain(..) {
                         if condition(&time.time(), &datum) {
                             out2.give(datum);
                         } else {
@@ -104,19 +102,17 @@ impl<S: Scope, C: Container> BranchWhen<S::Timestamp> for StreamCore<S, C> {
 
         builder.build(move |_| {
 
-            let mut container = Default::default();
             move |_frontiers| {
                 let mut output1_handle = output1.activate();
                 let mut output2_handle = output2.activate();
 
                 input.for_each(|time, data| {
-                    data.swap(&mut container);
                     let mut out = if condition(&time.time()) {
                         output2_handle.session(&time)
                     } else {
                         output1_handle.session(&time)
                     };
-                    out.give_container(&mut container);
+                    out.give_container(data);
                 });
             }
         });

--- a/timely/src/dataflow/operators/capability.rs
+++ b/timely/src/dataflow/operators/capability.rs
@@ -415,11 +415,9 @@ impl<T: Timestamp> CapabilitySet<T> {
     ///     vec![()].into_iter().to_stream(scope)
     ///         .unary_frontier(Pipeline, "example", |default_cap, _info| {
     ///             let mut cap = CapabilitySet::from_elem(default_cap);
-    ///             let mut vector = Vec::new();
     ///             move |input, output| {
     ///                 cap.downgrade(&input.frontier().frontier());
     ///                 while let Some((time, data)) = input.next() {
-    ///                     data.swap(&mut vector);
     ///                 }
     ///                 let a_cap = cap.first();
     ///                 if let Some(a_cap) = a_cap.as_ref() {

--- a/timely/src/dataflow/operators/core/capture/capture.rs
+++ b/timely/src/dataflow/operators/core/capture/capture.rs
@@ -139,7 +139,6 @@ impl<S: Scope, C: Container> Capture<S::Timestamp, C> for StreamCore<S, C> {
                 // turn each received message into an event.
                 while let Some(message) = input.next() {
                     let (time, data) = match message.as_ref_or_mut() {
-                        RefOrMut::Ref(reference) => (&reference.time, RefOrMut::Ref(&reference.data)),
                         RefOrMut::Mut(reference) => (&reference.time, RefOrMut::Mut(&mut reference.data)),
                     };
                     let vector = data.replace(Default::default());

--- a/timely/src/dataflow/operators/core/capture/capture.rs
+++ b/timely/src/dataflow/operators/core/capture/capture.rs
@@ -134,14 +134,12 @@ impl<S: Scope, C: Container> Capture<S::Timestamp, C> for StreamCore<S, C> {
                     event_pusher.push(Event::Progress(to_send.into_inner().to_vec()));
                 }
 
-                use crate::communication::message::RefOrMut;
-
                 // turn each received message into an event.
                 while let Some(message) = input.next() {
-                    let (time, data) = match message.as_ref_or_mut() {
-                        RefOrMut::Mut(reference) => (&reference.time, RefOrMut::Mut(&mut reference.data)),
-                    };
-                    let vector = data.replace(Default::default());
+                    let reference = message.as_mut();
+                    let time = &reference.time;
+                    let data = &mut reference.data;
+                    let vector = std::mem::take(data);
                     event_pusher.push(Event::Messages(time.clone(), vector));
                 }
                 input.consumed().borrow_mut().drain_into(&mut progress.consumeds[0]);

--- a/timely/src/dataflow/operators/core/capture/capture.rs
+++ b/timely/src/dataflow/operators/core/capture/capture.rs
@@ -136,9 +136,8 @@ impl<S: Scope, C: Container> Capture<S::Timestamp, C> for StreamCore<S, C> {
 
                 // turn each received message into an event.
                 while let Some(message) = input.next() {
-                    let reference = message.as_mut();
-                    let time = &reference.time;
-                    let data = &mut reference.data;
+                    let time = &message.payload.time;
+                    let data = &mut message.payload.data;
                     let vector = std::mem::take(data);
                     event_pusher.push(Event::Messages(time.clone(), vector));
                 }

--- a/timely/src/dataflow/operators/core/concat.rs
+++ b/timely/src/dataflow/operators/core/concat.rs
@@ -81,13 +81,11 @@ impl<G: Scope, C: Container> Concatenate<G, C> for G {
         // build an operator that plays out all input data.
         builder.build(move |_capability| {
 
-            let mut vector = Default::default();
             move |_frontier| {
                 let mut output = output.activate();
                 for handle in handles.iter_mut() {
                     handle.for_each(|time, data| {
-                        data.swap(&mut vector);
-                        output.session(&time).give_container(&mut vector);
+                        output.session(&time).give_container(data);
                     })
                 }
             }

--- a/timely/src/dataflow/operators/core/enterleave.rs
+++ b/timely/src/dataflow/operators/core/enterleave.rs
@@ -140,14 +140,12 @@ struct IngressNub<TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TContain
 impl<TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TContainer: Container> Push<Bundle<TOuter, TContainer>> for IngressNub<TOuter, TInner, TContainer> {
     fn push(&mut self, element: &mut Option<Bundle<TOuter, TContainer>>) {
         if let Some(message) = element {
-            let outer_message = message.as_mut();
+            let outer_message = &mut message.payload;
             let data = ::std::mem::take(&mut outer_message.data);
             let mut inner_message = Some(Bundle::from_typed(Message::new(TInner::to_inner(outer_message.time.clone()), data, 0, 0)));
             self.targets.push(&mut inner_message);
             if let Some(inner_message) = inner_message {
-                if let Some(inner_message) = inner_message.if_typed() {
-                    outer_message.data = inner_message.data;
-                }
+                outer_message.data = inner_message.payload.data;
             }
             self.active = true;
         }
@@ -171,14 +169,12 @@ impl<TOuter, TInner, TContainer: Container> Push<Bundle<TInner, TContainer>> for
 where TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, TContainer: Data {
     fn push(&mut self, message: &mut Option<Bundle<TInner, TContainer>>) {
         if let Some(message) = message {
-            let inner_message = message.as_mut();
+            let inner_message = &mut message.payload;
             let data = ::std::mem::take(&mut inner_message.data);
             let mut outer_message = Some(Bundle::from_typed(Message::new(inner_message.time.clone().to_outer(), data, 0, 0)));
             self.targets.push(&mut outer_message);
             if let Some(outer_message) = outer_message {
-                if let Some(outer_message) = outer_message.if_typed() {
-                    inner_message.data = outer_message.data;
-                }
+                inner_message.data = outer_message.payload.data;
             }
         }
         else { self.targets.done(); }

--- a/timely/src/dataflow/operators/core/exchange.rs
+++ b/timely/src/dataflow/operators/core/exchange.rs
@@ -36,12 +36,10 @@ where
     where
         for<'a> F: FnMut(&C::Item<'a>) -> u64,
     {
-        let mut container = Default::default();
         self.unary(ExchangeCore::new(route), "Exchange", |_, _| {
             move |input, output| {
                 input.for_each(|time, data| {
-                    data.swap(&mut container);
-                    output.session(&time).give_container(&mut container);
+                    output.session(&time).give_container(data);
                 });
             }
         })

--- a/timely/src/dataflow/operators/core/feedback.rs
+++ b/timely/src/dataflow/operators/core/feedback.rs
@@ -115,16 +115,14 @@ impl<G: Scope, C: Container> ConnectLoop<G, C> for StreamCore<G, C> {
 
         let mut input = builder.new_input_connection(self, Pipeline, vec![Antichain::from_elem(summary.clone())]);
 
-        let mut vector = Default::default();
         builder.build(move |_capability| move |_frontier| {
             let mut output = output.activate();
             input.for_each(|cap, data| {
-                data.swap(&mut vector);
                 if let Some(new_time) = summary.results_in(cap.time()) {
                     let new_cap = cap.delayed(&new_time);
                     output
                         .session(&new_cap)
-                        .give_container(&mut vector);
+                        .give_container(data);
                 }
             });
         });

--- a/timely/src/dataflow/operators/core/filter.rs
+++ b/timely/src/dataflow/operators/core/filter.rs
@@ -27,12 +27,10 @@ where
     for<'a> C: PushInto<C::Item<'a>>
 {
     fn filter<P: FnMut(&C::Item<'_>)->bool+'static>(&self, mut predicate: P) -> StreamCore<G, C> {
-        let mut container = Default::default();
         self.unary(Pipeline, "Filter", move |_,_| move |input, output| {
             input.for_each(|time, data| {
-                data.swap(&mut container);
-                if !container.is_empty() {
-                    output.session(&time).give_iterator(container.drain().filter(&mut predicate));
+                if !data.is_empty() {
+                    output.session(&time).give_iterator(data.drain().filter(&mut predicate));
                 }
             });
         })

--- a/timely/src/dataflow/operators/core/inspect.rs
+++ b/timely/src/dataflow/operators/core/inspect.rs
@@ -127,7 +127,6 @@ impl<G: Scope, C: Container> InspectCore<G, C> for StreamCore<G, C> {
     {
         use crate::progress::timestamp::Timestamp;
         let mut frontier = crate::progress::Antichain::from_elem(G::Timestamp::minimum());
-        let mut vector = Default::default();
         self.unary_frontier(Pipeline, "InspectBatch", move |_,_| move |input, output| {
             if input.frontier.frontier() != frontier.borrow() {
                 frontier.clear();
@@ -135,9 +134,8 @@ impl<G: Scope, C: Container> InspectCore<G, C> for StreamCore<G, C> {
                 func(Err(frontier.elements()));
             }
             input.for_each(|time, data| {
-                data.swap(&mut vector);
-                func(Ok((&time, &vector)));
-                output.session(&time).give_container(&mut vector);
+                func(Ok((&time, &*data)));
+                output.session(&time).give_container(data);
             });
         })
     }

--- a/timely/src/dataflow/operators/core/map.rs
+++ b/timely/src/dataflow/operators/core/map.rs
@@ -60,11 +60,9 @@ impl<S: Scope, C: Container> Map<S, C> for StreamCore<S, C> {
         C2: SizableContainer + PushInto<I::Item>,
         L: FnMut(C::Item<'_>)->I + 'static,
     {
-        let mut container = Default::default();
         self.unary(Pipeline, "FlatMap", move |_,_| move |input, output| {
             input.for_each(|time, data| {
-                data.swap(&mut container);
-                output.session(&time).give_iterator(container.drain().flat_map(&mut logic));
+                output.session(&time).give_iterator(data.drain().flat_map(&mut logic));
             });
         })
     }

--- a/timely/src/dataflow/operators/core/ok_err.rs
+++ b/timely/src/dataflow/operators/core/ok_err.rs
@@ -55,16 +55,14 @@ impl<S: Scope, C: Container> OkErr<S, C> for StreamCore<S, C> {
         let (mut output2, stream2) = builder.new_output();
 
         builder.build(move |_| {
-            let mut container = Default::default();
             move |_frontiers| {
                 let mut output1_handle = output1.activate();
                 let mut output2_handle = output2.activate();
 
                 input.for_each(|time, data| {
-                    data.swap(&mut container);
                     let mut out1 = output1_handle.session(&time);
                     let mut out2 = output2_handle.session(&time);
-                    for datum in container.drain() {
+                    for datum in data.drain() {
                         match logic(datum) {
                             Ok(datum) => out1.give(datum),
                             Err(datum) => out2.give(datum),

--- a/timely/src/dataflow/operators/core/probe.rs
+++ b/timely/src/dataflow/operators/core/probe.rs
@@ -113,9 +113,8 @@ impl<G: Scope, C: Container> Probe<G, C> for StreamCore<G, C> {
                 }
 
                 while let Some(message) = input.next() {
-                    let reference = message.as_mut();
-                    let time = &reference.time;
-                    let data = &mut reference.data;
+                    let time = &message.payload.time;
+                    let data = &mut message.payload.data;
                     output.session(time).give_container(data);
                 }
                 output.cease();

--- a/timely/src/dataflow/operators/core/probe.rs
+++ b/timely/src/dataflow/operators/core/probe.rs
@@ -118,7 +118,6 @@ impl<G: Scope, C: Container> Probe<G, C> for StreamCore<G, C> {
 
                 while let Some(message) = input.next() {
                     let (time, data) = match message.as_ref_or_mut() {
-                        RefOrMut::Ref(reference) => (&reference.time, RefOrMut::Ref(&reference.data)),
                         RefOrMut::Mut(reference) => (&reference.time, RefOrMut::Mut(&mut reference.data)),
                     };
                     data.swap(&mut vector);

--- a/timely/src/dataflow/operators/core/rc.rs
+++ b/timely/src/dataflow/operators/core/rc.rs
@@ -26,14 +26,12 @@ pub trait SharedStream<S: Scope, C: Container> {
 
 impl<S: Scope, C: Container> SharedStream<S, C> for StreamCore<S, C> {
     fn shared(&self) -> StreamCore<S, Rc<C>> {
-        let mut container = Default::default();
         self.unary(Pipeline, "Shared", move |_, _| {
             move |input, output| {
                 input.for_each(|time, data| {
-                    data.swap(&mut container);
                     output
                         .session(&time)
-                        .give_container(&mut Rc::new(std::mem::take(&mut container)));
+                        .give_container(&mut Rc::new(std::mem::take(data)));
                 });
             }
         })
@@ -54,20 +52,16 @@ mod test {
             scope
                 .concatenate([
                     shared.unary(Pipeline, "read shared 1", |_, _| {
-                        let mut container = Default::default();
                         move |input, output| {
                             input.for_each(|time, data| {
-                                data.swap(&mut container);
-                                output.session(&time).give(container.as_ptr() as usize);
+                                output.session(&time).give(data.as_ptr() as usize);
                             });
                         }
                     }),
                     shared.unary(Pipeline, "read shared 2", |_, _| {
-                        let mut container = Default::default();
                         move |input, output| {
                             input.for_each(|time, data| {
-                                data.swap(&mut container);
-                                output.session(&time).give(container.as_ptr() as usize);
+                                output.session(&time).give(data.as_ptr() as usize);
                             });
                         }
                     }),

--- a/timely/src/dataflow/operators/core/reclock.rs
+++ b/timely/src/dataflow/operators/core/reclock.rs
@@ -57,7 +57,7 @@ impl<S: Scope, C: Container> Reclock<S> for StreamCore<S, C> {
 
             // stash each data input with its timestamp.
             input1.for_each(|cap, data| {
-                stash.push((cap.time().clone(), data.replace(Default::default())));
+                stash.push((cap.time().clone(), std::mem::take(data)));
             });
 
             // request notification at time, to flush stash.

--- a/timely/src/dataflow/operators/count.rs
+++ b/timely/src/dataflow/operators/count.rs
@@ -1,8 +1,6 @@
 //! Counts the number of records at each time.
 use std::collections::HashMap;
 
-use crate::communication::message::RefOrMut;
-
 use crate::Data;
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::{Stream, Scope};
@@ -27,7 +25,7 @@ pub trait Accumulate<G: Scope, D: Data> {
     /// let extracted = captured.extract();
     /// assert_eq!(extracted, vec![(0, vec![45])]);
     /// ```
-    fn accumulate<A: Data>(&self, default: A, logic: impl Fn(&mut A, RefOrMut<Vec<D>>)+'static) -> Stream<G, A>;
+    fn accumulate<A: Data>(&self, default: A, logic: impl Fn(&mut A, &mut Vec<D>)+'static) -> Stream<G, A>;
     /// Counts the number of records observed at each time.
     ///
     /// # Examples
@@ -51,7 +49,7 @@ pub trait Accumulate<G: Scope, D: Data> {
 }
 
 impl<G: Scope, D: Data> Accumulate<G, D> for Stream<G, D> {
-    fn accumulate<A: Data>(&self, default: A, logic: impl Fn(&mut A, RefOrMut<Vec<D>>)+'static) -> Stream<G, A> {
+    fn accumulate<A: Data>(&self, default: A, logic: impl Fn(&mut A, &mut Vec<D>)+'static) -> Stream<G, A> {
 
         let mut accums = HashMap::new();
         self.unary_notify(Pipeline, "Accumulate", vec![], move |input, output, notificator| {

--- a/timely/src/dataflow/operators/delay.rs
+++ b/timely/src/dataflow/operators/delay.rs
@@ -97,11 +97,9 @@ pub trait Delay<G: Scope, D: Data> {
 impl<G: Scope, D: Data> Delay<G, D> for Stream<G, D> {
     fn delay<L: FnMut(&D, &G::Timestamp)->G::Timestamp+'static>(&self, mut func: L) -> Self {
         let mut elements = HashMap::new();
-        let mut vector = Vec::new();
         self.unary_notify(Pipeline, "Delay", vec![], move |input, output, notificator| {
             input.for_each(|time, data| {
-                data.swap(&mut vector);
-                for datum in vector.drain(..) {
+                for datum in data.drain(..) {
                     let new_time = func(&datum, &time);
                     assert!(time.time().less_equal(&new_time));
                     elements.entry(new_time.clone())
@@ -133,7 +131,7 @@ impl<G: Scope, D: Data> Delay<G, D> for Stream<G, D> {
                 assert!(time.time().less_equal(&new_time));
                 elements.entry(new_time.clone())
                         .or_insert_with(|| { notificator.notify_at(time.delayed(&new_time)); Vec::new() })
-                        .push(data.replace(Vec::new()));
+                        .push(std::mem::take(data));
             });
 
             // for each available notification, send corresponding set

--- a/timely/src/dataflow/operators/filter.rs
+++ b/timely/src/dataflow/operators/filter.rs
@@ -24,13 +24,11 @@ pub trait Filter<D: Data> {
 
 impl<G: Scope, D: Data> Filter<D> for Stream<G, D> {
     fn filter<P: FnMut(&D)->bool+'static>(&self, mut predicate: P) -> Stream<G, D> {
-        let mut vector = Vec::new();
         self.unary(Pipeline, "Filter", move |_,_| move |input, output| {
             input.for_each(|time, data| {
-                data.swap(&mut vector);
-                vector.retain(|x| predicate(x));
-                if !vector.is_empty() {
-                    output.session(&time).give_container(&mut vector);
+                data.retain(|x| predicate(x));
+                if !data.is_empty() {
+                    output.session(&time).give_container(data);
                 }
             });
         })

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -58,8 +58,7 @@ impl<'a, T: Timestamp, C: Container, P: Pull<Bundle<T, C>>> InputHandleCore<T, C
         let internal = &self.internal;
         let summaries = &self.summaries;
         self.pull_counter.next_guarded().map(|(guard, bundle)| {
-            let bundle = bundle.as_mut();
-            (InputCapability::new(internal.clone(), summaries.clone(), guard), &mut bundle.data)
+            (InputCapability::new(internal.clone(), summaries.clone(), guard), &mut bundle.payload.data)
         })
     }
 

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -14,7 +14,7 @@ use crate::dataflow::channels::pullers::Counter as PullCounter;
 use crate::dataflow::channels::pushers::Counter as PushCounter;
 use crate::dataflow::channels::pushers::buffer::{Buffer, Session};
 use crate::dataflow::channels::Bundle;
-use crate::communication::{Push, Pull, message::RefOrMut};
+use crate::communication::{Push, Pull};
 use crate::Container;
 use crate::container::{ContainerBuilder, CapacityContainerBuilder};
 use crate::logging::TimelyLogger as Logger;
@@ -54,15 +54,12 @@ impl<'a, T: Timestamp, C: Container, P: Pull<Bundle<T, C>>> InputHandleCore<T, C
     /// The timestamp `t` of the input buffer can be retrieved by invoking `.time()` on the capability.
     /// Returns `None` when there's no more data available.
     #[inline]
-    pub fn next(&mut self) -> Option<(InputCapability<T>, RefOrMut<C>)> {
+    pub fn next(&mut self) -> Option<(InputCapability<T>, &mut C)> {
         let internal = &self.internal;
         let summaries = &self.summaries;
         self.pull_counter.next_guarded().map(|(guard, bundle)| {
-            match bundle.as_ref_or_mut() {
-                RefOrMut::Mut(bundle) => {
-                    (InputCapability::new(internal.clone(), summaries.clone(), guard), RefOrMut::Mut(&mut bundle.data))
-                },
-            }
+            let bundle = bundle.as_mut();
+            (InputCapability::new(internal.clone(), summaries.clone(), guard), &mut bundle.data)
         })
     }
 
@@ -79,13 +76,13 @@ impl<'a, T: Timestamp, C: Container, P: Pull<Bundle<T, C>>> InputHandleCore<T, C
     ///     (0..10).to_stream(scope)
     ///            .unary(Pipeline, "example", |_cap, _info| |input, output| {
     ///                input.for_each(|cap, data| {
-    ///                    output.session(&cap).give_container(&mut data.replace(Vec::new()));
+    ///                    output.session(&cap).give_container(data);
     ///                });
     ///            });
     /// });
     /// ```
     #[inline]
-    pub fn for_each<F: FnMut(InputCapability<T>, RefOrMut<C>)>(&mut self, mut logic: F) {
+    pub fn for_each<F: FnMut(InputCapability<T>, &mut C)>(&mut self, mut logic: F) {
         let mut logging = self.logging.take();
         while let Some((cap, data)) = self.next() {
             logging.as_mut().map(|l| l.log(crate::logging::GuardedMessageEvent { is_start: true }));
@@ -110,7 +107,7 @@ impl<'a, T: Timestamp, C: Container, P: Pull<Bundle<T, C>>+'a> FrontieredInputHa
     /// The timestamp `t` of the input buffer can be retrieved by invoking `.time()` on the capability.
     /// Returns `None` when there's no more data available.
     #[inline]
-    pub fn next(&mut self) -> Option<(InputCapability<T>, RefOrMut<C>)> {
+    pub fn next(&mut self) -> Option<(InputCapability<T>, &mut C)> {
         self.handle.next()
     }
 
@@ -127,13 +124,13 @@ impl<'a, T: Timestamp, C: Container, P: Pull<Bundle<T, C>>+'a> FrontieredInputHa
     ///     (0..10).to_stream(scope)
     ///            .unary(Pipeline, "example", |_cap,_info| |input, output| {
     ///                input.for_each(|cap, data| {
-    ///                    output.session(&cap).give_container(&mut data.replace(Vec::new()));
+    ///                    output.session(&cap).give_container(data);
     ///                });
     ///            });
     /// });
     /// ```
     #[inline]
-    pub fn for_each<F: FnMut(InputCapability<T>, RefOrMut<C>)>(&mut self, logic: F) {
+    pub fn for_each<F: FnMut(InputCapability<T>, &mut C)>(&mut self, logic: F) {
         self.handle.for_each(logic)
     }
 
@@ -223,7 +220,7 @@ impl<'a, T: Timestamp, CB: ContainerBuilder, P: Push<Bundle<T, CB::Container>>> 
     ///                input.for_each(|cap, data| {
     ///                    let time = cap.time().clone() + 1;
     ///                    output.session_with_builder(&cap.delayed(&time))
-    ///                          .give_container(&mut data.replace(Vec::new()));
+    ///                          .give_container(data);
     ///                });
     ///            });
     /// });
@@ -257,7 +254,7 @@ impl<'a, T: Timestamp, C: Container, P: Push<Bundle<T, C>>> OutputHandleCore<'a,
     ///                input.for_each(|cap, data| {
     ///                    let time = cap.time().clone() + 1;
     ///                    output.session(&cap.delayed(&time))
-    ///                          .give_container(&mut data.replace(Vec::new()));
+    ///                          .give_container(data);
     ///                });
     ///            });
     /// });

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -59,9 +59,6 @@ impl<'a, T: Timestamp, C: Container, P: Pull<Bundle<T, C>>> InputHandleCore<T, C
         let summaries = &self.summaries;
         self.pull_counter.next_guarded().map(|(guard, bundle)| {
             match bundle.as_ref_or_mut() {
-                RefOrMut::Ref(bundle) => {
-                    (InputCapability::new(internal.clone(), summaries.clone(), guard), RefOrMut::Ref(&bundle.data))
-                },
                 RefOrMut::Mut(bundle) => {
                     (InputCapability::new(internal.clone(), summaries.clone(), guard), RefOrMut::Mut(&mut bundle.data))
                 },

--- a/timely/src/dataflow/operators/generic/notificator.rs
+++ b/timely/src/dataflow/operators/generic/notificator.rs
@@ -59,7 +59,7 @@ impl<'a, T: Timestamp> Notificator<'a, T> {
     ///     (0..10).to_stream(scope)
     ///            .unary_notify(Pipeline, "example", Some(0), |input, output, notificator| {
     ///                input.for_each(|cap, data| {
-    ///                    output.session(&cap).give_container(&mut data.replace(Vec::new()));
+    ///                    output.session(&cap).give_container(data);
     ///                    let time = cap.time().clone() + 1;
     ///                    notificator.notify_at(cap.delayed(&time));
     ///                });
@@ -198,17 +198,13 @@ fn notificator_delivers_notifications_in_topo_order() {
 ///         in1.binary_frontier(&in2, Pipeline, Pipeline, "example", |mut _default_cap, _info| {
 ///             let mut notificator = FrontierNotificator::new();
 ///             let mut stash = HashMap::new();
-///             let mut vector1 = Vec::new();
-///             let mut vector2 = Vec::new();
 ///             move |input1, input2, output| {
 ///                 while let Some((time, data)) = input1.next() {
-///                     data.swap(&mut vector1);
-///                     stash.entry(time.time().clone()).or_insert(Vec::new()).extend(vector1.drain(..));
+///                     stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.drain(..));
 ///                     notificator.notify_at(time.retain());
 ///                 }
 ///                 while let Some((time, data)) = input2.next() {
-///                     data.swap(&mut vector2);
-///                     stash.entry(time.time().clone()).or_insert(Vec::new()).extend(vector2.drain(..));
+///                     stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.drain(..));
 ///                     notificator.notify_at(time.retain());
 ///                 }
 ///                 notificator.for_each(&[input1.frontier(), input2.frontier()], |time, _| {
@@ -275,7 +271,7 @@ impl<T: Timestamp> FrontierNotificator<T> {
     ///                let mut notificator = FrontierNotificator::new();
     ///                move |input, output| {
     ///                    input.for_each(|cap, data| {
-    ///                        output.session(&cap).give_container(&mut data.replace(Vec::new()));
+    ///                        output.session(&cap).give_container(data);
     ///                        let time = cap.time().clone() + 1;
     ///                        notificator.notify_at(cap.delayed(&time));
     ///                    });
@@ -405,7 +401,7 @@ impl<T: Timestamp> FrontierNotificator<T> {
     ///                let mut notificator = FrontierNotificator::new();
     ///                move |input, output| {
     ///                    input.for_each(|cap, data| {
-    ///                        output.session(&cap).give_container(&mut data.replace(Vec::new()));
+    ///                        output.session(&cap).give_container(data);
     ///                        let time = cap.time().clone() + 1;
     ///                        notificator.notify_at(cap.delayed(&time));
     ///                        assert_eq!(notificator.pending().filter(|t| t.0.time() == &time).count(), 1);

--- a/timely/src/dataflow/operators/generic/operator.rs
+++ b/timely/src/dataflow/operators/generic/operator.rs
@@ -35,16 +35,14 @@ pub trait Operator<G: Scope, C1: Container> {
     ///                 let mut cap = Some(default_cap.delayed(&12));
     ///                 let mut notificator = FrontierNotificator::new();
     ///                 let mut stash = HashMap::new();
-    ///                 let mut vector = Vec::new();
     ///                 move |input, output| {
     ///                     if let Some(ref c) = cap.take() {
     ///                         output.session(&c).give(12);
     ///                     }
     ///                     while let Some((time, data)) = input.next() {
-    ///                         data.swap(&mut vector);
     ///                         stash.entry(time.time().clone())
     ///                              .or_insert(Vec::new())
-    ///                              .extend(vector.drain(..));
+    ///                              .extend(data.drain(..));
     ///                     }
     ///                     notificator.for_each(&[input.frontier()], |time, _not| {
     ///                         if let Some(mut vec) = stash.remove(time.time()) {
@@ -78,13 +76,11 @@ pub trait Operator<G: Scope, C1: Container> {
     ///
     /// fn main() {
     ///     timely::example(|scope| {
-    ///         let mut vector = Vec::new();
     ///         (0u64..10)
     ///             .to_stream(scope)
     ///             .unary_notify(Pipeline, "example", None, move |input, output, notificator| {
     ///                 input.for_each(|time, data| {
-    ///                     data.swap(&mut vector);
-    ///                     output.session(&time).give_container(&mut vector);
+    ///                     output.session(&time).give_container(data);
     ///                     notificator.notify_at(time.retain());
     ///                 });
     ///                 notificator.for_each(|time, _cnt, _not| {
@@ -116,14 +112,12 @@ pub trait Operator<G: Scope, C1: Container> {
     ///     (0u64..10).to_stream(scope)
     ///         .unary(Pipeline, "example", |default_cap, _info| {
     ///             let mut cap = Some(default_cap.delayed(&12));
-    ///             let mut vector = Vec::new();
     ///             move |input, output| {
     ///                 if let Some(ref c) = cap.take() {
     ///                     output.session(&c).give(100);
     ///                 }
     ///                 while let Some((time, data)) = input.next() {
-    ///                     data.swap(&mut vector);
-    ///                     output.session(&time).give_container(&mut vector);
+    ///                     output.session(&time).give_container(data);
     ///                 }
     ///             }
     ///         });
@@ -155,17 +149,13 @@ pub trait Operator<G: Scope, C1: Container> {
     ///        in1.binary_frontier(&in2, Pipeline, Pipeline, "example", |mut _default_cap, _info| {
     ///            let mut notificator = FrontierNotificator::new();
     ///            let mut stash = HashMap::new();
-    ///            let mut vector1 = Vec::new();
-    ///            let mut vector2 = Vec::new();
     ///            move |input1, input2, output| {
     ///                while let Some((time, data)) = input1.next() {
-    ///                    data.swap(&mut vector1);
-    ///                    stash.entry(time.time().clone()).or_insert(Vec::new()).extend(vector1.drain(..));
+    ///                    stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.drain(..));
     ///                    notificator.notify_at(time.retain());
     ///                }
     ///                while let Some((time, data)) = input2.next() {
-    ///                    data.swap(&mut vector2);
-    ///                    stash.entry(time.time().clone()).or_insert(Vec::new()).extend(vector2.drain(..));
+    ///                    stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.drain(..));
     ///                    notificator.notify_at(time.retain());
     ///                }
     ///                notificator.for_each(&[input1.frontier(), input2.frontier()], |time, _not| {
@@ -216,17 +206,13 @@ pub trait Operator<G: Scope, C1: Container> {
     ///        let (in1_handle, in1) = scope.new_input();
     ///        let (in2_handle, in2) = scope.new_input();
     ///
-    ///        let mut vector1 = Vec::new();
-    ///        let mut vector2 = Vec::new();
     ///        in1.binary_notify(&in2, Pipeline, Pipeline, "example", None, move |input1, input2, output, notificator| {
     ///            input1.for_each(|time, data| {
-    ///                data.swap(&mut vector1);
-    ///                output.session(&time).give_container(&mut vector1);
+    ///                output.session(&time).give_container(data);
     ///                notificator.notify_at(time.retain());
     ///            });
     ///            input2.for_each(|time, data| {
-    ///                data.swap(&mut vector2);
-    ///                output.session(&time).give_container(&mut vector2);
+    ///                output.session(&time).give_container(data);
     ///                notificator.notify_at(time.retain());
     ///            });
     ///            notificator.for_each(|time, _cnt, _not| {
@@ -271,19 +257,15 @@ pub trait Operator<G: Scope, C1: Container> {
     ///     (0u64..10).to_stream(scope)
     ///         .binary(&stream2, Pipeline, Pipeline, "example", |default_cap, _info| {
     ///             let mut cap = Some(default_cap.delayed(&12));
-    ///             let mut vector1 = Vec::new();
-    ///             let mut vector2 = Vec::new();
     ///             move |input1, input2, output| {
     ///                 if let Some(ref c) = cap.take() {
     ///                     output.session(&c).give(100);
     ///                 }
     ///                 while let Some((time, data)) = input1.next() {
-    ///                     data.swap(&mut vector1);
-    ///                     output.session(&time).give_container(&mut vector1);
+    ///                     output.session(&time).give_container(data);
     ///                 }
     ///                 while let Some((time, data)) = input2.next() {
-    ///                     data.swap(&mut vector2);
-    ///                     output.session(&time).give_container(&mut vector2);
+    ///                     output.session(&time).give_container(data);
     ///                 }
     ///             }
     ///         }).inspect(|x| println!("{:?}", x));

--- a/timely/src/dataflow/operators/map.rs
+++ b/timely/src/dataflow/operators/map.rs
@@ -53,12 +53,10 @@ pub trait Map<S: Scope, D: Data> {
 
 impl<S: Scope, D: Data> Map<S, D> for Stream<S, D> {
     fn map_in_place<L: FnMut(&mut D)+'static>(&self, mut logic: L) -> Stream<S, D> {
-        let mut vector = Vec::new();
         self.unary(Pipeline, "MapInPlace", move |_,_| move |input, output| {
             input.for_each(|time, data| {
-                data.swap(&mut vector);
-                for datum in vector.iter_mut() { logic(datum); }
-                output.session(&time).give_container(&mut vector);
+                for datum in data.iter_mut() { logic(datum); }
+                output.session(&time).give_container(data);
             })
         })
     }

--- a/timely/src/dataflow/operators/partition.rs
+++ b/timely/src/dataflow/operators/partition.rs
@@ -40,14 +40,12 @@ impl<G: Scope, D: Data, D2: Data, F: Fn(D)->(u64, D2)+'static> Partition<G, D, D
         }
 
         builder.build(move |_| {
-            let mut vector = Vec::new();
             move |_frontiers| {
                 let mut handles = outputs.iter_mut().map(|o| o.activate()).collect::<Vec<_>>();
                 input.for_each(|time, data| {
-                    data.swap(&mut vector);
                     let mut sessions = handles.iter_mut().map(|h| h.session(&time)).collect::<Vec<_>>();
 
-                    for datum in vector.drain(..) {
+                    for datum in data.drain(..) {
                         let (part, datum2) = route(datum);
                         sessions[part as usize].give(datum2);
                     }

--- a/timely/src/progress/broadcast.rs
+++ b/timely/src/progress/broadcast.rs
@@ -93,10 +93,10 @@ impl<T:Timestamp+Send> Progcaster<T> {
 
                 // Attempt to reuse allocations, if possible.
                 if let Some(tuple) = &mut self.to_push {
-                    let tuple = tuple.as_mut();
-                    tuple.0 = self.source;
-                    tuple.1 = self.counter;
-                    tuple.2.clear(); tuple.2.extend(changes.iter().cloned());
+                    tuple.payload.0 = self.source;
+                    tuple.payload.1 = self.counter;
+                    tuple.payload.2.clear(); 
+                    tuple.payload.2.extend(changes.iter().cloned());
                 }
                 // If we don't have an allocation ...
                 if self.to_push.is_none() {

--- a/timely/src/synchronization/sequence.rs
+++ b/timely/src/synchronization/sequence.rs
@@ -116,7 +116,6 @@ impl<T: ExchangeData> Sequencer<T> {
             let peers = dataflow.peers();
 
             let mut recvd = Vec::new();
-            let mut vector = Vec::new();
 
             // monotonic counter to maintain per-worker total order.
             let mut counter = 0;
@@ -178,10 +177,8 @@ impl<T: ExchangeData> Sequencer<T> {
 
                     // grab each command and queue it up
                     input.for_each(|time, data| {
-                        data.swap(&mut vector);
-
-                        recvd.reserve(vector.len());
-                        for (worker, counter, element) in vector.drain(..) {
+                        recvd.reserve(data.len());
+                        for (worker, counter, element) in data.drain(..) {
                             recvd.push(((time.time().clone(), worker, counter), element));
                         }
                     });

--- a/timely/tests/gh_523.rs
+++ b/timely/tests/gh_523.rs
@@ -7,17 +7,15 @@ use timely::Config;
 fn gh_523() {
     timely::execute(Config::thread(), |worker| {
         let mut input = InputHandle::new();
-        let mut buf = Vec::new();
         let probe = worker.dataflow::<u64, _, _>(|scope| {
             scope
                 .input_from(&mut input)
                 .unary(Pipeline, "Test", move |_, _| {
                     move |input, output| {
                         input.for_each(|cap, data| {
-                            data.swap(&mut buf);
                             let mut session = output.session(&cap);
                             session.give_container(&mut Vec::new());
-                            session.give_container(&mut buf);
+                            session.give_container(data);
                         });
                     }
                 })


### PR DESCRIPTION
This PR chases down some simplifications due to the removal of `abomonation`, looking forward to flexibility enabled by containers.

Specifically, the `Message<T>` type has wrapped several ways to present a `T`, including owned and borrowed forms, as well as numerous accessors. All of the borrowed forms have been dead code since the `abomonation` removal, and the attendant complexity unwarranted. This PR removes it.

Going forward, distinctions between owned and borrowed seem best housed in containers, which can themselves resemble `MessageContents<T>` which was the enum that could be owned or borrowed. The `Message<T>` type remains, but seemingly only to support serialization methods, but this behavior could be move into a trait that containers are expected to implement if they are to be used for exchange edges. 