### PR TITLE
Align `Bytesable` messages to `u64`

### DIFF
--- a/timely/src/dataflow/channels/mod.rs
+++ b/timely/src/dataflow/channels/mod.rs
@@ -58,7 +58,7 @@ impl<T, C: Container> Message<T, C> {
 
 // Instructions for serialization of `Message`.
 //
-// Serialization of each field is meant to be `u64` aligned, so that each has tha ability
+// Serialization of each field is meant to be `u64` aligned, so that each has the ability
 // to be decoded using safe transmutation, e.g. `bytemuck`.
 impl<T, C> crate::communication::Bytesable for Message<T, C>
 where

--- a/timely/src/dataflow/operators/core/partition.rs
+++ b/timely/src/dataflow/operators/core/partition.rs
@@ -12,7 +12,7 @@ pub trait Partition<G: Scope, C: Container> {
     /// Produces `parts` output streams, containing records produced and assigned by `route`.
     ///
     /// # Examples
-    /// ```ignore
+    /// ```
     /// use timely::dataflow::operators::ToStream;
     /// use timely::dataflow::operators::core::{Partition, Inspect};
     /// use timely_container::CapacityContainerBuilder;

--- a/timely/src/dataflow/operators/core/partition.rs
+++ b/timely/src/dataflow/operators/core/partition.rs
@@ -12,7 +12,7 @@ pub trait Partition<G: Scope, C: Container> {
     /// Produces `parts` output streams, containing records produced and assigned by `route`.
     ///
     /// # Examples
-    /// ```
+    /// ```ignore
     /// use timely::dataflow::operators::ToStream;
     /// use timely::dataflow::operators::core::{Partition, Inspect};
     /// use timely_container::CapacityContainerBuilder;

--- a/timely/src/lib.rs
+++ b/timely/src/lib.rs
@@ -108,8 +108,8 @@ impl<T: Clone+'static> Data for T { }
 ///
 /// The `ExchangeData` trait extends `Data` with any requirements imposed by the `timely_communication`
 /// `Data` trait, which describes requirements for communication along channels.
-pub trait ExchangeData: Data + encoding::Data + columnar::Columnar { }
-impl<T: Data + encoding::Data + columnar::Columnar> ExchangeData for T { }
+pub trait ExchangeData: Data + encoding::Data { }
+impl<T: Data + encoding::Data> ExchangeData for T { }
 
 #[doc = include_str!("../../README.md")]
 #[cfg(doctest)]

--- a/timely/src/lib.rs
+++ b/timely/src/lib.rs
@@ -108,8 +108,8 @@ impl<T: Clone+'static> Data for T { }
 ///
 /// The `ExchangeData` trait extends `Data` with any requirements imposed by the `timely_communication`
 /// `Data` trait, which describes requirements for communication along channels.
-pub trait ExchangeData: Data + encoding::Data { }
-impl<T: Data + encoding::Data> ExchangeData for T { }
+pub trait ExchangeData: Data + encoding::Data + columnar::Columnar { }
+impl<T: Data + encoding::Data + columnar::Columnar> ExchangeData for T { }
 
 #[doc = include_str!("../../README.md")]
 #[cfg(doctest)]
@@ -141,18 +141,25 @@ mod encoding {
         }
     }
 
+    // We will pad out anything we write to make the result `u64` aligned.
     impl<T: Data> Bytesable for Bincode<T> {
         fn from_bytes(bytes: Bytes) -> Self {
             let typed = ::bincode::deserialize(&bytes[..]).expect("bincode::deserialize() failed");
+            let typed_size = ::bincode::serialized_size(&typed).expect("bincode::serialized_size() failed") as usize;
+            assert_eq!(bytes.len(), (typed_size + 7) & !7);
             Bincode { payload: typed }
         }
 
         fn length_in_bytes(&self) -> usize {
-            ::bincode::serialized_size(&self.payload).expect("bincode::serialized_size() failed") as usize
+            let typed_size = ::bincode::serialized_size(&self.payload).expect("bincode::serialized_size() failed") as usize;
+            (typed_size + 7) & !7
         }
 
-        fn into_bytes<W: ::std::io::Write>(&self, writer: &mut W) {
-            ::bincode::serialize_into(writer, &self.payload).expect("bincode::serialize_into() failed");
+        fn into_bytes<W: ::std::io::Write>(&self, mut writer: &mut W) {
+            let typed_size = ::bincode::serialized_size(&self.payload).expect("bincode::serialized_size() failed") as usize;
+            let typed_slop = ((typed_size + 7) & !7) - typed_size;
+            ::bincode::serialize_into(&mut writer, &self.payload).expect("bincode::serialize_into() failed");
+            writer.write(&[0u8; 8][..typed_slop]).unwrap();
         }
     }
 


### PR DESCRIPTION
The `Bytesable` trait is what indicates how we want to serialize messages, should we need to do that. There is an advantage to data containers being `u64` aligned, specifically for `columnar` implementations but potentially for other implementations. This PR adds up to 7 bytes for each message to ensure that each part ends up `u64` aligned. With these changes, the `columnar` example does not need to relocate (memcpy) in order to get aligned data.

Tbd: other containers (e.g. `Vec`, `FlatStack`) don't have the same defensive measures in place yet, and we'll want to figure out how to prevent them from messing anything up either. Their `ContainerBytes` implementation could do this, or the `Bytesable` implementation for `Message` could round up once it has serialized everything.