### PR TITLE
Remove SizableContainer requirement from partition

### DIFF
--- a/container/src/lib.rs
+++ b/container/src/lib.rs
@@ -120,7 +120,6 @@ pub trait ContainerBuilder: Default + 'static {
     fn partition<I>(container: &mut Self::Container, builders: &mut [Self], mut index: I)
     where
         Self: for<'a> PushInto<<Self::Container as Container>::Item<'a>>,
-        Self::Container: SizableContainer,
         I: for<'a> FnMut(&<Self::Container as Container>::Item<'a>) -> usize,
     {
         for datum in container.drain() {

--- a/timely/src/dataflow/channels/pact.rs
+++ b/timely/src/dataflow/channels/pact.rs
@@ -53,7 +53,6 @@ pub type Exchange<D, F> = ExchangeCore<CapacityContainerBuilder<Vec<D>>, F>;
 impl<CB, F> ExchangeCore<CB, F>
 where
     CB: LengthPreservingContainerBuilder,
-    CB::Container: SizableContainer,
     for<'a> F: FnMut(&<CB::Container as Container>::Item<'a>)->u64
 {
     /// Allocates a new `Exchange` pact from a distribution function.
@@ -84,7 +83,7 @@ impl<T: Timestamp, CB, H: 'static> ParallelizationContract<T, CB::Container> for
 where
     CB: ContainerBuilder,
     CB: for<'a> PushInto<<CB::Container as Container>::Item<'a>>,
-    CB::Container: Data + Send + SizableContainer + crate::dataflow::channels::ContainerBytes,
+    CB::Container: Data + Send + crate::dataflow::channels::ContainerBytes,
     for<'a> H: FnMut(&<CB::Container as Container>::Item<'a>) -> u64
 {
     type Pusher = ExchangePusher<T, CB, LogPusher<T, CB::Container, Box<dyn Push<Message<T, CB::Container>>>>, H>;

--- a/timely/src/dataflow/channels/pushers/exchange.rs
+++ b/timely/src/dataflow/channels/pushers/exchange.rs
@@ -1,7 +1,7 @@
 //! The exchange pattern distributes pushed data between many target pushees.
 
 use crate::communication::Push;
-use crate::container::{ContainerBuilder, SizableContainer, PushInto};
+use crate::container::{ContainerBuilder, PushInto};
 use crate::dataflow::channels::Message;
 use crate::{Container, Data};
 
@@ -10,7 +10,6 @@ use crate::{Container, Data};
 pub struct Exchange<T, CB, P, H>
 where
     CB: ContainerBuilder,
-    CB::Container: SizableContainer,
     P: Push<Message<T, CB::Container>>,
     for<'a> H: FnMut(&<CB::Container as Container>::Item<'a>) -> u64
 {
@@ -23,7 +22,6 @@ where
 impl<T: Clone, CB, P, H>  Exchange<T, CB, P, H>
 where
     CB: ContainerBuilder,
-    CB::Container: SizableContainer,
     P: Push<Message<T, CB::Container>>,
     for<'a> H: FnMut(&<CB::Container as Container>::Item<'a>) -> u64
 {
@@ -53,7 +51,6 @@ where
 impl<T: Eq+Data, CB, P, H> Push<Message<T, CB::Container>> for Exchange<T, CB, P, H>
 where
     CB: ContainerBuilder,
-    CB::Container: SizableContainer,
     CB: for<'a> PushInto<<CB::Container as Container>::Item<'a>>,
     P: Push<Message<T, CB::Container>>,
     for<'a> H: FnMut(&<CB::Container as Container>::Item<'a>) -> u64


### PR DESCRIPTION
Removes the SizableContainer requirement from the partition operator. Also removes the same requirement from some places where it's not longer needed.
