### PR TITLE
Reorganize `Container` traits

### DIFF
--- a/container/src/columnation.rs
+++ b/container/src/columnation.rs
@@ -369,16 +369,18 @@ mod container {
     }
 
     impl<T: Columnation> SizableContainer for TimelyStack<T> {
-        fn capacity(&self) -> usize {
-            self.capacity()
+        fn at_capacity(&self) -> bool {
+            self.len() == self.capacity()
         }
-
-        fn preferred_capacity() -> usize {
-            crate::buffer::default_capacity::<T>()
-        }
-
-        fn reserve(&mut self, additional: usize) {
-            self.reserve(additional)
+        fn ensure_capacity(&mut self, stash: &mut Option<Self>) {
+            if self.capacity() == 0 {
+                *self = stash.take().unwrap_or_default();
+                self.clear();
+            }
+            let preferred = crate::buffer::default_capacity::<T>();
+            if self.capacity() < preferred {
+                self.reserve(preferred - self.capacity());
+            }
         }
     }
 }

--- a/container/src/flatcontainer.rs
+++ b/container/src/flatcontainer.rs
@@ -29,16 +29,18 @@ impl<R: Region> Container for FlatStack<R> {
 }
 
 impl<R: Region> SizableContainer for FlatStack<R> {
-    fn capacity(&self) -> usize {
-        self.capacity()
+    fn at_capacity(&self) -> bool {
+        self.len() == self.capacity()
     }
-
-    fn preferred_capacity() -> usize {
-        buffer::default_capacity::<R::Index>()
-    }
-
-    fn reserve(&mut self, additional: usize) {
-        self.reserve(additional);
+    fn ensure_capacity(&mut self, stash: &mut Option<Self>) {
+        if self.capacity() == 0 {
+            *self = stash.take().unwrap_or_default();
+            self.clear();
+        }
+        let preferred = buffer::default_capacity::<R::Index>();
+        if self.capacity() < preferred {
+            self.reserve(preferred - self.capacity());
+        }
     }
 }
 

--- a/timely/examples/columnar.rs
+++ b/timely/examples/columnar.rs
@@ -315,7 +315,7 @@ mod builder {
         }
     }
 
-    use timely::container::ContainerBuilder;
+    use timely::container::{ContainerBuilder, LengthPreservingContainerBuilder};
     impl<C: AsBytes + Clear + Len + Clone + Default + 'static> ContainerBuilder for ColumnBuilder<C>
     where
         for<'a> C::Borrowed<'a> : Len + Index,
@@ -341,4 +341,9 @@ mod builder {
             self.empty.as_mut()
         }
     }
+
+    impl<C: AsBytes + Clear + Len + Clone + Default + 'static> LengthPreservingContainerBuilder for ColumnBuilder<C>
+    where
+        for<'a> C::Borrowed<'a> : Len + Index,
+    { }
 }

--- a/timely/src/dataflow/channels/pact.rs
+++ b/timely/src/dataflow/channels/pact.rs
@@ -10,7 +10,7 @@
 use std::{fmt::{self, Debug}, marker::PhantomData};
 use std::rc::Rc;
 
-use crate::{Container, container::{ContainerBuilder, SizableContainer, CapacityContainerBuilder, PushInto}};
+use crate::{Container, container::{ContainerBuilder, LengthPreservingContainerBuilder, SizableContainer, CapacityContainerBuilder, PushInto}};
 use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
 use crate::communication::{Push, Pull};
 use crate::dataflow::channels::pushers::Exchange as ExchangePusher;
@@ -52,7 +52,7 @@ pub type Exchange<D, F> = ExchangeCore<CapacityContainerBuilder<Vec<D>>, F>;
 
 impl<CB, F> ExchangeCore<CB, F>
 where
