### PR TITLE
Demonstrate `BytesSlab` with abstracted bytes storage

### DIFF
--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -26,5 +26,6 @@ timely_container = { path = "../container", version = "0.14.0" }
 timely_logging = { path = "../logging", version = "0.13" }
 crossbeam-channel = "0.5"
 
-[dev-dependencies]
+# Lgalloc only supports linux and macos, don't depend on any other OS.
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dev-dependencies]
 lgalloc = "0.4"

--- a/communication/Cargo.toml
+++ b/communication/Cargo.toml
@@ -25,3 +25,6 @@ timely_bytes = { path = "../bytes", version = "0.13" }
 timely_container = { path = "../container", version = "0.14.0" }
 timely_logging = { path = "../logging", version = "0.13" }
 crossbeam-channel = "0.5"
+
+[dev-dependencies]
+lgalloc = "0.4"

--- a/communication/examples/lgalloc.rs
+++ b/communication/examples/lgalloc.rs
@@ -1,3 +1,5 @@
+#![cfg(any(target_os = "linux", target_os = "macos"))]
+
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 use timely_communication::{Allocate, Bytesable};

--- a/communication/examples/lgalloc.rs
+++ b/communication/examples/lgalloc.rs
@@ -1,0 +1,104 @@
+use std::ops::{Deref, DerefMut};
+use timely_communication::{Allocate, Bytesable};
+
+/// A wrapper that indicates the serialization/deserialization strategy.
+pub struct Message {
+    /// Text contents.
+    pub payload: String,
+}
+
+impl Bytesable for Message {
+    fn from_bytes(bytes: timely_bytes::arc::Bytes) -> Self {
+        Message { payload: std::str::from_utf8(&bytes[..]).unwrap().to_string() }
+    }
+
+    fn length_in_bytes(&self) -> usize {
+        self.payload.len()
+    }
+
+    fn into_bytes<W: ::std::io::Write>(&self, writer: &mut W) {
+        writer.write_all(self.payload.as_bytes()).unwrap();
+    }
+}
+
+fn lgalloc_refill(size: usize) -> Box<LgallocHandle> {
+    let (ptr, cap, handle) = lgalloc::allocate::<u8>(size).unwrap();
+    let slice = unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr(), cap) };
+    let handle = Some(handle);
+    Box::new(LgallocHandle { handle, slice: slice.into() })
+}
+
+struct LgallocHandle {
+    handle: Option<lgalloc::Handle>,
+    slice: Box<[u8]>
+}
+
+impl Deref for LgallocHandle {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.slice
+    }
+}
+
+impl DerefMut for LgallocHandle {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.slice
+    }
+}
+
+impl Drop for LgallocHandle {
+    fn drop(&mut self) {
+        Box::leak(std::mem::take(&mut self.slice));
+        lgalloc::deallocate(self.handle.take().unwrap());
+    }
+}
+
+fn main() {
+    let mut config = lgalloc::LgAlloc::new();
+    config.enable().with_path(std::env::temp_dir()); 
+    lgalloc::lgalloc_set_config(&config);
+
+    let refill = std::sync::Arc::new(|size| lgalloc_refill(size) as Box<dyn DerefMut<Target=[u8]>>);
+
+    // extract the configuration from user-supplied arguments, initialize the computation.
+    let config = timely_communication::Config::ProcessBinary(4);
+    let (allocators, others) = config.try_build_with(refill).unwrap();
+    let guards = timely_communication::initialize_from(allocators, others, |mut allocator| {
+
+        println!("worker {} of {} started", allocator.index(), allocator.peers());
+
+        // allocates a pair of senders list and one receiver.
+        let (mut senders, mut receiver) = allocator.allocate(0);
+
+        // send typed data along each channel
+        for i in 0 .. allocator.peers() {
+            senders[i].send(Message { payload: format!("hello, {}", i)});
+            senders[i].done();
+        }
+
+        // no support for termination notification,
+        // we have to count down ourselves.
+        let mut received = 0;
+        while received < allocator.peers() {
+
+            allocator.receive();
+
+            if let Some(message) = receiver.recv() {
+                println!("worker {}: received: <{}>", allocator.index(), message.payload);
+                received += 1;
+            }
+
+            allocator.release();
+        }
+
+        allocator.index()
+    });
+
+    // computation runs until guards are joined or dropped.
+    if let Ok(guards) = guards {
+        for guard in guards.join() {
+            println!("result: {:?}", guard);
+        }
+    }
+    else { println!("error in computation"); }
+}

--- a/communication/src/allocator/mod.rs
+++ b/communication/src/allocator/mod.rs
@@ -126,10 +126,12 @@ impl<T: Clone> Push<T> for Broadcaster<T> {
     }
 }
 
