### PR TITLE
Typed logging

### DIFF
--- a/timely/src/progress/broadcast.rs
+++ b/timely/src/progress/broadcast.rs
@@ -28,12 +28,12 @@ pub struct Progcaster<T:Timestamp> {
     /// Communication channel identifier
     channel_identifier: usize,
 
-    progress_logging: Option<ProgressLogger>,
+    progress_logging: Option<ProgressLogger<T>>,
 }
 
 impl<T:Timestamp+Send> Progcaster<T> {
     /// Creates a new `Progcaster` using a channel from the supplied worker.
-    pub fn new<A: crate::worker::AsWorker>(worker: &mut A, addr: Rc<[usize]>, mut logging: Option<Logger>, progress_logging: Option<ProgressLogger>) -> Progcaster<T> {
+    pub fn new<A: crate::worker::AsWorker>(worker: &mut A, addr: Rc<[usize]>, mut logging: Option<Logger>, progress_logging: Option<ProgressLogger<T>>) -> Progcaster<T> {
 
         let channel_identifier = worker.new_identifier();
         let (pushers, puller) = worker.allocate(channel_identifier, addr.clone());
@@ -65,8 +65,8 @@ impl<T:Timestamp+Send> Progcaster<T> {
                 // Pre-allocate enough space; we transfer ownership, so there is not
                 // an opportunity to re-use allocations (w/o changing the logging
                 // interface to accept references).
-                let mut messages = Box::new(Vec::with_capacity(changes.len()));
-                let mut internal = Box::new(Vec::with_capacity(changes.len()));
+                let mut messages = Vec::with_capacity(changes.len());
+                let mut internal = Vec::with_capacity(changes.len());
 
                 for ((location, time), diff) in changes.iter() {
                     match location.port {
@@ -134,8 +134,8 @@ impl<T:Timestamp+Send> Progcaster<T> {
             // options for improving it if performance limits users who want other logging.
             self.progress_logging.as_ref().map(|l| {
 
-                let mut messages = Box::new(Vec::with_capacity(changes.len()));
-                let mut internal = Box::new(Vec::with_capacity(changes.len()));
+                let mut messages = Vec::with_capacity(changes.len());
+                let mut internal = Vec::with_capacity(changes.len());
 
                 for ((location, time), diff) in recv_changes.iter() {
 

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -628,8 +628,9 @@ impl<A: Allocate> Worker<A> {
         let addr = vec![dataflow_index].into();
         let identifier = self.new_identifier();
 
-        let progress_logging = self.logging.borrow_mut().get("timely/progress");
-        let subscope = SubgraphBuilder::new_from(addr, logging.clone(), progress_logging.clone(), name);
+        let type_name = std::any::type_name::<T>();
+        let progress_logging = self.logging.borrow_mut().get(&format!("timely/progress/{type_name}"));
+        let subscope = SubgraphBuilder::new_from(addr, logging.clone(), name);
         let subscope = RefCell::new(subscope);
 
         let result = {


### PR DESCRIPTION
Convert the progress and reachability logs to typed logs, which do not require casting at runtime.

The loggers are accessible using new names:
* `timely/progress` -> `timely/progress/` with the type name appended.
* `timely/reachability` -> `timely/reachability/` with the type name appended.

It's using `std::any::type_name()` to determine a unique string for the timestamp type.

Analyzing `logging-send` for allocations, this roughly cuts down total allocations in half.

`target/release/examples/logging-send 1000 1000 -w4` produces roughly 850k allocations in current master, and 445k on this branch.

