### PR TITLE
Log operator summaries using clever approach

### DIFF
--- a/timely/examples/logging-send.rs
+++ b/timely/examples/logging-send.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use timely::dataflow::{InputHandle, ProbeHandle};
 use timely::dataflow::operators::{Input, Exchange, Probe};
-use timely::logging::{TimelyEventBuilder, TimelyProgressEventBuilder};
+use timely::logging::{TimelyEventBuilder, TimelyProgressEventBuilder, TimelySummaryEventBuilder};
 use timely::container::CapacityContainerBuilder;
 use timely::progress::reachability::logging::TrackerEventBuilder;
 
@@ -58,6 +58,17 @@ fn main() {
             }
             else {
                 println!("REACHABILITY: Flush {time:?}");
+            }
+        );
+
+        worker.log_register().insert::<TimelySummaryEventBuilder<usize>,_>("timely/summary/usize", |time, data|
+            if let Some(data) = data {
+                data.iter().for_each(|(_, x)| {
+                    println!("SUMMARY: {:?}", x);
+                })
+            }
+            else {
+                println!("SUMMARY: Flush {time:?}");
             }
         );
 

--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -132,8 +132,9 @@ where
 
         let type_name = std::any::type_name::<T2>();
         let progress_logging = self.log_register().get(&format!("timely/progress/{type_name}"));
+        let summary_logging = self.log_register().get(&format!("timely/summary/{type_name}"));
 
-        let subscope = RefCell::new(SubgraphBuilder::new_from(path, self.logging(), name));
+        let subscope = RefCell::new(SubgraphBuilder::new_from(path, self.logging(), summary_logging, name));
         let result = {
             let mut builder = Child {
                 subgraph: &subscope,

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -10,6 +10,10 @@ pub type TimelyLogger = crate::logging_core::TypedLogger<TimelyEventBuilder, Tim
 pub type TimelyProgressEventBuilder<T> = CapacityContainerBuilder<Vec<(Duration, TimelyProgressEvent<T>)>>;
 /// Logger for timely dataflow progress events (the "timely/progress" log stream).
 pub type TimelyProgressLogger<T> = crate::logging_core::Logger<TimelyProgressEventBuilder<T>>;
+/// Container builder for timely dataflow progress events.
+pub type TimelySummaryEventBuilder<TS> = CapacityContainerBuilder<Vec<(Duration, OperatesSummaryEvent<TS>)>>;
+/// Logger for timely dataflow progress events (the "timely/progress" log stream).
+pub type TimelySummaryLogger<TS> = crate::logging_core::Logger<TimelySummaryEventBuilder<TS>>;
 
 use std::time::Duration;
 use columnar::Columnar;
@@ -63,6 +67,16 @@ pub struct OperatesEvent {
     pub addr: Vec<usize>,
     /// A helpful name.
     pub name: String,
+}
+
+
+#[derive(Serialize, Deserialize, Columnar, Debug, Clone, Eq, PartialEq)]
+/// The summary of internal connectivity of an `Operate` implementor.
+pub struct OperatesSummaryEvent<TS> {
+    /// Worker-unique identifier for the operator.
+    pub id: usize,
+    /// Timestamp action summaries for (input, output) pairs.
+    pub summary: Vec<Vec<crate::progress::Antichain<TS>>>,
 }
 
 #[derive(Serialize, Deserialize, Columnar, Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -8,11 +8,11 @@ pub type TimelyEventBuilder = CapacityContainerBuilder<Vec<(Duration, TimelyEven
 pub type TimelyLogger = crate::logging_core::TypedLogger<TimelyEventBuilder, TimelyEvent>;
 /// Container builder for timely dataflow progress events.
 pub type TimelyProgressEventBuilder<T> = CapacityContainerBuilder<Vec<(Duration, TimelyProgressEvent<T>)>>;
-/// Logger for timely dataflow progress events (the "timely/progress" log stream).
+/// Logger for timely dataflow progress events (the "timely/progress/*" log streams).
 pub type TimelyProgressLogger<T> = crate::logging_core::Logger<TimelyProgressEventBuilder<T>>;
-/// Container builder for timely dataflow progress events.
+/// Container builder for timely dataflow operator summary events.
 pub type TimelySummaryEventBuilder<TS> = CapacityContainerBuilder<Vec<(Duration, OperatesSummaryEvent<TS>)>>;
-/// Logger for timely dataflow progress events (the "timely/progress" log stream).
+/// Logger for timely dataflow operator summary events (the "timely/summary/*" log streams).
 pub type TimelySummaryLogger<TS> = crate::logging_core::Logger<TimelySummaryEventBuilder<TS>>;
 
 use std::time::Duration;

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -630,7 +630,8 @@ impl<A: Allocate> Worker<A> {
 
         let type_name = std::any::type_name::<T>();
         let progress_logging = self.logging.borrow_mut().get(&format!("timely/progress/{type_name}"));
-        let subscope = SubgraphBuilder::new_from(addr, logging.clone(), name);
+        let summary_logging = self.logging.borrow_mut().get(&format!("timely/summary/{type_name}"));
+        let subscope = SubgraphBuilder::new_from(addr, logging.clone(), summary_logging, name);
         let subscope = RefCell::new(subscope);
 
         let result = {


### PR DESCRIPTION
Attempt at logging operator summaries (the internal matrix of input->output timestamp summaries describing the operator's internal connectivity). I mostly copied existing code, and .. once this is up I'll be able to have a better look and see if it makes any sense. It roughly follows #624 which did something similar for progress and reachability logging, though I may have erred in important ways.