### PR TITLE
is_empty check before retrieving elapsed time for activations

### DIFF
--- a/timely/src/scheduling/activate.rs
+++ b/timely/src/scheduling/activate.rs
@@ -96,10 +96,12 @@ impl Activations {
         }
 
         // Drain timer-based activations.
-        let now = self.timer.elapsed();
-        while self.queue.peek().map(|Reverse((t,_))| t <= &now) == Some(true) {
-            let Reverse((_time, path)) = self.queue.pop().unwrap();
-            self.activate(&path[..]);
+        if !self.queue.is_empty() {
+            let now = self.timer.elapsed();
+            while self.queue.peek().map(|Reverse((t,_))| t <= &now) == Some(true) {
+                let Reverse((_time, path)) = self.queue.pop().unwrap();
+                self.activate(&path[..]);
+            }
         }
 
         self.bounds.drain(.. self.clean);


### PR DESCRIPTION
While profiling our application, I noticed that we were spending a lot of time in `std::time::Instant::elapsed`. Despite not having any timer-based activations, it looks like this function was being invoked quite a bit and checking the elapsed time unnecessarily on every call. Just a quick fix to make sure the queue has items first.