+use crate::allocator::zero_copy::bytes_slab::BytesRefill;
+
 /// A builder for vectors of peers.
 pub trait PeerBuilder {
     /// The peer type.
     type Peer: AllocateBuilder + Sized;
     /// Allocate a list of `Self::Peer` of length `peers`.
-    fn new_vector(peers: usize) -> Vec<Self::Peer>;
+    fn new_vector(peers: usize, refill: BytesRefill) -> Vec<Self::Peer>;
 }

--- a/communication/src/allocator/process.rs
+++ b/communication/src/allocator/process.rs
@@ -75,7 +75,7 @@ impl Process {
 impl PeerBuilder for Process {
     type Peer = ProcessBuilder;
     /// Allocate a list of connected intra-process allocators.
-    fn new_vector(peers: usize) -> Vec<ProcessBuilder> {
+    fn new_vector(peers: usize, _refill: crate::allocator::BytesRefill) -> Vec<ProcessBuilder> {
 
         let mut counters_send = Vec::with_capacity(peers);
         let mut counters_recv = Vec::with_capacity(peers);

--- a/communication/src/allocator/zero_copy/bytes_exchange.rs
+++ b/communication/src/allocator/zero_copy/bytes_exchange.rs
@@ -145,7 +145,7 @@ impl<P: BytesPush> SendEndpoint<P> {
     pub fn new(queue: P) -> Self {
         SendEndpoint {
             send: queue,
-            buffer: BytesSlab::new(20),
+            buffer: BytesSlab::new(20, Box::new(|size| Box::new(vec![0u8; size]))),
         }
     }
     /// Makes the next `bytes` bytes valid.

--- a/communication/src/allocator/zero_copy/bytes_exchange.rs
+++ b/communication/src/allocator/zero_copy/bytes_exchange.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::collections::VecDeque;
 
 use timely_bytes::arc::Bytes;
-use super::bytes_slab::BytesSlab;
+use super::bytes_slab::{BytesRefill, BytesSlab};
 
 /// A target for `Bytes`.
 pub trait BytesPush {
@@ -142,10 +142,10 @@ impl<P: BytesPush> SendEndpoint<P> {
     }
 
     /// Allocates a new `BytesSendEndpoint` from a shared queue.
-    pub fn new(queue: P) -> Self {
+    pub fn new(queue: P, refill: BytesRefill) -> Self {
         SendEndpoint {
             send: queue,
-            buffer: BytesSlab::new(20, Box::new(|size| Box::new(vec![0u8; size]))),
+            buffer: BytesSlab::new(20, refill),
         }
     }
     /// Makes the next `bytes` bytes valid.

--- a/communication/src/allocator/zero_copy/tcp.rs
+++ b/communication/src/allocator/zero_copy/tcp.rs
@@ -45,7 +45,7 @@ where
 
     let mut targets: Vec<MergeQueue> = targets.into_iter().map(|x| x.recv().expect("Failed to receive MergeQueue")).collect();
 
-    let mut buffer = BytesSlab::new(20);
+    let mut buffer = BytesSlab::new(20, Box::new(|size| Box::new(vec![0u8; size])));
 
     // Where we stash Bytes before handing them off.
     let mut stageds = Vec::with_capacity(targets.len());

--- a/communication/src/allocator/zero_copy/tcp.rs
+++ b/communication/src/allocator/zero_copy/tcp.rs
@@ -5,7 +5,7 @@ use crossbeam_channel::{Sender, Receiver};
 
 use crate::networking::MessageHeader;
 
-use super::bytes_slab::BytesSlab;
+use super::bytes_slab::{BytesRefill, BytesSlab};
 use super::bytes_exchange::MergeQueue;
 use super::stream::Stream;
 
@@ -35,7 +35,9 @@ pub fn recv_loop<S>(
     worker_offset: usize,
     process: usize,
     remote: usize,
-    logger: Option<Logger<CommunicationEventBuilder>>)
+    refill: BytesRefill,
+    logger: Option<Logger<CommunicationEventBuilder>>
+)
 where
     S: Stream,
 {
@@ -45,7 +47,7 @@ where
 
     let mut targets: Vec<MergeQueue> = targets.into_iter().map(|x| x.recv().expect("Failed to receive MergeQueue")).collect();
 
-    let mut buffer = BytesSlab::new(20, Box::new(|size| Box::new(vec![0u8; size])));
+    let mut buffer = BytesSlab::new(20, refill);
 
     // Where we stash Bytes before handing them off.
     let mut stageds = Vec::with_capacity(targets.len());


### PR DESCRIPTION
This PR demonstrates how one could use a `BytesSlab` without specifying the `T: DerefMut<Target=[u8]>` and instead using a `Box<dyn ...>` instead.