### PR TITLE
Move opinions about encoding from `communication` to `timely`.

### DIFF
--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -18,7 +18,6 @@ default = ["getopts"]
 
 [dependencies]
 getopts = { version = "0.2.21", optional = true }
-bincode = { version = "1.0" }
 byteorder = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 timely_bytes = { path = "../bytes", version = "0.12" }

--- a/communication/examples/comm_hello.rs
+++ b/communication/examples/comm_hello.rs
@@ -1,6 +1,6 @@
 use timely_communication::{Allocate, Bytesable};
 
-/// A wrapper that indicates `bincode` as the serialization/deserialization strategy.
+/// A wrapper that indicates the serialization/deserialization strategy.
 pub struct Message {
     /// Text contents.
     pub payload: String,

--- a/communication/src/allocator/generic.rs
+++ b/communication/src/allocator/generic.rs
@@ -8,11 +8,11 @@ use std::cell::RefCell;
 
 use crate::allocator::thread::ThreadBuilder;
 use crate::allocator::process::ProcessBuilder as TypedProcessBuilder;
-use crate::allocator::{Allocate, AllocateBuilder, Thread, Process};
+use crate::allocator::{Allocate, AllocateBuilder, Exchangeable, Thread, Process};
 use crate::allocator::zero_copy::allocator_process::{ProcessBuilder, ProcessAllocator};
 use crate::allocator::zero_copy::allocator::{TcpBuilder, TcpAllocator};
 
-use crate::{Push, Pull, Data, Message};
+use crate::{Push, Pull};
 
 /// Enumerates known implementors of `Allocate`.
 /// Passes trait method calls on to members.
@@ -47,7 +47,7 @@ impl Generic {
         }
     }
     /// Constructs several send endpoints and one receive endpoint.