-    CB: ContainerBuilder,
+    CB: LengthPreservingContainerBuilder,
     CB::Container: SizableContainer,
     for<'a> F: FnMut(&<CB::Container as Container>::Item<'a>)->u64
 {

--- a/timely/src/dataflow/channels/pact.rs
+++ b/timely/src/dataflow/channels/pact.rs
@@ -10,10 +10,9 @@
 use std::{fmt::{self, Debug}, marker::PhantomData};
 use std::rc::Rc;
 
-use crate::Container;
+use crate::{Container, container::{ContainerBuilder, SizableContainer, CapacityContainerBuilder, PushInto}};
 use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
 use crate::communication::{Push, Pull};
-use crate::container::PushPartitioned;
 use crate::dataflow::channels::pushers::Exchange as ExchangePusher;
 use crate::dataflow::channels::Message;
 use crate::logging::{TimelyLogger as Logger, MessagesEvent};
@@ -46,18 +45,33 @@ impl<T: 'static, C: Container + 'static> ParallelizationContract<T, C> for Pipel
 }
 
 /// An exchange between multiple observers by data
-pub struct ExchangeCore<C, F> { hash_func: F, phantom: PhantomData<C> }
+pub struct ExchangeCore<CB, F> { hash_func: F, phantom: PhantomData<CB> }
 
 /// [ExchangeCore] specialized to vector-based containers.
-pub type Exchange<D, F> = ExchangeCore<Vec<D>, F>;
+pub type Exchange<D, F> = ExchangeCore<CapacityContainerBuilder<Vec<D>>, F>;
 
-impl<C, F> ExchangeCore<C, F>
+impl<CB, F> ExchangeCore<CB, F>
 where
-    C: PushPartitioned,
+    CB: ContainerBuilder,
+    CB::Container: SizableContainer,
+    for<'a> F: FnMut(&<CB::Container as Container>::Item<'a>)->u64
+{
+    /// Allocates a new `Exchange` pact from a distribution function.
+    pub fn new_core(func: F) -> ExchangeCore<CB, F> {
+        ExchangeCore {
+            hash_func:  func,
+            phantom:    PhantomData,
+        }
+    }
+}
+
+impl<C, F> ExchangeCore<CapacityContainerBuilder<C>, F>
+where
+    C: SizableContainer,
     for<'a> F: FnMut(&C::Item<'a>)->u64
 {
     /// Allocates a new `Exchange` pact from a distribution function.
-    pub fn new(func: F) -> ExchangeCore<C, F> {
+    pub fn new(func: F) -> ExchangeCore<CapacityContainerBuilder<C>, F> {
         ExchangeCore {
             hash_func:  func,
             phantom:    PhantomData,
@@ -66,16 +80,18 @@ where
 }
 
 // Exchange uses a `Box<Pushable>` because it cannot know what type of pushable will return from the allocator.
-impl<T: Timestamp, C, H: 'static> ParallelizationContract<T, C> for ExchangeCore<C, H>
+impl<T: Timestamp, CB, H: 'static> ParallelizationContract<T, CB::Container> for ExchangeCore<CB, H>
 where
-    C: Data + Send + PushPartitioned + crate::dataflow::channels::ContainerBytes,
-    for<'a> H: FnMut(&C::Item<'a>) -> u64
+    CB: ContainerBuilder,
+    CB: for<'a> PushInto<<CB::Container as Container>::Item<'a>>,
+    CB::Container: Data + Send + SizableContainer + crate::dataflow::channels::ContainerBytes,
+    for<'a> H: FnMut(&<CB::Container as Container>::Item<'a>) -> u64
 {
-    type Pusher = ExchangePusher<T, C, LogPusher<T, C, Box<dyn Push<Message<T, C>>>>, H>;
-    type Puller = LogPuller<T, C, Box<dyn Pull<Message<T, C>>>>;
+    type Pusher = ExchangePusher<T, CB, LogPusher<T, CB::Container, Box<dyn Push<Message<T, CB::Container>>>>, H>;
+    type Puller = LogPuller<T, CB::Container, Box<dyn Pull<Message<T, CB::Container>>>>;
 
     fn connect<A: AsWorker>(self, allocator: &mut A, identifier: usize, address: Rc<[usize]>, logging: Option<Logger>) -> (Self::Pusher, Self::Puller) {
-        let (senders, receiver) = allocator.allocate::<Message<T, C>>(identifier, address);
+        let (senders, receiver) = allocator.allocate::<Message<T, CB::Container>>(identifier, address);
         let senders = senders.into_iter().enumerate().map(|(i,x)| LogPusher::new(x, allocator.index(), i, identifier, logging.clone())).collect::<Vec<_>>();
         (ExchangePusher::new(senders, self.hash_func), LogPuller::new(receiver, allocator.index(), identifier, logging.clone()))
     }

--- a/timely/src/dataflow/channels/pushers/exchange.rs
+++ b/timely/src/dataflow/channels/pushers/exchange.rs
@@ -1,28 +1,34 @@
 //! The exchange pattern distributes pushed data between many target pushees.
 
 use crate::communication::Push;
-use crate::container::PushPartitioned;
+use crate::container::{ContainerBuilder, SizableContainer, PushInto};
 use crate::dataflow::channels::Message;
 use crate::{Container, Data};
 
 // TODO : Software write combining
 /// Distributes records among target pushees according to a distribution function.
-pub struct Exchange<T, C: PushPartitioned, P: Push<Message<T, C>>, H>
+pub struct Exchange<T, CB, P, H>
 where
-    for<'a> H: FnMut(&C::Item<'a>) -> u64
+    CB: ContainerBuilder,
+    CB::Container: SizableContainer,
+    P: Push<Message<T, CB::Container>>,
+    for<'a> H: FnMut(&<CB::Container as Container>::Item<'a>) -> u64
 {
     pushers: Vec<P>,
-    buffers: Vec<C>,
+    buffers: Vec<CB>,
     current: Option<T>,
     hash_func: H,
 }
 
