### PR TITLE
Prefer `byteorder` in place of `bincode`

### DIFF
--- a/timely/Cargo.toml
+++ b/timely/Cargo.toml
@@ -21,6 +21,7 @@ getopts = ["getopts-dep", "timely_communication/getopts"]
 [dependencies]
 getopts-dep = { package = "getopts", version = "0.2.21", optional = true }
 bincode = { version = "1.0" }
+byteorder = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 timely_bytes = { path = "../bytes", version = "0.12" }
 timely_logging = { path = "../logging", version = "0.12" }


### PR DESCRIPTION
Some framing parts of `Message<C, T>` use `bincode` to encode `u64` data, though `byteorder` is just as good and may have better alignment properties (it's unclear if `bincode` ensures alignment, or uses clever varint encoding). This moves us in a direction where there can be more certainty about the shape of serialized data, that would make zero-copy deserialization, which relies on alignment of bytes to be efficient, more likely to work out well.