-    fn allocate<T: Data>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<Message<T>>>>, Box<dyn Pull<Message<T>>>) {
+    fn allocate<T: Exchangeable>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<T>>>, Box<dyn Pull<T>>) {
         match self {
             Generic::Thread(t) => t.allocate(identifier),
             Generic::Process(p) => p.allocate(identifier),
@@ -86,7 +86,7 @@ impl Generic {
 impl Allocate for Generic {
     fn index(&self) -> usize { self.index() }
     fn peers(&self) -> usize { self.peers() }
-    fn allocate<T: Data>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<Message<T>>>>, Box<dyn Pull<Message<T>>>) {
+    fn allocate<T: Exchangeable>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<T>>>, Box<dyn Pull<T>>) {
         self.allocate(identifier)
     }
 

--- a/communication/src/allocator/mod.rs
+++ b/communication/src/allocator/mod.rs
@@ -85,8 +85,8 @@ pub trait Allocate {
     /// By default, this method uses the thread-local channel constructor
     /// based on a shared `VecDeque` which updates the event queue.
     fn pipeline<T: 'static>(&mut self, identifier: usize) ->
-        (thread::ThreadPusher<Message<T>>,
-         thread::ThreadPuller<Message<T>>)
+        (thread::ThreadPusher<T>,
+         thread::ThreadPuller<T>)
     {
         thread::Thread::new_from(identifier, self.events().clone())
     }

--- a/communication/src/allocator/mod.rs
+++ b/communication/src/allocator/mod.rs
@@ -17,7 +17,7 @@ pub mod counters;
 
 pub mod zero_copy;
 
-use crate::{Push, Pull};
+use crate::{Bytesable, Push, Pull};
 
 /// A proto-allocator, which implements `Send` and can be completed with `build`.
 ///
@@ -33,11 +33,10 @@ pub trait AllocateBuilder : Send {
 }
 
 use std::any::Any;
-use crate::message::Bytesable;
 
 /// A type that can be sent along an allocated channel.
-pub trait Exchangeable : Send+Sync+Any+Bytesable+'static { }
-impl<T: Send+Sync+Any+Bytesable+'static> Exchangeable for T { }
+pub trait Exchangeable : Send+Any+Bytesable+'static { }
+impl<T: Send+Any+Bytesable+'static> Exchangeable for T { }
 
 /// A type capable of allocating channels.
 ///

--- a/communication/src/allocator/mod.rs
+++ b/communication/src/allocator/mod.rs
@@ -35,8 +35,8 @@ pub trait AllocateBuilder : Send {
 use std::any::Any;
 
 /// A type that can be sent along an allocated channel.
-pub trait Exchangeable : Send+Any+Bytesable+'static { }
-impl<T: Send+Any+Bytesable+'static> Exchangeable for T { }
+pub trait Exchangeable : Send+Any+Bytesable { }
+impl<T: Send+Any+Bytesable> Exchangeable for T { }
 
 /// A type capable of allocating channels.
 ///

--- a/communication/src/allocator/process.rs
+++ b/communication/src/allocator/process.rs
@@ -10,7 +10,7 @@ use crossbeam_channel::{Sender, Receiver};
 
 use crate::allocator::thread::{ThreadBuilder};
 use crate::allocator::{Allocate, AllocateBuilder, Thread};
-use crate::{Push, Pull, Message};
+use crate::{Push, Pull};
 use crate::buzzer::Buzzer;
 
 /// An allocator for inter-thread, intra-process communication
@@ -110,7 +110,7 @@ impl Process {
 impl Allocate for Process {
     fn index(&self) -> usize { self.index }
     fn peers(&self) -> usize { self.peers }
-    fn allocate<T: Any+Send+Sync+'static>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<Message<T>>>>, Box<dyn Pull<Message<T>>>) {
+    fn allocate<T: Any+Send+Sync+'static>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<T>>>, Box<dyn Pull<T>>) {
 
         // this is race-y global initialisation of all channels for all workers, performed by the
         // first worker that enters this critical section
@@ -126,7 +126,7 @@ impl Allocate for Process {
                 let mut pushers = Vec::with_capacity(self.peers);
                 let mut pullers = Vec::with_capacity(self.peers);
                 for buzzer in self.buzzers.iter() {
-                    let (s, r): (Sender<Message<T>>, Receiver<Message<T>>) = crossbeam_channel::unbounded();
+                    let (s, r): (Sender<T>, Receiver<T>) = crossbeam_channel::unbounded();
                     // TODO: the buzzer in the pusher may be redundant, because we need to buzz post-counter.
                     pushers.push((Pusher { target: s }, buzzer.clone()));
                     pullers.push(Puller { source: r, current: None });
@@ -142,7 +142,7 @@ impl Allocate for Process {
 
             let vector =
             entry
-                .downcast_mut::<Vec<Option<(Vec<(Pusher<Message<T>>, Buzzer)>, Puller<Message<T>>)>>>()
+                .downcast_mut::<Vec<Option<(Vec<(Pusher<T>, Buzzer)>, Puller<T>)>>>()
                 .expect("failed to correctly cast channel");
 
             let (sends, recv) =
@@ -166,10 +166,10 @@ impl Allocate for Process {
         sends.into_iter()
              .zip(self.counters_send.iter())
              .map(|((s,b), sender)| CountPusher::new(s, identifier, sender.clone(), b))
-             .map(|s| Box::new(s) as Box<dyn Push<super::Message<T>>>)
+             .map(|s| Box::new(s) as Box<dyn Push<T>>)
              .collect::<Vec<_>>();
 
-        let recv = Box::new(CountPuller::new(recv, identifier, self.inner.events().clone())) as Box<dyn Pull<super::Message<T>>>;
+        let recv = Box::new(CountPuller::new(recv, identifier, self.inner.events().clone())) as Box<dyn Pull<T>>;
 
         (sends, recv)
     }

--- a/communication/src/allocator/process.rs
+++ b/communication/src/allocator/process.rs
@@ -110,7 +110,7 @@ impl Process {
 impl Allocate for Process {
     fn index(&self) -> usize { self.index }
     fn peers(&self) -> usize { self.peers }
-    fn allocate<T: Any+Send+'static>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<T>>>, Box<dyn Pull<T>>) {
+    fn allocate<T: Any+Send>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<T>>>, Box<dyn Pull<T>>) {
 
         // this is race-y global initialisation of all channels for all workers, performed by the
         // first worker that enters this critical section

--- a/communication/src/allocator/process.rs
+++ b/communication/src/allocator/process.rs
@@ -110,7 +110,7 @@ impl Process {
 impl Allocate for Process {
     fn index(&self) -> usize { self.index }
     fn peers(&self) -> usize { self.peers }
-    fn allocate<T: Any+Send+Sync+'static>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<T>>>, Box<dyn Pull<T>>) {
+    fn allocate<T: Any+Send+'static>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<T>>>, Box<dyn Pull<T>>) {
 
         // this is race-y global initialisation of all channels for all workers, performed by the
         // first worker that enters this critical section

--- a/communication/src/allocator/thread.rs
+++ b/communication/src/allocator/thread.rs
@@ -62,9 +62,9 @@ impl Thread {
 
     /// Creates a new thread-local channel from an identifier and shared counts.
     pub fn new_from<T: 'static>(identifier: usize, events: Rc<RefCell<Vec<usize>>>)
-        -> (ThreadPusher<Message<T>>, ThreadPuller<Message<T>>)
+        -> (ThreadPusher<T>, ThreadPuller<T>)
     {
-        let shared = Rc::new(RefCell::new((VecDeque::<Message<T>>::new(), VecDeque::<Message<T>>::new())));
+        let shared = Rc::new(RefCell::new((VecDeque::<T>::new(), VecDeque::<T>::new())));
         let pusher = Pusher { target: shared.clone() };
         let pusher = CountPusher::new(pusher, identifier, events.clone());
         let puller = Puller { source: shared, current: None };

--- a/communication/src/allocator/thread.rs
+++ b/communication/src/allocator/thread.rs
@@ -8,7 +8,7 @@ use std::collections::VecDeque;
 use crate::allocator::{Allocate, AllocateBuilder};
 use crate::allocator::counters::Pusher as CountPusher;
 use crate::allocator::counters::Puller as CountPuller;
-use crate::{Push, Pull, Message};
+use crate::{Push, Pull};
 
 /// Builder for single-threaded allocator.
 pub struct ThreadBuilder;
@@ -28,7 +28,7 @@ pub struct Thread {
 impl Allocate for Thread {
     fn index(&self) -> usize { 0 }
     fn peers(&self) -> usize { 1 }
-    fn allocate<T: 'static>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<Message<T>>>>, Box<dyn Pull<Message<T>>>) {
+    fn allocate<T: 'static>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<T>>>, Box<dyn Pull<T>>) {
         let (pusher, puller) = Thread::new_from(identifier, self.events.clone());
         (vec![Box::new(pusher)], Box::new(puller))
     }

--- a/communication/src/allocator/zero_copy/allocator.rs
+++ b/communication/src/allocator/zero_copy/allocator.rs
@@ -8,8 +8,8 @@ use timely_bytes::arc::Bytes;
 
 use crate::networking::MessageHeader;
 
-use crate::{Allocate, Message, Data, Push, Pull};
-use crate::allocator::AllocateBuilder;
+use crate::{Allocate, Push, Pull};
+use crate::allocator::{AllocateBuilder, Exchangeable};
 use crate::allocator::canary::Canary;
 
 use super::bytes_exchange::{BytesPull, SendEndpoint, MergeQueue};
@@ -135,7 +135,7 @@ pub struct TcpAllocator<A: Allocate> {
 impl<A: Allocate> Allocate for TcpAllocator<A> {
     fn index(&self) -> usize { self.index }
     fn peers(&self) -> usize { self.peers }
-    fn allocate<T: Data>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<Message<T>>>>, Box<dyn Pull<Message<T>>>) {
+    fn allocate<T: Exchangeable>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<T>>>, Box<dyn Pull<T>>) {
 
         // Assume and enforce in-order identifier allocation.
         if let Some(bound) = self.channel_id_bound {
@@ -144,7 +144,7 @@ impl<A: Allocate> Allocate for TcpAllocator<A> {
         self.channel_id_bound = Some(identifier);
 
         // Result list of boxed pushers.
-        let mut pushes = Vec::<Box<dyn Push<Message<T>>>>::new();
+        let mut pushes = Vec::<Box<dyn Push<T>>>::new();
 
         // Inner exchange allocations.
         let inner_peers = self.inner.peers();

--- a/communication/src/allocator/zero_copy/allocator_process.rs
+++ b/communication/src/allocator/zero_copy/allocator_process.rs
@@ -9,8 +9,8 @@ use timely_bytes::arc::Bytes;
 
 use crate::networking::MessageHeader;
 
-use crate::{Allocate, Message, Data, Push, Pull};
-use crate::allocator::{AllocateBuilder};
+use crate::{Allocate, Push, Pull};
+use crate::allocator::{AllocateBuilder, Exchangeable};
 use crate::allocator::canary::Canary;
 
 use super::bytes_exchange::{BytesPull, SendEndpoint, MergeQueue};
@@ -119,7 +119,7 @@ pub struct ProcessAllocator {
 impl Allocate for ProcessAllocator {
     fn index(&self) -> usize { self.index }
     fn peers(&self) -> usize { self.peers }
-    fn allocate<T: Data>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<Message<T>>>>, Box<dyn Pull<Message<T>>>) {
+    fn allocate<T: Exchangeable>(&mut self, identifier: usize) -> (Vec<Box<dyn Push<T>>>, Box<dyn Pull<T>>) {
 
         // Assume and enforce in-order identifier allocation.
         if let Some(bound) = self.channel_id_bound {
@@ -127,7 +127,7 @@ impl Allocate for ProcessAllocator {
         }
         self.channel_id_bound = Some(identifier);
 
-        let mut pushes = Vec::<Box<dyn Push<Message<T>>>>::with_capacity(self.peers());
+        let mut pushes = Vec::<Box<dyn Push<T>>>::with_capacity(self.peers());
 
         for target_index in 0 .. self.peers() {
 

--- a/communication/src/allocator/zero_copy/push_pull.rs
+++ b/communication/src/allocator/zero_copy/push_pull.rs
@@ -11,7 +11,7 @@ use crate::networking::MessageHeader;
 
 use crate::{Data, Push, Pull};
 use crate::allocator::Message;
-
+use crate::message::Bytesable;
 use super::bytes_exchange::{BytesPush, SendEndpoint};
 
 /// An adapter into which one may push elements of type `T`.

--- a/communication/src/allocator/zero_copy/push_pull.rs
+++ b/communication/src/allocator/zero_copy/push_pull.rs
@@ -8,8 +8,7 @@ use timely_bytes::arc::Bytes;
 
 use crate::allocator::canary::Canary;
 use crate::networking::MessageHeader;
-use crate::message::Bytesable;
-use crate::{Push, Pull};
+use crate::{Bytesable, Push, Pull};
 
 use super::bytes_exchange::{BytesPush, SendEndpoint};
 

--- a/communication/src/initialize.rs
+++ b/communication/src/initialize.rs
@@ -184,7 +184,7 @@ impl Config {
 /// ```
 /// use timely_communication::{Allocate, Bytesable};
 /// 
-/// /// A wrapper that indicates `bincode` as the serialization/deserialization strategy.
+/// /// A wrapper that indicates the serialization/deserialization strategy.
 /// pub struct Message {
 ///     /// Text contents.
 ///     pub payload: String,

--- a/communication/src/initialize.rs
+++ b/communication/src/initialize.rs
@@ -182,47 +182,71 @@ impl Config {
 ///
 /// # Examples
 /// ```
-/// use timely_communication::Allocate;
-///
-/// // configure for two threads, just one process.
-/// let config = timely_communication::Config::Process(2);
-///
-/// // initializes communication, spawns workers
-/// let guards = timely_communication::initialize(config, |mut allocator| {
-///     println!("worker {} started", allocator.index());
-///
-///     // allocates a pair of senders list and one receiver.
-///     let (mut senders, mut receiver) = allocator.allocate(0);
-///
-///     // send typed data along each channel
-///     use timely_communication::Message;
-///     senders[0].send(Message::from_typed(format!("hello, {}", 0)));
-///     senders[1].send(Message::from_typed(format!("hello, {}", 1)));
-///
-///     // no support for termination notification,
-///     // we have to count down ourselves.
-///     let mut expecting = 2;
-///     while expecting > 0 {
-///         allocator.receive();
-///         if let Some(message) = receiver.recv() {
-///             use std::ops::Deref;
-///             println!("worker {}: received: <{}>", allocator.index(), message.deref());
-///             expecting -= 1;
-///         }
-///         allocator.release();
+/// use timely_communication::{Allocate, Bytesable};
+/// 
+/// /// A wrapper that indicates `bincode` as the serialization/deserialization strategy.
+/// pub struct Message {
+///     /// Text contents.
+///     pub payload: String,
+/// }
+/// 
+/// impl Bytesable for Message {
+///     fn from_bytes(bytes: timely_bytes::arc::Bytes) -> Self {
+///         Message { payload: std::str::from_utf8(&bytes[..]).unwrap().to_string() }
 ///     }
-///
-///     // optionally, return something
-///     allocator.index()
-/// });
-///
-/// // computation runs until guards are joined or dropped.
-/// if let Ok(guards) = guards {
-///     for guard in guards.join() {
-///         println!("result: {:?}", guard);
+/// 
+///     fn length_in_bytes(&self) -> usize {
+///         self.payload.len()
+///     }
+/// 
+///     fn into_bytes<W: ::std::io::Write>(&self, writer: &mut W) {
+///         writer.write_all(self.payload.as_bytes()).unwrap();
 ///     }
 /// }
-/// else { println!("error in computation"); }
+/// 
+/// fn main() {
+/// 
+///     // extract the configuration from user-supplied arguments, initialize the computation.
+///     let config = timely_communication::Config::from_args(std::env::args()).unwrap();
+///     let guards = timely_communication::initialize(config, |mut allocator| {
+/// 
+///         println!("worker {} of {} started", allocator.index(), allocator.peers());
+/// 
+///         // allocates a pair of senders list and one receiver.
+///         let (mut senders, mut receiver) = allocator.allocate(0);
+/// 
+///         // send typed data along each channel
+///         for i in 0 .. allocator.peers() {
+///             senders[i].send(Message { payload: format!("hello, {}", i)});
+///             senders[i].done();
+///         }
+/// 
+///         // no support for termination notification,
+///         // we have to count down ourselves.
+///         let mut received = 0;
+///         while received < allocator.peers() {
+/// 
+///             allocator.receive();
+/// 
+///             if let Some(message) = receiver.recv() {
+///                 println!("worker {}: received: <{}>", allocator.index(), message.payload);
+///                 received += 1;
+///             }
+/// 
+///             allocator.release();
+///         }
+/// 
+///         allocator.index()
+///     });
+/// 
+///     // computation runs until guards are joined or dropped.
+///     if let Ok(guards) = guards {
+///         for guard in guards.join() {
+///             println!("result: {:?}", guard);
+///         }
+///     }
+///     else { println!("error in computation"); }
+/// }
 /// ```
 ///
 /// The should produce output like:
@@ -254,47 +278,71 @@ pub fn initialize<T:Send+'static, F: Fn(Generic)->T+Send+Sync+'static>(
 ///
 /// # Examples
 /// ```
-/// use timely_communication::Allocate;
-///
-/// // configure for two threads, just one process.
-/// let builders = timely_communication::allocator::process::Process::new_vector(2);
-///
-/// // initializes communication, spawns workers
-/// let guards = timely_communication::initialize_from(builders, Box::new(()), |mut allocator| {
-///     println!("worker {} started", allocator.index());
-///
-///     // allocates a pair of senders list and one receiver.
-///     let (mut senders, mut receiver) = allocator.allocate(0);
-///
-///     // send typed data along each channel
-///     use timely_communication::Message;
-///     senders[0].send(Message::from_typed(format!("hello, {}", 0)));
-///     senders[1].send(Message::from_typed(format!("hello, {}", 1)));
-///
-///     // no support for termination notification,
-///     // we have to count down ourselves.
-///     let mut expecting = 2;
-///     while expecting > 0 {
-///         allocator.receive();
-///         if let Some(message) = receiver.recv() {
-///             use std::ops::Deref;
-///             println!("worker {}: received: <{}>", allocator.index(), message.deref());
-///             expecting -= 1;
-///         }
-///         allocator.release();
+/// use timely_communication::{Allocate, Bytesable};
+/// 
+/// /// A wrapper that indicates `bincode` as the serialization/deserialization strategy.
+/// pub struct Message {
+///     /// Text contents.
+///     pub payload: String,
+/// }
+/// 
+/// impl Bytesable for Message {
+///     fn from_bytes(bytes: timely_bytes::arc::Bytes) -> Self {
+///         Message { payload: std::str::from_utf8(&bytes[..]).unwrap().to_string() }
 ///     }
-///
-///     // optionally, return something
-///     allocator.index()
-/// });
-///
-/// // computation runs until guards are joined or dropped.
-/// if let Ok(guards) = guards {
-///     for guard in guards.join() {
-///         println!("result: {:?}", guard);
+/// 
+///     fn length_in_bytes(&self) -> usize {
+///         self.payload.len()
+///     }
+/// 
+///     fn into_bytes<W: ::std::io::Write>(&self, writer: &mut W) {
+///         writer.write_all(self.payload.as_bytes()).unwrap();
 ///     }
 /// }
-/// else { println!("error in computation"); }
+/// 
+/// fn main() {
+/// 
+///     // extract the configuration from user-supplied arguments, initialize the computation.
+///     let config = timely_communication::Config::from_args(std::env::args()).unwrap();
+///     let guards = timely_communication::initialize(config, |mut allocator| {
+/// 
+///         println!("worker {} of {} started", allocator.index(), allocator.peers());
+/// 
+///         // allocates a pair of senders list and one receiver.
+///         let (mut senders, mut receiver) = allocator.allocate(0);
+/// 
+///         // send typed data along each channel
+///         for i in 0 .. allocator.peers() {
+///             senders[i].send(Message { payload: format!("hello, {}", i)});
+///             senders[i].done();
+///         }
+/// 
+///         // no support for termination notification,
+///         // we have to count down ourselves.
+///         let mut received = 0;
+///         while received < allocator.peers() {
+/// 
+///             allocator.receive();
+/// 
+///             if let Some(message) = receiver.recv() {
+///                 println!("worker {}: received: <{}>", allocator.index(), message.payload);
+///                 received += 1;
+///             }
+/// 
+///             allocator.release();
+///         }
+/// 
+///         allocator.index()
+///     });
+/// 
+///     // computation runs until guards are joined or dropped.
+///     if let Ok(guards) = guards {
+///         for guard in guards.join() {
+///             println!("result: {:?}", guard);
+///         }
+///     }
+///     else { println!("error in computation"); }
+/// }
 /// ```
 pub fn initialize_from<A, T, F>(
     builders: Vec<A>,

--- a/communication/src/lib.rs
+++ b/communication/src/lib.rs
@@ -104,7 +104,7 @@ pub mod logging;
 pub mod buzzer;
 
 pub use allocator::Generic as Allocator;
-pub use allocator::Allocate;
+pub use allocator::{Allocate, Exchangeable};
 pub use initialize::{initialize, initialize_from, Config, WorkerGuards};
 
 use timely_bytes::arc::Bytes;

--- a/communication/src/lib.rs
+++ b/communication/src/lib.rs
@@ -8,55 +8,78 @@
 //! receive endpoint. Messages sent into a send endpoint will eventually be received by the corresponding worker,
 //! if it receives often enough. The point-to-point channels are each FIFO, but with no fairness guarantees.
 //!
-//! To be communicated, a type must implement the [`Serialize`](serde::Serialize) trait.
+//! To be communicated, a type must implement the [`Bytesable`] trait.
 //!
 //! Channel endpoints also implement a lower-level `push` and `pull` interface (through the [`Push`] and [`Pull`]
 //! traits), which is used for more precise control of resources.
 //!
 //! # Examples
 //! ```
-//! use timely_communication::Allocate;
-//!
-//! // configure for two threads, just one process.
-//! let config = timely_communication::Config::Process(2);
-//!
-//! // initializes communication, spawns workers
-//! let guards = timely_communication::initialize(config, |mut allocator| {
-//!     println!("worker {} started", allocator.index());
-//!
-//!     // allocates a pair of senders list and one receiver.
-//!     let (mut senders, mut receiver) = allocator.allocate(0);
-//!
-//!     // send typed data along each channel
-//!     use timely_communication::Message;
-//!     senders[0].send(Message::from_typed(format!("hello, {}", 0)));
-//!     senders[1].send(Message::from_typed(format!("hello, {}", 1)));
-//!
-//!     // no support for termination notification,
-//!     // we have to count down ourselves.
-//!     let mut expecting = 2;
-//!     while expecting > 0 {
-//!
-//!         allocator.receive();
-//!         if let Some(message) = receiver.recv() {
-//!             use std::ops::Deref;
-//!             println!("worker {}: received: <{}>", allocator.index(), message.deref());
-//!             expecting -= 1;
-//!         }
-//!         allocator.release();
+//! use timely_communication::{Allocate, Bytesable};
+//! 
+//! /// A wrapper that indicates `bincode` as the serialization/deserialization strategy.
+//! pub struct Message {
+//!     /// Text contents.
+//!     pub payload: String,
+//! }
+//! 
+//! impl Bytesable for Message {
+//!     fn from_bytes(bytes: timely_bytes::arc::Bytes) -> Self {
+//!         Message { payload: std::str::from_utf8(&bytes[..]).unwrap().to_string() }
 //!     }
-//!
-//!     // optionally, return something
-//!     allocator.index()
-//! });
-//!
-//! // computation runs until guards are joined or dropped.
-//! if let Ok(guards) = guards {
-//!     for guard in guards.join() {
-//!         println!("result: {:?}", guard);
+//! 
+//!     fn length_in_bytes(&self) -> usize {
+//!         self.payload.len()
+//!     }
+//! 
+//!     fn into_bytes<W: ::std::io::Write>(&self, writer: &mut W) {
+//!         writer.write_all(self.payload.as_bytes()).unwrap();
 //!     }
 //! }
-//! else { println!("error in computation"); }
+//! 
+//! fn main() {
+//! 
+//!     // extract the configuration from user-supplied arguments, initialize the computation.
+//!     let config = timely_communication::Config::from_args(std::env::args()).unwrap();
+//!     let guards = timely_communication::initialize(config, |mut allocator| {
+//! 
+//!         println!("worker {} of {} started", allocator.index(), allocator.peers());
+//! 
+//!         // allocates a pair of senders list and one receiver.
+//!         let (mut senders, mut receiver) = allocator.allocate(0);
+//! 
+//!         // send typed data along each channel
+//!         for i in 0 .. allocator.peers() {
+//!             senders[i].send(Message { payload: format!("hello, {}", i)});
+//!             senders[i].done();
+//!         }
+//! 
+//!         // no support for termination notification,
+//!         // we have to count down ourselves.
+//!         let mut received = 0;
+//!         while received < allocator.peers() {
+//! 
+//!             allocator.receive();
+//! 
+//!             if let Some(message) = receiver.recv() {
+//!                 println!("worker {}: received: <{}>", allocator.index(), message.payload);
+//!                 received += 1;
+//!             }
+//! 
+//!             allocator.release();
+//!         }
+//! 
+//!         allocator.index()
+//!     });
+//! 
+//!     // computation runs until guards are joined or dropped.
+//!     if let Ok(guards) = guards {
+//!         for guard in guards.join() {
+//!             println!("result: {:?}", guard);
+//!         }
+//!     }
+//!     else { println!("error in computation"); }
+//! }
 //! ```
 //!
 //! This should produce output like:
@@ -78,21 +101,25 @@ pub mod allocator;
 pub mod networking;
 pub mod initialize;
 pub mod logging;
-pub mod message;
 pub mod buzzer;
-
-use std::any::Any;
-
-use serde::{Serialize, Deserialize};
 
 pub use allocator::Generic as Allocator;
 pub use allocator::Allocate;
 pub use initialize::{initialize, initialize_from, Config, WorkerGuards};
-pub use message::Message;
 
-/// A composite trait for types that may be used with channels.
-pub trait Data : Send+Sync+Any+Serialize+for<'a>Deserialize<'a>+'static { }
-impl<T: Send+Sync+Any+Serialize+for<'a>Deserialize<'a>+'static> Data for T { }
+use timely_bytes::arc::Bytes;
+
+/// A type that can be serialized and deserialized through `Bytes`.
+pub trait Bytesable {
+    /// Wrap bytes as `Self`.
+    fn from_bytes(bytes: Bytes) -> Self;
+
+    /// The number of bytes required to serialize the data.
+    fn length_in_bytes(&self) -> usize;
+
+    /// Writes the binary representation into `writer`.
+    fn into_bytes<W: ::std::io::Write>(&self, writer: &mut W);
+}
 
 /// Pushing elements of type `T`.
 ///

--- a/communication/src/message.rs
+++ b/communication/src/message.rs
@@ -3,33 +3,45 @@
 use timely_bytes::arc::Bytes;
 use crate::Data;
 
-/// A wrapped message which supports serialization and deserialization.
+/// A type that can be serialized and deserialized through `Bytes`.
+pub trait Bytesable {
+    /// Wrap bytes as a Message.
+    fn from_bytes(bytes: Bytes) -> Self;
+
+    /// The number of bytes required to serialize the data.
+    fn length_in_bytes(&self) -> usize;
+
+    /// Writes the binary representation into `writer`.
+    fn into_bytes<W: ::std::io::Write>(&self, writer: &mut W);
+}
+
+/// A wrapped Message which supports serialization and deserialization.
 pub struct Message<T> {
     /// Message contents.
     pub payload: T,
 }
 
 impl<T> Message<T> {
-    /// Wrap a typed item as a message.
+    /// Wrap a typed item as a Message.
     pub fn from_typed(typed: T) -> Self {
         Message { payload: typed }
     }
 }
 
-impl<T: Data> Message<T> {
-    /// Wrap bytes as a message.
-    pub fn from_bytes(bytes: Bytes) -> Self {
+impl<T: Data> Bytesable for Message<T> {
+    /// Wrap bytes as a Message.
+    fn from_bytes(bytes: Bytes) -> Self {
         let typed = ::bincode::deserialize(&bytes[..]).expect("bincode::deserialize() failed");
         Message { payload: typed }
     }
 
     /// The number of bytes required to serialize the data.
-    pub fn length_in_bytes(&self) -> usize {
+    fn length_in_bytes(&self) -> usize {
         ::bincode::serialized_size(&self.payload).expect("bincode::serialized_size() failed") as usize
     }
 
     /// Writes the binary representation into `writer`.
-    pub fn into_bytes<W: ::std::io::Write>(&self, writer: &mut W) {
+    fn into_bytes<W: ::std::io::Write>(&self, writer: &mut W) {
         ::bincode::serialize_into(writer, &self.payload).expect("bincode::serialize_into() failed");
     }
 }

--- a/timely/src/dataflow/channels/mod.rs
+++ b/timely/src/dataflow/channels/mod.rs
@@ -12,7 +12,7 @@ pub mod pullers;
 pub mod pact;
 
 /// The input to and output from timely dataflow communication channels.
-pub type Bundle<T, C> = crate::communication::Message<Message<T, C>>;
+pub type Bundle<T, C> = crate::Message<Message<T, C>>;
 
 /// A serializable representation of timestamped data.
 #[derive(Clone, Serialize, Deserialize)]

--- a/timely/src/dataflow/channels/pact.rs
+++ b/timely/src/dataflow/channels/pact.rs
@@ -12,13 +12,14 @@ use std::rc::Rc;
 
 use crate::Container;
 use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
-use crate::communication::{Push, Pull, Data};
+use crate::communication::{Push, Pull};
 use crate::container::PushPartitioned;
 use crate::dataflow::channels::pushers::Exchange as ExchangePusher;
 use crate::dataflow::channels::{Bundle, Message};
 use crate::logging::{TimelyLogger as Logger, MessagesEvent};
 use crate::progress::Timestamp;
 use crate::worker::AsWorker;
+use crate::ExchangeData;
 
 /// A `ParallelizationContract` allocates paired `Push` and `Pull` implementors.
 pub trait ParallelizationContract<T, C> {
@@ -67,7 +68,7 @@ where
 // Exchange uses a `Box<Pushable>` because it cannot know what type of pushable will return from the allocator.
 impl<T: Timestamp, C, H: 'static> ParallelizationContract<T, C> for ExchangeCore<C, H>
 where
-    C: Data + PushPartitioned,
+    C: ExchangeData + PushPartitioned,
     for<'a> H: FnMut(&C::Item<'a>) -> u64
 {
     type Pusher = ExchangePusher<T, C, LogPusher<T, C, Box<dyn Push<Bundle<T, C>>>>, H>;

--- a/timely/src/dataflow/channels/pullers/mod.rs
+++ b/timely/src/dataflow/channels/pullers/mod.rs
@@ -1,11 +1,2 @@
 pub use self::counter::Counter;
 pub mod counter;
-
-
-// pub trait Pullable<T, D> {
-//     fn pull(&mut self) -> Option<(&T, &mut Message<D>)>;
-// }
-//
-// impl<T, D, P: ?Sized + Pullable<T, D>> Pullable<T, D> for Box<P> {
-//     fn pull(&mut self) -> Option<(&T, &mut Message<D>)> { (**self).pull() }
-// }

--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -3,9 +3,8 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use crate::communication::{Push, Pull};
+use crate::communication::{Exchangeable, Push, Pull};
 use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
-use crate::communication::allocator::Exchangeable;
 use crate::scheduling::Scheduler;
 use crate::scheduling::activate::Activations;
 use crate::progress::{Timestamp, Operate, SubgraphBuilder};

--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -3,7 +3,7 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use crate::communication::{Data, Push, Pull};
+use crate::communication::{Push, Pull};
 use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
 use crate::scheduling::Scheduler;
 use crate::scheduling::activate::Activations;
@@ -14,6 +14,7 @@ use crate::order::Product;
 use crate::logging::TimelyLogger as Logger;
 use crate::logging::TimelyProgressLogger as ProgressLogger;
 use crate::worker::{AsWorker, Config};
+use crate::ExchangeData;
 
 use super::{ScopeParent, Scope};
 
@@ -58,7 +59,7 @@ where
     fn config(&self) -> &Config { self.parent.config() }
     fn index(&self) -> usize { self.parent.index() }
     fn peers(&self) -> usize { self.parent.peers() }
-    fn allocate<D: Data>(&mut self, identifier: usize, address: Rc<[usize]>) -> (Vec<Box<dyn Push<Message<D>>>>, Box<dyn Pull<Message<D>>>) {
+    fn allocate<D: ExchangeData>(&mut self, identifier: usize, address: Rc<[usize]>) -> (Vec<Box<dyn Push<Message<D>>>>, Box<dyn Pull<Message<D>>>) {
         self.parent.allocate(identifier, address)
     }
     fn pipeline<D: 'static>(&mut self, identifier: usize, address: Rc<[usize]>) -> (ThreadPusher<Message<D>>, ThreadPuller<Message<D>>) {
@@ -148,7 +149,7 @@ where
     }
 }
 
-use crate::communication::Message;
+use crate::Message;
 
 impl<'a, G, T> Clone for Child<'a, G, T>
 where

--- a/timely/src/lib.rs
+++ b/timely/src/lib.rs
@@ -126,8 +126,8 @@ mod encoding {
     use timely_communication::Bytesable;
 
     /// A composite trait for types that may be used with channels.
-    pub trait Data : Send+Any+Serialize+for<'a>Deserialize<'a>+'static { }
-    impl<T: Send+Any+Serialize+for<'a>Deserialize<'a>+'static> Data for T { }
+    pub trait Data : Send+Any+Serialize+for<'a>Deserialize<'a> { }
+    impl<T: Send+Any+Serialize+for<'a>Deserialize<'a>> Data for T { }
 
     /// A wrapper that indicates `bincode` as the serialization/deserialization strategy.
     pub struct Bincode<T> {

--- a/timely/src/progress/broadcast.rs
+++ b/timely/src/progress/broadcast.rs
@@ -3,9 +3,10 @@
 use std::rc::Rc;
 use crate::progress::{ChangeBatch, Timestamp};
 use crate::progress::{Location, Port};
-use crate::communication::{Message, Push, Pull};
+use crate::communication::{Push, Pull};
 use crate::logging::TimelyLogger as Logger;
 use crate::logging::TimelyProgressLogger as ProgressLogger;
+use crate::Message;
 
 /// A list of progress updates corresponding to `((child_scope, [in/out]_port, timestamp), delta)`
 pub type ProgressVec<T> = Vec<((Location, T), i64)>;

--- a/timely/src/progress/timestamp.rs
+++ b/timely/src/progress/timestamp.rs
@@ -5,11 +5,11 @@ use std::any::Any;
 use std::default::Default;
 use std::hash::Hash;
 
-use crate::communication::Data;
+use crate::ExchangeData;
 use crate::order::PartialOrder;
 
 /// A composite trait for types that serve as timestamps in timely dataflow.
-pub trait Timestamp: Clone+Eq+PartialOrder+Debug+Send+Any+Data+Hash+Ord {
+pub trait Timestamp: Clone+Eq+PartialOrder+Debug+Send+Any+ExchangeData+Hash+Ord {
     /// A type summarizing action on a timestamp along a dataflow path.
     type Summary : PathSummary<Self> + 'static;
     /// A minimum value suitable as a default.

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -9,9 +9,8 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
-use crate::communication::{Allocate, Push, Pull};
+use crate::communication::{Allocate, Exchangeable, Push, Pull};
 use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
-use crate::communication::allocator::Exchangeable;
 use crate::scheduling::{Schedule, Scheduler, Activations};
 use crate::progress::timestamp::{Refines};
 use crate::progress::SubgraphBuilder;

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -11,13 +11,13 @@ use std::sync::Arc;
 
 use crate::communication::{Allocate, Push, Pull};
 use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
+use crate::communication::allocator::Exchangeable;
 use crate::scheduling::{Schedule, Scheduler, Activations};
 use crate::progress::timestamp::{Refines};
 use crate::progress::SubgraphBuilder;
 use crate::progress::operate::Operate;
 use crate::dataflow::scopes::Child;
 use crate::logging::TimelyLogger;
-use crate::ExchangeData;
 
 /// Different ways in which timely's progress tracking can work.
 ///
@@ -192,12 +192,12 @@ pub trait AsWorker : Scheduler {
     /// scheduled in response to the receipt of records on the channel.
     /// Most commonly, this would be the address of the *target* of the
     /// channel.
-    fn allocate<T: ExchangeData>(&mut self, identifier: usize, address: Rc<[usize]>) -> (Vec<Box<dyn Push<Message<T>>>>, Box<dyn Pull<Message<T>>>);
+    fn allocate<T: Exchangeable>(&mut self, identifier: usize, address: Rc<[usize]>) -> (Vec<Box<dyn Push<T>>>, Box<dyn Pull<T>>);
     /// Constructs a pipeline channel from the worker to itself.
     ///
     /// By default this method uses the native channel allocation mechanism, but the expectation is
     /// that this behavior will be overridden to be more efficient.
-    fn pipeline<T: 'static>(&mut self, identifier: usize, address: Rc<[usize]>) -> (ThreadPusher<Message<T>>, ThreadPuller<Message<T>>);
+    fn pipeline<T: 'static>(&mut self, identifier: usize, address: Rc<[usize]>) -> (ThreadPusher<T>, ThreadPuller<T>);
 
     /// Allocates a new worker-unique identifier.
     fn new_identifier(&mut self) -> usize;
@@ -234,14 +234,14 @@ impl<A: Allocate> AsWorker for Worker<A> {
     fn config(&self) -> &Config { &self.config }
     fn index(&self) -> usize { self.allocator.borrow().index() }
     fn peers(&self) -> usize { self.allocator.borrow().peers() }
-    fn allocate<D: ExchangeData>(&mut self, identifier: usize, address: Rc<[usize]>) -> (Vec<Box<dyn Push<Message<D>>>>, Box<dyn Pull<Message<D>>>) {
+    fn allocate<D: Exchangeable>(&mut self, identifier: usize, address: Rc<[usize]>) -> (Vec<Box<dyn Push<D>>>, Box<dyn Pull<D>>) {
         if address.is_empty() { panic!("Unacceptable address: Length zero"); }
         let mut paths = self.paths.borrow_mut();
         paths.insert(identifier, address);
         self.temp_channel_ids.borrow_mut().push(identifier);
         self.allocator.borrow_mut().allocate(identifier)
     }
-    fn pipeline<T: 'static>(&mut self, identifier: usize, address: Rc<[usize]>) -> (ThreadPusher<Message<T>>, ThreadPuller<Message<T>>) {
+    fn pipeline<T: 'static>(&mut self, identifier: usize, address: Rc<[usize]>) -> (ThreadPusher<T>, ThreadPuller<T>) {
         if address.is_empty() { panic!("Unacceptable address: Length zero"); }
         let mut paths = self.paths.borrow_mut();
         paths.insert(identifier, address);
@@ -719,8 +719,6 @@ impl<A: Allocate> Worker<A> {
         *self.dataflow_counter.borrow() - 1
     }
 }
-
-use crate::Message;
 
 impl<A: Allocate> Clone for Worker<A> {
     fn clone(&self) -> Self {


### PR DESCRIPTION
This PR introduces a trait `Bytesable` with methods from and into `Bytes`. It removes from `communication` any reliance on `bincode`, not because it is bad just because it is an opinion. It almost removes all dependence on `serde`, except that it creates several logging types that want to derive `Serialize` and `Deserialize`, but it is not otherwise reliant on them.

The trait that was formerly `communication::Data` is now instead `communication::allocator::Exchangeable`, and it looks like so:
```rust
/// A type that can be sent along an allocated channel.
pub trait Exchangeable : Send+Any+Bytesable+'static { }
impl<T: Send+Any+Bytesable+'static> Exchangeable for T { }
```

In exchange, timely gets a relatively small opinion, currently in the `encoding` module, that one can implement `Bytesable` with some reliance on `serde` and `bincode`. The opinions are expressed in a trait
```rust
    /// A composite trait for types that may be used with channels.
    pub trait Data : Send+Any+Serialize+for<'a>Deserialize<'a>+'static { }
    impl<T: Send+Any+Serialize+for<'a>Deserialize<'a>+'static> Data for T { }
```
which informs the `timely::ExchangeData` trait.