### PR TITLE
Public Message type

### DIFF
--- a/timely/src/lib.rs
+++ b/timely/src/lib.rs
@@ -116,7 +116,7 @@ impl<T: Data + encoding::Data> ExchangeData for T { }
 pub struct ReadmeDoctests;
 
 /// A wrapper that indicates a serialization/deserialization strategy.
-use encoding::Bincode as Message;
+pub use encoding::Bincode as Message;
 
 mod encoding {
 


### PR DESCRIPTION
Currently, it's not possible to access `Message` from dependent crates. Fix it by `pub` using the type.
