### PR TITLE
Linear connectivity

### DIFF
--- a/timely/src/dataflow/operators/core/feedback.rs
+++ b/timely/src/dataflow/operators/core/feedback.rs
@@ -113,7 +113,8 @@ impl<G: Scope, C: Container + Data> ConnectLoop<G, C> for StreamCore<G, C> {
         let summary = handle.summary;
         let mut output = handle.output;
 
-        let mut input = builder.new_input_connection(self, Pipeline, vec![Antichain::from_elem(summary.clone())]);
+        let connection = Some((0, Antichain::from_elem(summary.clone()))).into_iter().collect();
+        let mut input = builder.new_input_connection(self, Pipeline, connection);
 
         builder.build(move |_capability| move |_frontier| {
             let mut output = output.activate();

--- a/timely/src/dataflow/operators/core/input.rs
+++ b/timely/src/dataflow/operators/core/input.rs
@@ -7,9 +7,9 @@ use crate::container::{CapacityContainerBuilder, ContainerBuilder, PushInto};
 
 use crate::scheduling::{Schedule, Activator};
 
-use crate::progress::frontier::Antichain;
 use crate::progress::{Operate, operate::SharedProgress, Timestamp, ChangeBatch};
 use crate::progress::Source;
+use crate::progress::operate::Connectivity;
 
 use crate::{Container, Data};
 use crate::communication::Push;
@@ -205,7 +205,7 @@ impl<T:Timestamp> Operate<T> for Operator<T> {
     fn inputs(&self) -> usize { 0 }
     fn outputs(&self) -> usize { 1 }
 
-    fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<<T as Timestamp>::Summary>>>, Rc<RefCell<SharedProgress<T>>>) {
+    fn get_internal_summary(&mut self) -> (Connectivity<T::Summary>, Rc<RefCell<SharedProgress<T>>>) {
         self.shared_progress.borrow_mut().internals[0].update(T::minimum(), self.copies as i64);
         (Vec::new(), self.shared_progress.clone())
     }

--- a/timely/src/dataflow/operators/core/unordered_input.rs
+++ b/timely/src/dataflow/operators/core/unordered_input.rs
@@ -7,10 +7,10 @@ use crate::container::{ContainerBuilder, CapacityContainerBuilder};
 
 use crate::scheduling::{Schedule, ActivateOnDrop};
 
-use crate::progress::frontier::Antichain;
 use crate::progress::{Operate, operate::SharedProgress, Timestamp};
 use crate::progress::Source;
 use crate::progress::ChangeBatch;
+use crate::progress::operate::Connectivity;
 
 use crate::dataflow::channels::pushers::{Counter, Tee};
 use crate::dataflow::channels::pushers::buffer::{Buffer as PushBuffer, AutoflushSession};
@@ -134,7 +134,7 @@ impl<T:Timestamp> Operate<T> for UnorderedOperator<T> {
     fn inputs(&self) -> usize { 0 }
     fn outputs(&self) -> usize { 1 }
 
-    fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<<T as Timestamp>::Summary>>>, Rc<RefCell<SharedProgress<T>>>) {
+    fn get_internal_summary(&mut self) -> (Connectivity<T::Summary>, Rc<RefCell<SharedProgress<T>>>) {
         let mut borrow = self.internal.borrow_mut();
         for (time, count) in borrow.drain() {
             self.shared_progress.borrow_mut().internals[0].update(time, count * (self.peers as i64));

--- a/timely/src/dataflow/operators/generic/builder_raw.rs
+++ b/timely/src/dataflow/operators/generic/builder_raw.rs
@@ -12,6 +12,7 @@ use crate::scheduling::{Schedule, Activations};
 
 use crate::progress::{Source, Target};
 use crate::progress::{Timestamp, Operate, operate::SharedProgress, Antichain};
+use crate::progress::operate::Connectivity;
 
 use crate::Container;
 use crate::dataflow::{StreamCore, Scope};
@@ -60,7 +61,7 @@ pub struct OperatorBuilder<G: Scope> {
     global: usize,
     address: Rc<[usize]>,    // path to the operator (ending with index).
     shape: OperatorShape,
-    summary: Vec<Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>>,
+    summary: Connectivity<<G::Timestamp as Timestamp>::Summary>,
 }
 
 impl<G: Scope> OperatorBuilder<G> {
@@ -188,7 +189,7 @@ where
     logic: L,
     shared_progress: Rc<RefCell<SharedProgress<T>>>,
     activations: Rc<RefCell<Activations>>,
-    summary: Vec<Vec<Antichain<T::Summary>>>,
+    summary: Connectivity<T::Summary>,
 }
 
 impl<T, L> Schedule for OperatorCore<T, L>
@@ -213,7 +214,7 @@ where
     fn outputs(&self) -> usize { self.shape.outputs }
 
     // announce internal topology as fully connected, and hold all default capabilities.
-    fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<T::Summary>>>, Rc<RefCell<SharedProgress<T>>>) {
+    fn get_internal_summary(&mut self) -> (Connectivity<T::Summary>, Rc<RefCell<SharedProgress<T>>>) {
 
         // Request the operator to be scheduled at least once.
         self.activations.borrow_mut().activate(&self.address[..]);

--- a/timely/src/dataflow/operators/generic/builder_raw.rs
+++ b/timely/src/dataflow/operators/generic/builder_raw.rs
@@ -124,7 +124,6 @@ impl<G: Scope> OperatorBuilder<G> {
         stream.connect_to(target, sender, channel_id);
 
         self.shape.inputs += 1;
-        assert_eq!(self.shape.outputs, connection.len());
         self.summary.push(connection);
 
         receiver

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -6,10 +6,10 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use crate::progress::Antichain;
 use crate::progress::Timestamp;
 use crate::progress::ChangeBatch;
 use crate::progress::frontier::MutableAntichain;
+use crate::progress::operate::PortConnectivity;
 use crate::dataflow::channels::pullers::Counter as PullCounter;
 use crate::dataflow::channels::pushers::Counter as PushCounter;
 use crate::dataflow::channels::pushers::buffer::{Buffer, Session};
@@ -30,7 +30,7 @@ pub struct InputHandleCore<T: Timestamp, C: Container, P: Pull<Message<T, C>>> {
     ///
     /// Each timestamp received through this input may only produce output timestamps
     /// greater or equal to the input timestamp subjected to at least one of these summaries.
-    summaries: Rc<RefCell<Vec<Antichain<T::Summary>>>>, 
+    summaries: Rc<RefCell<PortConnectivity<T::Summary>>>,
     logging: Option<Logger>,
 }
 
@@ -148,8 +148,8 @@ pub fn _access_pull_counter<T: Timestamp, C: Container, P: Pull<Message<T, C>>>(
 /// Declared separately so that it can be kept private when `InputHandle` is re-exported.
 pub fn new_input_handle<T: Timestamp, C: Container, P: Pull<Message<T, C>>>(
     pull_counter: PullCounter<T, C, P>, 
-    internal: Rc<RefCell<Vec<Rc<RefCell<ChangeBatch<T>>>>>>, 
-    summaries: Rc<RefCell<Vec<Antichain<T::Summary>>>>, 
+    internal: Rc<RefCell<Vec<Rc<RefCell<ChangeBatch<T>>>>>>,
+    summaries: Rc<RefCell<PortConnectivity<T::Summary>>>,
     logging: Option<Logger>
 ) -> InputHandleCore<T, C, P> {
     InputHandleCore {

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use crate::Container;
 use crate::container::CapacityContainerBuilder;
 use crate::dataflow::operators::capture::{Event, EventPusher};
+use crate::progress::operate::Connectivity;
 
 /// Logs events as a timely stream, with progress statements.
 pub struct BatchLogger<P, C> where P: EventPusher<Duration, C> {
@@ -76,7 +77,7 @@ pub struct OperatesSummaryEvent<TS> {
     /// Worker-unique identifier for the operator.
     pub id: usize,
     /// Timestamp action summaries for (input, output) pairs.
-    pub summary: Vec<Vec<crate::progress::Antichain<TS>>>,
+    pub summary: Connectivity<TS>,
 }
 
 #[derive(Serialize, Deserialize, Columnar, Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]

--- a/timely/src/progress/operate.rs
+++ b/timely/src/progress/operate.rs
@@ -44,7 +44,7 @@ pub trait Operate<T: Timestamp> : Schedule {
     ///
     /// The default behavior is to indicate that timestamps on any input can emerge unchanged on
     /// any output, and no initial capabilities are held.
-    fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<T::Summary>>>, Rc<RefCell<SharedProgress<T>>>);
+    fn get_internal_summary(&mut self) -> (Connectivity<T::Summary>, Rc<RefCell<SharedProgress<T>>>);
 
     /// Signals that external frontiers have been set.
     ///
@@ -57,6 +57,9 @@ pub trait Operate<T: Timestamp> : Schedule {
     /// Indicates of whether the operator requires `push_external_progress` information or not.
     fn notify_me(&self) -> bool { true }
 }
+
+/// Operator internal connectivity, from inputs to outputs.
+pub type Connectivity<TS> = Vec<Vec<Antichain<TS>>>;
 
 /// Progress information shared between parent and child.
 #[derive(Debug)]

--- a/timely/src/progress/operate.rs
+++ b/timely/src/progress/operate.rs
@@ -59,7 +59,9 @@ pub trait Operate<T: Timestamp> : Schedule {
 }
 
 /// Operator internal connectivity, from inputs to outputs.
-pub type Connectivity<TS> = Vec<Vec<Antichain<TS>>>;
+pub type Connectivity<TS> = Vec<PortConnectivity<TS>>;
+/// Internal connectivity from one port to any number of opposing ports.
+pub type PortConnectivity<TS> = std::collections::BTreeMap<usize, Antichain<TS>>;
 
 /// Progress information shared between parent and child.
 #[derive(Debug)]

--- a/timely/src/progress/reachability.rs
+++ b/timely/src/progress/reachability.rs
@@ -79,7 +79,7 @@ use crate::progress::Timestamp;
 use crate::progress::{Source, Target};
 use crate::progress::ChangeBatch;
 use crate::progress::{Location, Port};
-
+use crate::progress::operate::Connectivity;
 use crate::progress::frontier::{Antichain, MutableAntichain};
 use crate::progress::timestamp::PathSummary;
 
@@ -132,7 +132,7 @@ pub struct Builder<T: Timestamp> {
     /// Indexed by operator index, then input port, then output port. This is the
     /// same format returned by `get_internal_summary`, as if we simply appended
     /// all of the summaries for the hosted nodes.
-    pub nodes: Vec<Vec<Vec<Antichain<T::Summary>>>>,
+    pub nodes: Vec<Connectivity<T::Summary>>,
     /// Direct connections from sources to targets.
     ///
     /// Edges do not affect timestamps, so we only need to know the connectivity.
@@ -156,7 +156,7 @@ impl<T: Timestamp> Builder<T> {
     /// Add links internal to operators.
     ///
     /// This method overwrites any existing summary, instead of anything more sophisticated.
-    pub fn add_node(&mut self, index: usize, inputs: usize, outputs: usize, summary: Vec<Vec<Antichain<T::Summary>>>) {
+    pub fn add_node(&mut self, index: usize, inputs: usize, outputs: usize, summary: Connectivity<T::Summary>) {
 
         // Assert that all summaries exist.
         debug_assert_eq!(inputs, summary.len());
@@ -195,7 +195,7 @@ impl<T: Timestamp> Builder<T> {
     /// default summaries (a serious liveness issue).
     ///
     /// The optional logger information is baked into the resulting tracker.
-    pub fn build(self, logger: Option<logging::TrackerLogger<T>>) -> (Tracker<T>, Vec<Vec<Antichain<T::Summary>>>) {
+    pub fn build(self, logger: Option<logging::TrackerLogger<T>>) -> (Tracker<T>, Connectivity<T::Summary>) {
 
         if !self.is_acyclic() {
             println!("Cycle detected without timestamp increment");
@@ -361,7 +361,7 @@ pub struct Tracker<T:Timestamp> {
     /// Indexed by operator index, then input port, then output port. This is the
     /// same format returned by `get_internal_summary`, as if we simply appended
     /// all of the summaries for the hosted nodes.
-    nodes: Vec<Vec<Vec<Antichain<T::Summary>>>>,
+    nodes: Vec<Connectivity<T::Summary>>,
     /// Direct connections from sources to targets.
     ///
     /// Edges do not affect timestamps, so we only need to know the connectivity.
@@ -503,7 +503,7 @@ impl<T:Timestamp> Tracker<T> {
     /// output port.
     ///
     /// If the optional logger is provided, it will be used to log various tracker events.
-    pub fn allocate_from(builder: Builder<T>, logger: Option<logging::TrackerLogger<T>>) -> (Self, Vec<Vec<Antichain<T::Summary>>>) {
+    pub fn allocate_from(builder: Builder<T>, logger: Option<logging::TrackerLogger<T>>) -> (Self, Connectivity<T::Summary>) {
 
         // Allocate buffer space for each input and input port.
         let mut per_operator =
@@ -732,7 +732,7 @@ impl<T:Timestamp> Tracker<T> {
 /// Graph locations may be missing from the output, in which case they have no
 /// paths to scope outputs.
 fn summarize_outputs<T: Timestamp>(
-    nodes: &[Vec<Vec<Antichain<T::Summary>>>],
+    nodes: &[Connectivity<T::Summary>],
     edges: &[Vec<Vec<Target>>],
     ) -> HashMap<Location, Vec<Antichain<T::Summary>>>
 {

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -572,8 +572,8 @@ where
             "the internal summary should have as many elements as there are inputs",
         );
         debug_assert!(
-            internal_summary.iter().all(|summary| summary.len() == self.outputs()),
-            "each element of the internal summary should have as many elements as there are outputs",
+            internal_summary.iter().all(|summary| summary.keys().all(|output| output < &self.outputs())),
+            "each element of the internal summary should only reference recognized outputs",
         );
 
         // Each child has expressed initial capabilities (their `shared_progress.internals`).
@@ -673,7 +673,7 @@ impl<T: Timestamp> PerOperatorState<T> {
             inputs,
         );
         assert!(
-            !internal_summary.iter().any(|x| x.len() != outputs),
+            !internal_summary.iter().any(|x| x.keys().any(|k| k >= &outputs)),
             "operator summary had too few outputs",
         );
 

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -19,7 +19,7 @@ use crate::scheduling::activate::Activations;
 use crate::progress::frontier::{Antichain, MutableAntichain, MutableAntichainFilter};
 use crate::progress::{Timestamp, Operate, operate::SharedProgress};
 use crate::progress::{Location, Port, Source, Target};
-
+use crate::progress::operate::Connectivity;
 use crate::progress::ChangeBatch;
 use crate::progress::broadcast::Progcaster;
 use crate::progress::reachability;
@@ -270,7 +270,7 @@ where
     progcaster: Progcaster<TInner>,
 
     shared_progress: Rc<RefCell<SharedProgress<TOuter>>>,
-    scope_summary: Vec<Vec<Antichain<TInner::Summary>>>,
+    scope_summary: Connectivity<TInner::Summary>,
 
     progress_mode: ProgressMode,
 }
@@ -546,7 +546,7 @@ where
 
     // produces connectivity summaries from inputs to outputs, and reports initial internal
     // capabilities on each of the outputs (projecting capabilities from contained scopes).
-    fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<TOuter::Summary>>>, Rc<RefCell<SharedProgress<TOuter>>>) {
+    fn get_internal_summary(&mut self) -> (Connectivity<TOuter::Summary>, Rc<RefCell<SharedProgress<TOuter>>>) {
 
         // double-check that child 0 (the outside world) is correctly shaped.
         assert_eq!(self.children[0].outputs, self.inputs());
@@ -614,7 +614,7 @@ struct PerOperatorState<T: Timestamp> {
 
     shared_progress: Rc<RefCell<SharedProgress<T>>>,
 
-    internal_summary: Vec<Vec<Antichain<T::Summary>>>,   // cached result from get_internal_summary.
+    internal_summary: Connectivity<T::Summary>,   // cached result from get_internal_summary.
 
     logging: Option<Logger>,
 }

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -552,10 +552,7 @@ where
         assert_eq!(self.children[0].outputs, self.inputs());
         assert_eq!(self.children[0].inputs, self.outputs());
 
-        // Note that we need to have `self.inputs()` elements in the summary
-        // with each element containing `self.outputs()` antichains regardless
-        // of how long `self.scope_summary` is
-        // let mut internal_summary: Connectivity<TOuter::Summary> = vec![PortConnectivity::default(); self.inputs()];
+        // Apply `TInner::summarize` to each path summary, to present paths outwards.
         let mut internal_summary: Connectivity<TOuter::Summary> = Vec::with_capacity(self.inputs());
         for input in self.scope_summary.iter() {
             let input_connectivity = input.iter().map(|(o, summary)| {

--- a/timely/tests/shape_scaling.rs
+++ b/timely/tests/shape_scaling.rs
@@ -1,0 +1,79 @@
+use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::Input;
+use timely::dataflow::InputHandle;
+use timely::Config;
+
+#[test] fn operator_scaling_1() { operator_scaling(1); }
+#[test] fn operator_scaling_10() { operator_scaling(10); }
+#[test] fn operator_scaling_100() { operator_scaling(100); }
+#[test] fn operator_scaling_1000() { operator_scaling(1000); }
+#[test] fn operator_scaling_10000() { operator_scaling(10000); }
+#[test] fn operator_scaling_100000() { operator_scaling(100000); }
+
+fn operator_scaling(scale: u64) {
+    timely::execute(Config::thread(), move |worker| {
+        let mut input = InputHandle::new();
+        worker.dataflow::<u64, _, _>(|scope| {
+            use timely::dataflow::operators::Partition;
+            let parts =
+            scope
+                .input_from(&mut input)
+                .partition(scale, |()| (0, ()));
+
+            use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
+            let mut builder = OperatorBuilder::new("OpScaling".to_owned(), scope.clone());
+            let mut handles = Vec::with_capacity(parts.len());
+            let mut outputs = Vec::with_capacity(parts.len());
+            for (index, part) in parts.into_iter().enumerate() {
+                use timely::container::CapacityContainerBuilder;
+                let (output, stream) = builder.new_output_connection::<CapacityContainerBuilder<Vec<()>>>(Default::default());
+                use timely::progress::Antichain;
+                let connectivity = [(index, Antichain::from_elem(Default::default()))].into();
+                handles.push((builder.new_input_connection(&part, Pipeline, connectivity), output));
+                outputs.push(stream);
+            }
+
+            builder.build(move |_| {
+                move |_frontiers| {
+                    for (input, output) in handles.iter_mut() {
+                        let mut output = output.activate();
+                        input.for_each(|time, data| {
+                            let mut output = output.session_with_builder(&time);
+                            for datum in data.drain(..) {
+                                output.give(datum);
+                            }
+                        });
+                    }
+                }
+            });
+        });
+    })
+    .unwrap();
+}
+
+#[test] fn subgraph_scaling_1() { subgraph_scaling(1); }
+#[test] fn subgraph_scaling_10() { subgraph_scaling(10); }
+#[test] fn subgraph_scaling_100() { subgraph_scaling(100); }
+#[test] fn subgraph_scaling_1000() { subgraph_scaling(1000); }
+#[test] fn subgraph_scaling_10000() { subgraph_scaling(10000); }
+#[test] fn subgraph_scaling_100000() { subgraph_scaling(100000); }
+
+fn subgraph_scaling(scale: u64) {
+    timely::execute(Config::thread(), move |worker| {
+        let mut input = InputHandle::new();
+        worker.dataflow::<u64, _, _>(|scope| {
+            use timely::dataflow::operators::Partition;
+            let parts =
+            scope
+                .input_from(&mut input)
+                .partition(scale, |()| (0, ()));
+
+            use timely::dataflow::Scope;
+            let _outputs = scope.region(|inner| {
+                use timely::dataflow::operators::{Enter, Leave};
+                parts.into_iter().map(|part| part.enter(inner).leave()).collect::<Vec<_>>()
+            });
+        });
+    })
+    .unwrap();
+}


### PR DESCRIPTION
The PR updates how we express operator-internal connectivity information, from `input` and `output` indexed dense vectors `Vec<Vec<Antichain<TS>>>`, to `Vec<BTreeMap<usize, Antichain<TS>>>`. This change reduces the complexity from `inputs * outputs` to `inputs + edges`, which is a substantial reduction for operators with many inputs and outputs, and relatively sparse connectivity.

The PR introduces two type definitions, which could become `struct` types in the own right:
```rust
/// Operator internal connectivity, from inputs to outputs.
pub type Connectivity<TS> = Vec<PortConnectivity<TS>>;
/// Internal connectivity from one port to any number of opposing ports.
pub type PortConnectivity<TS> = std::collections::BTreeMap<usize, Antichain<TS>>;
```

As it turns out, we only perform random access into the `BTreeMap` structures as part of set-up, so the performance penalty for random access is bounded. Otherwise, we iterate over the contents when moving progress information forward, which should be roughly as performant with `BTreeMap::iter()` as our previous iteration and enumeration.

A `shape_scaling.rs` test is added, for both operators with many inputs and outputs, and subgraphs with many inputs and outputs. The test goes up to 100k of each; 1M does complete, in roughly linear time, but it exceeds 60s. Memory requirements are not small (hundreds of megabytes), but seem to be linear.
