### PR TITLE
Convert `Write::write` to `Write::write_all`

### DIFF
--- a/timely/src/dataflow/channels/mod.rs
+++ b/timely/src/dataflow/channels/mod.rs
@@ -92,7 +92,7 @@ where
         ::bincode::serialize_into(&mut *writer, &self.time).expect("bincode::serialize_into() failed");
         let time_size = ::bincode::serialized_size(&self.time).expect("bincode::serialized_size() failed") as usize;
         let time_slop = ((time_size + 7) & !7) - time_size;
-        writer.write(&[0u8; 8][..time_slop]).unwrap();
+        writer.write_all(&[0u8; 8][..time_slop]).unwrap();
         self.data.into_bytes(&mut *writer);
     }
 }
@@ -132,7 +132,7 @@ mod implementations {
             ::bincode::serialize_into(&mut counter, &self).expect("bincode::serialize_into() failed");
             let written = counter.count;
             let written_slop = ((written + 7) & !7) - written;
-            counter.write(&[0u8; 8][..written_slop]).unwrap();
+            counter.write_all(&[0u8; 8][..written_slop]).unwrap();
         }
     }
 
@@ -152,7 +152,7 @@ mod implementations {
             ::bincode::serialize_into(&mut counter, &self).expect("bincode::serialize_into() failed");
             let written = counter.count;
             let written_slop = ((written + 7) & !7) - written;
-            counter.write(&[0u8; 8][..written_slop]).unwrap();
+            counter.write_all(&[0u8; 8][..written_slop]).unwrap();
         }
     }
 

--- a/timely/src/lib.rs
+++ b/timely/src/lib.rs
@@ -160,7 +160,7 @@ mod encoding {
             let typed_size = ::bincode::serialized_size(&self.payload).expect("bincode::serialized_size() failed") as usize;
             let typed_slop = ((typed_size + 7) & !7) - typed_size;
             ::bincode::serialize_into(&mut writer, &self.payload).expect("bincode::serialize_into() failed");
-            writer.write(&[0u8; 8][..typed_slop]).unwrap();
+            writer.write_all(&[0u8; 8][..typed_slop]).unwrap();
         }
     }
 


### PR DESCRIPTION
A bug picked up by `clippy`; many thanks!

We were using `Write::write`, which doesn't guarantee it will write all the bytes, and returns the number it wrote, which one is meant to react to. Clippy noticed that we did not, and it's a bug! Converting these to `Write::write_all` ensures all bytes are written.