### PR TITLE
Avoid allocation in progcaster

### DIFF
--- a/timely/src/progress/broadcast.rs
+++ b/timely/src/progress/broadcast.rs
@@ -104,7 +104,7 @@ impl<T:Timestamp+Send> Progcaster<T> {
                     self.to_push = Some(Bincode::from((
                         self.source,
                         self.counter,
-                        changes.clone().into_inner().to_vec(),
+                        changes.clone().into_inner().into_vec(),
                     )));
                 }
 


### PR DESCRIPTION
Previously, we'd first clone the changes to be sent downstream before
converting them to a vector. This can cause two allocations, one for
cloning the change batch, and one for the `to_vec` call (it takes self by
reference). This change adjusts it so that we convert the SmallVec into a
vector (`into_vec`).

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>
