### PR TITLE
Introduce foundation for broadcast channel

### DIFF
--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -64,6 +64,9 @@ where
     fn pipeline<D: 'static>(&mut self, identifier: usize, address: Rc<[usize]>) -> (ThreadPusher<D>, ThreadPuller<D>) {
         self.parent.pipeline(identifier, address)
     }
+    fn broadcast<D: Exchangeable + Clone>(&mut self, identifier: usize, address: Rc<[usize]>) -> (Box<dyn Push<D>>, Box<dyn Pull<D>>) {
+        self.parent.broadcast(identifier, address)
+    }
     fn new_identifier(&mut self) -> usize {
         self.parent.new_identifier()
     }

--- a/timely/src/lib.rs
+++ b/timely/src/lib.rs
@@ -130,6 +130,7 @@ mod encoding {
     impl<T: Send+Any+Serialize+for<'a>Deserialize<'a>> Data for T { }
 
     /// A wrapper that indicates `bincode` as the serialization/deserialization strategy.
+    #[derive(Clone)]
     pub struct Bincode<T> {
         /// Bincode contents.
         pub payload: T,


### PR DESCRIPTION
This PR introduces a `broadcast` channel allocation method to `communication::Allocate`. It defaults to using a point-to-point channel and cloning the contents, but it can be implemented more thoughtfully by implementors. For example, we might soon like to have the inter-process channels only send the data once, rather than once for each remote worker.

Potential follow-up: an `all_reduce` channel, not unlike a broadcast channel but with the opportunity to consolidate updates that move along the channel. Both the broadcast and hypothetical all-reduce are in service of progress messages, which support an all-reduce pattern.