### PR TITLE
Get `columnar` example to non-`realloc`'ing state

### DIFF
--- a/communication/src/allocator/thread.rs
+++ b/communication/src/allocator/thread.rs
@@ -94,12 +94,12 @@ impl<T> Pull<T> for Puller<T> {
     #[inline]
     fn pull(&mut self) -> &mut Option<T> {
         let mut borrow = self.source.borrow_mut();
-        // if let Some(element) = self.current.take() {
-        //     // TODO : Arbitrary constant.
-        //     if borrow.1.len() < 16 {
-        //         borrow.1.push_back(element);
-        //     }
-        // }
+        if let Some(element) = self.current.take() {
+            // TODO : Arbitrary constant.
+            if borrow.1.len() < 16 {
+                borrow.1.push_back(element);
+            }
+        }
         self.current = borrow.0.pop_front();
         &mut self.current
     }

--- a/timely/examples/columnar.rs
+++ b/timely/examples/columnar.rs
@@ -99,7 +99,7 @@ fn main() {
         });
 
         // introduce data and watch!
-        for round in 0..10 {
+        for round in 0.. {
             input.send(WordCountReference { text: "flat container", diff: 1 });
             input.advance_to(round + 1);
             while probe.less_than(input.time()) {
@@ -327,9 +327,12 @@ mod builder {
         fn finish(&mut self) -> Option<&mut Self::Container> {
             if !self.current.is_empty() {
                 self.pending.push_back(Column::Typed(std::mem::take(&mut self.current)));
+                if let Some(Column::Typed(spare)) = self.empty.take() {
+                    self.current = spare;
+                    self.current.clear();
+                }
             }
-            self.empty = self.pending.pop_front();
-            self.empty.as_mut()
+            self.extract()
         }
     }
 


### PR DESCRIPTION
Changes made to timely and `examples/columnar.rs` so that the example can run indefinitely without calling `realloc` in steady state. Concretely, 
```
sudo dtrace -n 'pid$target::realloc:entry { @ = quantize(arg1); }' -c 'target/debug/examples/columnar'
```
results in (after however long you like)
```
...
seen: WordCountReference { text: "flat", diff: 24367 }
seen: WordCountReference { text: "flat", diff: 24368 }
seen: WordCountReference { text: "flat", diff: 24369 }
seen: WordCountReference { text: "container", diff: 24367 }
seen: WordCountReference { text: "container", diff: 24368 }
seen: WordCountReference { text: "container", diff: 24369 }
^C


           value  ------------- Distribution ------------- count    
               4 |                                         0        
               8 |@                                        3        
              16 |@@@@@                                    14       
              32 |@@                                       4        
              64 |@@@@@@@                                  18       
             128 |@@@@@@@@@@                               25       
             256 |@@@@@@@                                  19       
             512 |@@@@@                                    12       
            1024 |@@@                                      7        
            2048 |                                         0        

mcsherry@gallustrate timely-dataflow %
```
The changes are not all great. In particular, the changes to `thread::Puller` feeds allocations back to the pusher from which it received them, which has the potential to leak some amount of memory, if the pusher is no longer active. But if you don't have this, the pipeline channel is a moment where allocations leave the system (the recipient has nothing it can do but drop them).

The other changes seem pretty good, but worth discussing. Mostly just a bit more care around exactly when we overwrite containers, and restricting that to moments where we are more confident that we aren't electing to lose allocated containers. Worth understanding, as "fixing these bugs" has the potential to look like having `thread::Puller` return containers into a length-one buffer: we sit on a bit more memory than before, although we probably intended to do so.

One thought was that containers have `extract` and `finish`, but they don't have an `activate`, or some other signal to indicate that now is a good time to prep a buffer from storage. The `CapacityContainerBuilder` for example has a `current` and `empty`, both of which sit on resources and can't perfectly navigate the moments at which they should swap. E.g. once full `current` goes in to `pending` and is refilled from `empty`, and eventually `pending` drains in to `empty` and is revealed, but just after that moment you'd like to move `empty` to `current`, which we cannot easily do at the moment.