### PR TITLE
Allow containers to specify their own serialization

### DIFF
--- a/timely/src/dataflow/channels/pact.rs
+++ b/timely/src/dataflow/channels/pact.rs
@@ -68,7 +68,7 @@ where
 // Exchange uses a `Box<Pushable>` because it cannot know what type of pushable will return from the allocator.
 impl<T: Timestamp, C, H: 'static> ParallelizationContract<T, C> for ExchangeCore<C, H>
 where
-    C: ExchangeData + PushPartitioned,
+    C: ExchangeData + PushPartitioned + crate::dataflow::channels::ContainerBytes,
     for<'a> H: FnMut(&C::Item<'a>) -> u64
 {
     type Pusher = ExchangePusher<T, C, LogPusher<T, C, Box<dyn Push<Message<T, C>>>>, H>;

--- a/timely/src/dataflow/operators/core/exchange.rs
+++ b/timely/src/dataflow/operators/core/exchange.rs
@@ -30,7 +30,7 @@ pub trait Exchange<C: PushPartitioned> {
 
 impl<G: Scope, C> Exchange<C> for StreamCore<G, C>
 where
-    C: PushPartitioned + ExchangeData,
+    C: PushPartitioned + ExchangeData + crate::dataflow::channels::ContainerBytes,
 {
     fn exchange<F>(&self, route: F) -> StreamCore<G, C>
     where


### PR DESCRIPTION
This PR allows containers to specify how to write to and read from `Bytes`. This should open the door up to custom zero-copy implementations, as should be allowed by `columnar`. I haven't prototyped that up yet, and we may learn about the container trait when doing so (right now: one container for both send and recv; should be workable, but this will let us test).

Design-wise, not in love with the new trait, but it allows us to provide implementations for containers here, rather than e.g. in `communication`, or (probably where they belong) in `container` after bringing in dependencies on `bincode` and the like. Up for discussing that, but I think we just need a trait somewhere, and implementations very near by. Otherwise, we need to have some wrappers and rework a lot of code, which doesn't sound as good.