### PR TITLE
Make `Buffer::push_into` private

### DIFF
--- a/timely/src/dataflow/channels/pushers/buffer.rs
+++ b/timely/src/dataflow/channels/pushers/buffer.rs
@@ -114,16 +114,10 @@ impl<T, CB: ContainerBuilder, P: Push<Message<T, CB::Container>>> Buffer<T, CB, 
             Message::push_at(container, time, &mut self.pusher);
         }
     }
-}
-
-impl<T, CB, P, D> PushInto<D> for Buffer<T, CB, P>
-where
-    T: Eq+Clone,
-    CB: ContainerBuilder + PushInto<D>,
-    P: Push<Message<T, CB::Container>>
-{
+    
+    /// An internal implementation of push that should only be called by sessions.
     #[inline]
-    fn push_into(&mut self, item: D) {
+    fn push_internal<D>(&mut self, item: D) where CB: PushInto<D> {
         self.builder.push_into(item);
         self.extract_and_send();
     }
@@ -189,7 +183,7 @@ where
 {
     #[inline]
     fn push_into(&mut self, item: D) {
-        self.buffer.push_into(item);
+        self.buffer.push_internal(item);
     }
 }
 
@@ -241,7 +235,7 @@ where
 {
     #[inline]
     fn push_into(&mut self, item: D) {
-        self.buffer.push_into(item);
+        self.buffer.push_internal(item);
     }
 }
 


### PR DESCRIPTION
We saw a crash where a flushing buffer had data in its container, but had not been initialized with a time yet. This suggests that either the container's `is_empty` method is wrong, or that we sneaked data into the container not through a session (or something else, but local inspection suggests that these are private fields that can only be accessed through sessions, except for the `PushInto` implementation).

This shouldn't fix any bugs, as much as smoke out potentially incorrect usage of these buffers.