### PR TITLE
Allow event iterators to surface owned data

### DIFF
--- a/timely/src/dataflow/operators/core/capture/replay.rs
+++ b/timely/src/dataflow/operators/core/capture/replay.rs
@@ -95,10 +95,16 @@ where
                 for event_stream in event_streams.iter_mut() {
                     while let Some(event) = event_stream.next() {
                         match event {
-                            Event::Progress(vec) => {
+                            Ok(Event::Progress(vec)) => {
+                                progress.internals[0].extend(vec.into_iter());
+                            },
+                            Ok(Event::Messages(time, mut data)) => {
+                                output.session(&time).give_container(&mut data);
+                            }
+                            Err(Event::Progress(vec)) => {
                                 progress.internals[0].extend(vec.iter().cloned());
                             },
-                            Event::Messages(ref time, data) => {
+                            Err(Event::Messages(time, data)) => {
                                 allocation.clone_from(data);
                                 output.session(time).give_container(&mut allocation);
                             }

--- a/timely/src/dataflow/operators/core/capture/replay.rs
+++ b/timely/src/dataflow/operators/core/capture/replay.rs
@@ -94,17 +94,18 @@ where
 
                 for event_stream in event_streams.iter_mut() {
                     while let Some(event) = event_stream.next() {
+                        use std::borrow::Cow::*;
                         match event {
-                            Ok(Event::Progress(vec)) => {
+                            Owned(Event::Progress(vec)) => {
                                 progress.internals[0].extend(vec.into_iter());
                             },
-                            Ok(Event::Messages(time, mut data)) => {
+                            Owned(Event::Messages(time, mut data)) => {
                                 output.session(&time).give_container(&mut data);
                             }
-                            Err(Event::Progress(vec)) => {
+                            Borrowed(Event::Progress(vec)) => {
                                 progress.internals[0].extend(vec.iter().cloned());
                             },
-                            Err(Event::Messages(time, data)) => {
+                            Borrowed(Event::Messages(time, data)) => {
                                 allocation.clone_from(data);
                                 output.session(time).give_container(&mut allocation);
                             }


### PR DESCRIPTION
Previously, event iterators were forced to handing out references to data,
even if they could return owned data. This is not great because it requires
the replay operator to clone the data to send it downstream.

With this change, the event iterator can surface either owned or shared
data, which allows the `Rc<EventLink>` to surface owned data when it is
uniquely owned, and references when it is shared. This avoids cloning data
when there is only a single replay operator attached to an event link.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>