-impl<T: Clone, C: PushPartitioned, P: Push<Message<T, C>>, H>  Exchange<T, C, P, H>
+impl<T: Clone, CB, P, H>  Exchange<T, CB, P, H>
 where
-    for<'a> H: FnMut(&C::Item<'a>) -> u64
+    CB: ContainerBuilder,
+    CB::Container: SizableContainer,
+    P: Push<Message<T, CB::Container>>,
+    for<'a> H: FnMut(&<CB::Container as Container>::Item<'a>) -> u64
 {
     /// Allocates a new `Exchange` from a supplied set of pushers and a distribution function.
-    pub fn new(pushers: Vec<P>, key: H) -> Exchange<T, C, P, H> {
+    pub fn new(pushers: Vec<P>, key: H) -> Exchange<T, CB, P, H> {
         let mut buffers = vec![];
         for _ in 0..pushers.len() {
             buffers.push(Default::default());
@@ -36,21 +42,24 @@ where
     }
     #[inline]
     fn flush(&mut self, index: usize) {
-        if !self.buffers[index].is_empty() {
+        while let Some(container) = self.buffers[index].finish() {
             if let Some(ref time) = self.current {
-                Message::push_at(&mut self.buffers[index], time.clone(), &mut self.pushers[index]);
+                Message::push_at(container, time.clone(), &mut self.pushers[index]);
             }
         }
     }
 }
 
-impl<T: Eq+Data, C: Container, P: Push<Message<T, C>>, H, > Push<Message<T, C>> for Exchange<T, C, P, H>
+impl<T: Eq+Data, CB, P, H> Push<Message<T, CB::Container>> for Exchange<T, CB, P, H>
 where
-    C: PushPartitioned,
-    for<'a> H: FnMut(&C::Item<'a>) -> u64
+    CB: ContainerBuilder,
+    CB::Container: SizableContainer,
+    CB: for<'a> PushInto<<CB::Container as Container>::Item<'a>>,
+    P: Push<Message<T, CB::Container>>,
+    for<'a> H: FnMut(&<CB::Container as Container>::Item<'a>) -> u64
 {
     #[inline(never)]
-    fn push(&mut self, message: &mut Option<Message<T, C>>) {
+    fn push(&mut self, message: &mut Option<Message<T, CB::Container>>) {
         // if only one pusher, no exchange
         if self.pushers.len() == 1 {
             self.pushers[0].push(message);
@@ -73,28 +82,18 @@ where
             // if the number of pushers is a power of two, use a mask
             if self.pushers.len().is_power_of_two() {
                 let mask = (self.pushers.len() - 1) as u64;
-                let pushers = &mut self.pushers;
-                data.push_partitioned(
-                    &mut self.buffers,
-                    move |datum| ((hash_func)(datum) & mask) as usize,
-                    |index, buffer| {
-                        Message::push_at(buffer, time.clone(), &mut pushers[index]);
-                    }
-                );
+                CB::partition(data, &mut self.buffers, |datum| ((hash_func)(datum) & mask) as usize);
             }
             // as a last resort, use mod (%)
             else {
                 let num_pushers = self.pushers.len() as u64;
-                let pushers = &mut self.pushers;
-                data.push_partitioned(
-                    &mut self.buffers,
-                    move |datum| ((hash_func)(datum) % num_pushers) as usize,
-                    |index, buffer| {
-                        Message::push_at(buffer, time.clone(), &mut pushers[index]);
-                    }
-                );
+                CB::partition(data, &mut self.buffers, |datum| ((hash_func)(datum) % num_pushers) as usize);
             }
-
+            for (buffer, pusher) in self.buffers.iter_mut().zip(self.pushers.iter_mut()) {
+                while let Some(container) = buffer.extract() {
+                    Message::push_at(container, time.clone(), pusher);
+                }
+            }
         }
         else {
             // flush

--- a/timely/src/dataflow/channels/pushers/exchange.rs
+++ b/timely/src/dataflow/channels/pushers/exchange.rs
@@ -78,7 +78,7 @@ where
                     &mut self.buffers,
                     move |datum| ((hash_func)(datum) & mask) as usize,
                     |index, buffer| {
-                            Message::push_at(buffer, time.clone(), &mut pushers[index]);
+                        Message::push_at(buffer, time.clone(), &mut pushers[index]);
                     }
                 );
             }

--- a/timely/src/dataflow/operators/core/exchange.rs
+++ b/timely/src/dataflow/operators/core/exchange.rs
@@ -1,13 +1,13 @@
 //! Exchange records between workers.
 
 use crate::ExchangeData;
-use crate::container::PushPartitioned;
+use crate::container::{Container, SizableContainer, PushInto};
 use crate::dataflow::channels::pact::ExchangeCore;
 use crate::dataflow::operators::generic::operator::Operator;
 use crate::dataflow::{Scope, StreamCore};
 
 /// Exchange records between workers.
-pub trait Exchange<C: PushPartitioned> {
+pub trait Exchange<C: Container> {
     /// Exchange records between workers.
     ///
     /// The closure supplied should map a reference to a record to a `u64`,
@@ -30,7 +30,9 @@ pub trait Exchange<C: PushPartitioned> {
 
 impl<G: Scope, C> Exchange<C> for StreamCore<G, C>
 where
-    C: PushPartitioned + ExchangeData + crate::dataflow::channels::ContainerBytes,
+    C: SizableContainer + ExchangeData + crate::dataflow::channels::ContainerBytes,
+    C: for<'a> PushInto<C::Item<'a>>,
+
 {
     fn exchange<F>(&self, route: F) -> StreamCore<G, C>
     where


### PR DESCRIPTION
The `SizableContainer` trait spoke about capacities for containers, meant to allow them to express their capacity, a preference for a capacity, and how to acquire more capacity. It seems like this logic was used to implement some right-sizing of containers, but always in a way that the container could have chosen for itself anyhow.

With that in mind, this PR tries out a new trait that instead looks like
```rust
/// A container that can be sized and reveals its capacity.
pub trait SizableContainer: Container {
    /// Indicates that the container is "full" and should be shipped.
    fn at_capacity(&self) -> bool;
    /// Restores `self` to its desired capacity, if it has one.
    ///
    /// The `stash` argument is available, and may have the intended capacity.
    /// However, it may be non-empty, and may be of the wrong capacity. The
    /// method should guard against these cases.
    fn ensure_capacity(&mut self, stash: &mut Option<Self>);
}
```
Here the container can indicate if it is "at capacity" or in `Vec` terms if its length equals its capacity, and also it can restore its capacity. Each implementation had seemingly straight-forward implementations, and the place the logic was used seem to work great with these functions.

---

The commits continue with one that removes `PushPartitioned` and allows `Exchange` to be parameterized by `CB: ContainerBuilder`, rather than by containers.

---

One VERY IMPORTANT thing to sort out: if folks are allowed to create `Exchange` edges with their own container builders, they *must* preserve the counts correctly, otherwise progress tracking breaks. This might be a moment to revisit that, and see if there is a reasonable decoupling of `.len()` from "number of items in the container". At least, there is a very specific thing that needs to be maintained (count of records accepted), and perhaps it shouldn't be up to the container builder to maintain this?