### PR TITLE
Allow limits on spare buffers maintained in `BytesSlab`

### DIFF
--- a/communication/examples/lgalloc.rs
+++ b/communication/examples/lgalloc.rs
@@ -3,6 +3,7 @@
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 use timely_communication::{Allocate, Bytesable};
+use timely_communication::allocator::zero_copy::bytes_slab::BytesRefill;
 
 /// A wrapper that indicates the serialization/deserialization strategy.
 pub struct Message {
@@ -62,7 +63,10 @@ fn main() {
     config.enable().with_path(std::env::temp_dir()); 
     lgalloc::lgalloc_set_config(&config);
 
-    let refill = std::sync::Arc::new(|size| lgalloc_refill(size) as Box<dyn DerefMut<Target=[u8]>>);
+    let refill = BytesRefill {
+        logic: std::sync::Arc::new(|size| lgalloc_refill(size) as Box<dyn DerefMut<Target=[u8]>>),
+        limit: None,
+    };
 
     // extract the configuration from user-supplied arguments, initialize the computation.
     let config = timely_communication::Config::ProcessBinary(4);

--- a/communication/src/initialize.rs
+++ b/communication/src/initialize.rs
@@ -152,7 +152,10 @@ impl Config {
 
     /// Attempts to assemble the described communication infrastructure.
     pub fn try_build(self) -> Result<(Vec<GenericBuilder>, Box<dyn Any+Send>), String> {
-        let refill = Arc::new(|size| Box::new(vec![0_u8; size]) as Box<dyn DerefMut<Target=[u8]>>);
+        let refill = BytesRefill {
+            logic: Arc::new(|size| Box::new(vec![0_u8; size]) as Box<dyn DerefMut<Target=[u8]>>),
+            limit: None,
+        };
         self.try_build_with(refill)
     }
 


### PR DESCRIPTION
The `BytesSlab` creates byte buffers for communication, and once fully read stashes them for future use. This PR allows the specification of an optional number of buffers to retain, above which the buffers are discarded. This is currently a *number* of buffers, rather than aggregate memory, or something more sophisticated. I'm not certain how we want this to end up, but starting with connecting the dots to try something out.