### PR TITLE
Zero-copy for networked processes

### DIFF
--- a/communication/src/allocator/generic.rs
+++ b/communication/src/allocator/generic.rs
@@ -25,6 +25,8 @@ pub enum Generic {
     ProcessBinary(ProcessAllocator),
     /// Inter-process allocator.
     ZeroCopy(TcpAllocator<Process>),
+    /// Inter-process allocator, intra-process serializing allocator.
+    ZeroCopyBinary(TcpAllocator<ProcessAllocator>),
 }
 
 impl Generic {
@@ -35,6 +37,7 @@ impl Generic {
             Generic::Process(p) => p.index(),
             Generic::ProcessBinary(pb) => pb.index(),
             Generic::ZeroCopy(z) => z.index(),
+            Generic::ZeroCopyBinary(z) => z.index(),
         }
     }
     /// The number of workers.
@@ -44,6 +47,7 @@ impl Generic {
             Generic::Process(p) => p.peers(),
             Generic::ProcessBinary(pb) => pb.peers(),
             Generic::ZeroCopy(z) => z.peers(),
+            Generic::ZeroCopyBinary(z) => z.peers(),
         }
     }
     /// Constructs several send endpoints and one receive endpoint.
@@ -53,6 +57,7 @@ impl Generic {
             Generic::Process(p) => p.allocate(identifier),
             Generic::ProcessBinary(pb) => pb.allocate(identifier),
             Generic::ZeroCopy(z) => z.allocate(identifier),
+            Generic::ZeroCopyBinary(z) => z.allocate(identifier),
         }
     }
     /// Constructs several send endpoints and one receive endpoint.
@@ -62,6 +67,7 @@ impl Generic {
             Generic::Process(p) => p.broadcast(identifier),
             Generic::ProcessBinary(pb) => pb.broadcast(identifier),
             Generic::ZeroCopy(z) => z.broadcast(identifier),
+            Generic::ZeroCopyBinary(z) => z.broadcast(identifier),
         }
     }
     /// Perform work before scheduling operators.
@@ -71,6 +77,7 @@ impl Generic {
             Generic::Process(p) => p.receive(),
             Generic::ProcessBinary(pb) => pb.receive(),
             Generic::ZeroCopy(z) => z.receive(),
+            Generic::ZeroCopyBinary(z) => z.receive(),
         }
     }
     /// Perform work after scheduling operators.
@@ -80,6 +87,7 @@ impl Generic {
             Generic::Process(p) => p.release(),
             Generic::ProcessBinary(pb) => pb.release(),
             Generic::ZeroCopy(z) => z.release(),
+            Generic::ZeroCopyBinary(z) => z.release(),
         }
     }
     fn events(&self) -> &Rc<RefCell<Vec<usize>>> {
@@ -88,6 +96,7 @@ impl Generic {
             Generic::Process(ref p) => p.events(),
             Generic::ProcessBinary(ref pb) => pb.events(),
             Generic::ZeroCopy(ref z) => z.events(),
+            Generic::ZeroCopyBinary(ref z) => z.events(),
         }
     }
 }
@@ -110,6 +119,7 @@ impl Allocate for Generic {
             Generic::Process(p) => p.await_events(_duration),
             Generic::ProcessBinary(pb) => pb.await_events(_duration),
             Generic::ZeroCopy(z) => z.await_events(_duration),
+            Generic::ZeroCopyBinary(z) => z.await_events(_duration),
         }
     }
 }
@@ -129,6 +139,8 @@ pub enum GenericBuilder {
     ProcessBinary(ProcessBuilder),
     /// Builder for `ZeroCopy` allocator.
     ZeroCopy(TcpBuilder<TypedProcessBuilder>),
+    /// Builder for `ZeroCopyBinary` allocator.
+    ZeroCopyBinary(TcpBuilder<ProcessBuilder>),
 }
 
 impl AllocateBuilder for GenericBuilder {
@@ -139,6 +151,7 @@ impl AllocateBuilder for GenericBuilder {
             GenericBuilder::Process(p) => Generic::Process(p.build()),
             GenericBuilder::ProcessBinary(pb) => Generic::ProcessBinary(pb.build()),
             GenericBuilder::ZeroCopy(z) => Generic::ZeroCopy(z.build()),
+            GenericBuilder::ZeroCopyBinary(z) => Generic::ZeroCopyBinary(z.build()),
         }
     }
 }

