### PR TITLE
Update columnar to 0.3, make workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 
+[workspace.dependencies]
+columnar = "0.3"
+
 [profile.release]
 opt-level = 3
 debug = true

--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT"
 default = ["getopts"]
 
 [dependencies]
-columnar = "0.2"
+columnar = { workspace = true }
 getopts = { version = "0.2.21", optional = true }
 byteorder = "1.5"
 serde = { version = "1.0", features = ["derive"] }

--- a/timely/Cargo.toml
+++ b/timely/Cargo.toml
@@ -19,7 +19,7 @@ default = ["getopts"]
 getopts = ["getopts-dep", "timely_communication/getopts"]
 
 [dependencies]
-columnar = "0.3"
+columnar = { workspace = true }
 getopts-dep = { package = "getopts", version = "0.2.21", optional = true }
 bincode = { version = "1.0" }
 byteorder = "1.5"


### PR DESCRIPTION
Update to columnar 0.3, and turn the dependency into a workspace
dependency. This forces all uses of columnar to a single version.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>