--- a/communication/src/allocator/mod.rs
+++ b/communication/src/allocator/mod.rs
@@ -125,3 +125,11 @@ impl<T: Clone> Push<T> for Broadcaster<T> {
         }
     }
 }
+
+/// A builder for vectors of peers.
+pub trait PeerBuilder {
+    /// The peer type.
+    type Peer: AllocateBuilder + Sized;
+    /// Allocate a list of `Self::Peer` of length `peers`.
+    fn new_vector(peers: usize) -> Vec<Self::Peer>;
+}

--- a/communication/src/allocator/process.rs
+++ b/communication/src/allocator/process.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap};
 use crossbeam_channel::{Sender, Receiver};
 
 use crate::allocator::thread::{ThreadBuilder};
-use crate::allocator::{Allocate, AllocateBuilder, Thread};
+use crate::allocator::{Allocate, AllocateBuilder, PeerBuilder, Thread};
 use crate::{Push, Pull};
 use crate::buzzer::Buzzer;
 
@@ -70,8 +70,12 @@ pub struct Process {
 impl Process {
     /// Access the wrapped inner allocator.
     pub fn inner(&mut self) -> &mut Thread { &mut self.inner }
+}
+
+impl PeerBuilder for Process {
+    type Peer = ProcessBuilder;
     /// Allocate a list of connected intra-process allocators.
-    pub fn new_vector(peers: usize) -> Vec<ProcessBuilder> {
+    fn new_vector(peers: usize) -> Vec<ProcessBuilder> {
 
         let mut counters_send = Vec::with_capacity(peers);
         let mut counters_recv = Vec::with_capacity(peers);

--- a/communication/src/allocator/zero_copy/allocator_process.rs
+++ b/communication/src/allocator/zero_copy/allocator_process.rs
@@ -10,7 +10,7 @@ use timely_bytes::arc::Bytes;
 use crate::networking::MessageHeader;
 
 use crate::{Allocate, Push, Pull};
-use crate::allocator::{AllocateBuilder, Exchangeable};
+use crate::allocator::{AllocateBuilder, Exchangeable, PeerBuilder};
 use crate::allocator::canary::Canary;
 
 use super::bytes_exchange::{BytesPull, SendEndpoint, MergeQueue};
@@ -30,11 +30,12 @@ pub struct ProcessBuilder {
     pullers: Vec<Sender<MergeQueue>>,   // for pulling bytes from other workers.
 }
 
-impl ProcessBuilder {
+impl PeerBuilder for ProcessBuilder {
+    type Peer = ProcessBuilder;
     /// Creates a vector of builders, sharing appropriate state.
     ///
     /// This method requires access to a byte exchanger, from which it mints channels.
-    pub fn new_vector(count: usize) -> Vec<ProcessBuilder> {
+    fn new_vector(count: usize) -> Vec<ProcessBuilder> {
 
         // Channels for the exchange of `MergeQueue` endpoints.
         let (pullers_vec, pushers_vec) = crate::promise_futures(count, count);
@@ -53,7 +54,9 @@ impl ProcessBuilder {
             )
             .collect()
     }
+}
 
+impl ProcessBuilder {
     /// Builds a `ProcessAllocator`, instantiating `Rc<RefCell<_>>` elements.
     pub fn build(self) -> ProcessAllocator {
 

--- a/communication/src/initialize.rs
+++ b/communication/src/initialize.rs
@@ -49,14 +49,14 @@ impl Debug for Config {
             Config::Thread => write!(f, "Config::Thread()"),
             Config::Process(n) => write!(f, "Config::Process({})", n),
             Config::ProcessBinary(n) => write!(f, "Config::ProcessBinary({})", n),
-            Config::Cluster { threads, process, addresses, report, .. } => f
+            Config::Cluster { threads, process, addresses, report, zerocopy, log_fn: _ } => f
                 .debug_struct("Config::Cluster")
                 .field("threads", threads)
                 .field("process", process)
                 .field("addresses", addresses)
                 .field("report", report)
-                // TODO: Use `.finish_non_exhaustive()` after rust/#67364 lands
-                .finish()
+                .field("zerocopy", zerocopy)
+                .finish_non_exhaustive()
         }
     }
 }
@@ -115,7 +115,7 @@ impl Config {
                 }
             }
 
-            assert!(processes == addresses.len());
+            assert_eq!(processes, addresses.len());
             Ok(Config::Cluster {
                 threads,
                 process,


### PR DESCRIPTION
Introduce a intra- and inter-process serializing configuration variant.
Previously, it wasn't possible to construct a networked configuration that
would use zero-copy for process-local communication.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>
