### PR TITLE
Linear reachability, take 2

### DIFF
--- a/timely/src/dataflow/operators/capability.rs
+++ b/timely/src/dataflow/operators/capability.rs
@@ -27,9 +27,9 @@ use std::cell::RefCell;
 use std::fmt::{self, Debug};
 
 use crate::order::PartialOrder;
-use crate::progress::Antichain;
 use crate::progress::Timestamp;
 use crate::progress::ChangeBatch;
+use crate::progress::operate::PortConnectivity;
 use crate::scheduling::Activations;
 use crate::dataflow::channels::pullers::counter::ConsumedGuard;
 
@@ -238,7 +238,7 @@ pub struct InputCapability<T: Timestamp> {
     /// Output capability buffers, for use in minting capabilities.
     internal: CapabilityUpdates<T>,
     /// Timestamp summaries for each output.
-    summaries: Rc<RefCell<Vec<Antichain<T::Summary>>>>,
+    summaries: Rc<RefCell<PortConnectivity<T::Summary>>>,
     /// A drop guard that updates the consumed capability this InputCapability refers to on drop
     consumed_guard: ConsumedGuard<T>,
 }
@@ -257,7 +257,7 @@ impl<T: Timestamp> CapabilityTrait<T> for InputCapability<T> {
 impl<T: Timestamp> InputCapability<T> {
     /// Creates a new capability reference at `time` while incrementing (and keeping a reference to)
     /// the provided [`ChangeBatch`].
-    pub(crate) fn new(internal: CapabilityUpdates<T>, summaries: Rc<RefCell<Vec<Antichain<T::Summary>>>>, guard: ConsumedGuard<T>) -> Self {
+    pub(crate) fn new(internal: CapabilityUpdates<T>, summaries: Rc<RefCell<PortConnectivity<T::Summary>>>, guard: ConsumedGuard<T>) -> Self {
         InputCapability {
             internal,
             summaries,

--- a/timely/src/dataflow/operators/core/feedback.rs
+++ b/timely/src/dataflow/operators/core/feedback.rs
@@ -113,7 +113,7 @@ impl<G: Scope, C: Container + Data> ConnectLoop<G, C> for StreamCore<G, C> {
         let summary = handle.summary;
         let mut output = handle.output;
 
-        let mut input = builder.new_input_connection(self, Pipeline, vec![Antichain::from_elem(summary.clone())]);
+        let mut input = builder.new_input_connection(self, Pipeline, [(0, Antichain::from_elem(summary.clone()))]);
 
         builder.build(move |_capability| move |_frontier| {
             let mut output = output.activate();

--- a/timely/src/dataflow/operators/core/input.rs
+++ b/timely/src/dataflow/operators/core/input.rs
@@ -7,10 +7,9 @@ use crate::container::{CapacityContainerBuilder, ContainerBuilder, PushInto};
 
 use crate::scheduling::{Schedule, Activator};
 
-use crate::progress::frontier::Antichain;
 use crate::progress::{Operate, operate::SharedProgress, Timestamp, ChangeBatch};
 use crate::progress::Source;
-
+use crate::progress::operate::Connectivity;
 use crate::{Container, Data};
 use crate::communication::Push;
 use crate::dataflow::{Scope, ScopeParent, StreamCore};
@@ -205,7 +204,7 @@ impl<T:Timestamp> Operate<T> for Operator<T> {
     fn inputs(&self) -> usize { 0 }
     fn outputs(&self) -> usize { 1 }
 
-    fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<<T as Timestamp>::Summary>>>, Rc<RefCell<SharedProgress<T>>>) {
+    fn get_internal_summary(&mut self) -> (Connectivity<<T as Timestamp>::Summary>, Rc<RefCell<SharedProgress<T>>>) {
         self.shared_progress.borrow_mut().internals[0].update(T::minimum(), self.copies as i64);
         (Vec::new(), Rc::clone(&self.shared_progress))
     }

--- a/timely/src/dataflow/operators/core/unordered_input.rs
+++ b/timely/src/dataflow/operators/core/unordered_input.rs
@@ -7,11 +7,10 @@ use crate::container::{ContainerBuilder, CapacityContainerBuilder};
 
 use crate::scheduling::{Schedule, ActivateOnDrop};
 
-use crate::progress::frontier::Antichain;
 use crate::progress::{Operate, operate::SharedProgress, Timestamp};
 use crate::progress::Source;
 use crate::progress::ChangeBatch;
-
+use crate::progress::operate::Connectivity;
 use crate::dataflow::channels::pushers::{Counter, Tee};
 use crate::dataflow::channels::pushers::buffer::{Buffer as PushBuffer, AutoflushSession};
 
@@ -134,7 +133,7 @@ impl<T:Timestamp> Operate<T> for UnorderedOperator<T> {
     fn inputs(&self) -> usize { 0 }
     fn outputs(&self) -> usize { 1 }
 
-    fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<<T as Timestamp>::Summary>>>, Rc<RefCell<SharedProgress<T>>>) {
+    fn get_internal_summary(&mut self) -> (Connectivity<<T as Timestamp>::Summary>, Rc<RefCell<SharedProgress<T>>>) {
         let mut borrow = self.internal.borrow_mut();
         for (time, count) in borrow.drain() {
             self.shared_progress.borrow_mut().internals[0].update(time, count * (self.peers as i64));

--- a/timely/src/dataflow/operators/generic/builder_raw.rs
+++ b/timely/src/dataflow/operators/generic/builder_raw.rs
@@ -12,7 +12,7 @@ use crate::scheduling::{Schedule, Activations};
 
 use crate::progress::{Source, Target};
 use crate::progress::{Timestamp, Operate, operate::SharedProgress, Antichain};
-
+use crate::progress::operate::Connectivity;
 use crate::Container;
 use crate::dataflow::{StreamCore, Scope};
 use crate::dataflow::channels::pushers::Tee;
@@ -60,7 +60,7 @@ pub struct OperatorBuilder<G: Scope> {
     global: usize,
     address: Rc<[usize]>,    // path to the operator (ending with index).
     shape: OperatorShape,
-    summary: Vec<Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>>,
+    summary: Connectivity<<G::Timestamp as Timestamp>::Summary>,
 }
 
 impl<G: Scope> OperatorBuilder<G> {
@@ -188,7 +188,7 @@ where
     logic: L,
     shared_progress: Rc<RefCell<SharedProgress<T>>>,
     activations: Rc<RefCell<Activations>>,
-    summary: Vec<Vec<Antichain<T::Summary>>>,
+    summary: Connectivity<T::Summary>,
 }
 
 impl<T, L> Schedule for OperatorCore<T, L>
@@ -213,7 +213,7 @@ where
     fn outputs(&self) -> usize { self.shape.outputs }
 
     // announce internal topology as fully connected, and hold all default capabilities.
-    fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<T::Summary>>>, Rc<RefCell<SharedProgress<T>>>) {
+    fn get_internal_summary(&mut self) -> (Connectivity<T::Summary>, Rc<RefCell<SharedProgress<T>>>) {
 
         // Request the operator to be scheduled at least once.
         self.activations.borrow_mut().activate(&self.address[..]);

--- a/timely/src/dataflow/operators/generic/builder_raw.rs
+++ b/timely/src/dataflow/operators/generic/builder_raw.rs
@@ -138,15 +138,15 @@ impl<G: Scope> OperatorBuilder<G> {
 
     /// Adds a new output to a generic operator builder, returning the `Push` implementor to use.
     pub fn new_output_connection<C: Container>(&mut self, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> (Tee<G::Timestamp, C>, StreamCore<G, C>) {
-
+        let new_output = self.shape.outputs;
+        self.shape.outputs += 1;
         let (targets, registrar) = Tee::<G::Timestamp,C>::new();
-        let source = Source::new(self.index, self.shape.outputs);
+        let source = Source::new(self.index, new_output);
         let stream = StreamCore::new(source, registrar, self.scope.clone());
 
-        self.shape.outputs += 1;
         assert_eq!(self.shape.inputs, connection.len());
         for (summary, entry) in self.summary.iter_mut().zip(connection.into_iter()) {
-            summary.add_port(entry);
+            summary.add_port(new_output, entry);
         }
 
         (targets, stream)

--- a/timely/src/dataflow/operators/generic/builder_raw.rs
+++ b/timely/src/dataflow/operators/generic/builder_raw.rs
@@ -124,7 +124,7 @@ impl<G: Scope> OperatorBuilder<G> {
 
         self.shape.inputs += 1;
         assert_eq!(self.shape.outputs, connection.len());
-        self.summary.push(connection);
+        self.summary.push(connection.into());
 
         receiver
     }
@@ -146,7 +146,7 @@ impl<G: Scope> OperatorBuilder<G> {
         self.shape.outputs += 1;
         assert_eq!(self.shape.inputs, connection.len());
         for (summary, entry) in self.summary.iter_mut().zip(connection.into_iter()) {
-            summary.push(entry);
+            summary.add_port(entry);
         }
 
         (targets, stream)

--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -20,7 +20,7 @@ use crate::dataflow::operators::capability::Capability;
 use crate::dataflow::operators::generic::handles::{InputHandleCore, new_input_handle, OutputWrapper};
 use crate::dataflow::operators::generic::operator_info::OperatorInfo;
 use crate::dataflow::operators::generic::builder_raw::OperatorShape;
-
+use crate::progress::operate::PortConnectivity;
 use crate::logging::TimelyLogger as Logger;
 
 use super::builder_raw::OperatorBuilder as OperatorBuilderRaw;
@@ -33,7 +33,7 @@ pub struct OperatorBuilder<G: Scope> {
     consumed: Vec<Rc<RefCell<ChangeBatch<G::Timestamp>>>>,
     internal: Rc<RefCell<Vec<Rc<RefCell<ChangeBatch<G::Timestamp>>>>>>,
     /// For each input, a shared list of summaries to each output.
-    summaries: Vec<Rc<RefCell<Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>>>>,
+    summaries: Vec<Rc<RefCell<PortConnectivity<<G::Timestamp as Timestamp>::Summary>>>>,
     produced: Vec<Rc<RefCell<ChangeBatch<G::Timestamp>>>>,
     logging: Option<Logger>,
 }

--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -113,7 +113,7 @@ impl<G: Scope> OperatorBuilder<G> {
         OutputWrapper<G::Timestamp, CB, Tee<G::Timestamp, CB::Container>>,
         StreamCore<G, CB::Container>
     ) {
-
+        let new_output = self.shape().outputs();
         let (tee, stream) = self.builder.new_output_connection(connection.clone());
 
         let internal = Rc::new(RefCell::new(ChangeBatch::new()));
@@ -123,7 +123,7 @@ impl<G: Scope> OperatorBuilder<G> {
         self.produced.push(Rc::clone(buffer.inner().produced()));
 
         for (summary, connection) in self.summaries.iter().zip(connection.into_iter()) {
-            summary.borrow_mut().add_port(connection.clone());
+            summary.borrow_mut().add_port(new_output, connection.clone());
         }
 
         (OutputWrapper::new(buffer, internal), stream)

--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -64,7 +64,7 @@ impl<G: Scope> OperatorBuilder<G> {
     where
         P: ParallelizationContract<G::Timestamp, C> {
 
-        let connection = (0..self.builder.shape().outputs()).map(|_| Antichain::from_elem(Default::default())).collect();
+        let connection = (0..self.builder.shape().outputs()).map(|o| (o, Antichain::from_elem(Default::default())));
         self.new_input_connection(stream, pact, connection)
     }
 
@@ -76,17 +76,18 @@ impl<G: Scope> OperatorBuilder<G> {
     ///
     /// Commonly the connections are either the unit summary, indicating the same timestamp might be produced as output, or an empty
     /// antichain indicating that there is no connection from the input to the output.
-    pub fn new_input_connection<C: Container, P>(&mut self, stream: &StreamCore<G, C>, pact: P, connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>) -> InputHandleCore<G::Timestamp, C, P::Puller>
-        where
-            P: ParallelizationContract<G::Timestamp, C> {
-
+    pub fn new_input_connection<C: Container, P, I>(&mut self, stream: &StreamCore<G, C>, pact: P, connection: I) -> InputHandleCore<G::Timestamp, C, P::Puller>
+    where
+        P: ParallelizationContract<G::Timestamp, C>,
+        I: IntoIterator<Item = (usize, Antichain<<G::Timestamp as Timestamp>::Summary>)> + Clone,
+    {
         let puller = self.builder.new_input_connection(stream, pact, connection.clone());
 
         let input = PullCounter::new(puller);
         self.frontier.push(MutableAntichain::new());
         self.consumed.push(Rc::clone(input.consumed()));
 
-        let shared_summary = Rc::new(RefCell::new(connection.into()));
+        let shared_summary = Rc::new(RefCell::new(connection.into_iter().collect()));
         self.summaries.push(Rc::clone(&shared_summary));
 
         new_input_handle(input, Rc::clone(&self.internal), shared_summary, self.logging.clone())
@@ -94,7 +95,7 @@ impl<G: Scope> OperatorBuilder<G> {
 
     /// Adds a new output to a generic operator builder, returning the `Push` implementor to use.
     pub fn new_output<CB: ContainerBuilder>(&mut self) -> (OutputWrapper<G::Timestamp, CB, Tee<G::Timestamp, CB::Container>>, StreamCore<G, CB::Container>) {
-        let connection = (0..self.builder.shape().inputs()).map(|_| Antichain::from_elem(Default::default())).collect();
+        let connection = (0..self.builder.shape().inputs()).map(|i| (i, Antichain::from_elem(Default::default())));
         self.new_output_connection(connection)
     }
 
@@ -106,13 +107,13 @@ impl<G: Scope> OperatorBuilder<G> {
     ///
     /// Commonly the connections are either the unit summary, indicating the same timestamp might be produced as output, or an empty
     /// antichain indicating that there is no connection from the input to the output.
-    pub fn new_output_connection<CB: ContainerBuilder>(
-        &mut self,
-        connection: Vec<Antichain<<G::Timestamp as Timestamp>::Summary>>
-    ) -> (
+    pub fn new_output_connection<CB: ContainerBuilder, I>(&mut self, connection: I) -> (
         OutputWrapper<G::Timestamp, CB, Tee<G::Timestamp, CB::Container>>,
         StreamCore<G, CB::Container>
-    ) {
+    )
+    where
+        I: IntoIterator<Item = (usize, Antichain<<G::Timestamp as Timestamp>::Summary>)> + Clone,
+    {
         let new_output = self.shape().outputs();
         let (tee, stream) = self.builder.new_output_connection(connection.clone());
 
@@ -122,8 +123,8 @@ impl<G: Scope> OperatorBuilder<G> {
         let mut buffer = PushBuffer::new(PushCounter::new(tee));
         self.produced.push(Rc::clone(buffer.inner().produced()));
 
-        for (summary, connection) in self.summaries.iter().zip(connection.into_iter()) {
-            summary.borrow_mut().add_port(new_output, connection.clone());
+        for (input, entry) in connection {
+            self.summaries[input].borrow_mut().add_port(new_output, entry);
         }
 
         (OutputWrapper::new(buffer, internal), stream)

--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -86,7 +86,7 @@ impl<G: Scope> OperatorBuilder<G> {
         self.frontier.push(MutableAntichain::new());
         self.consumed.push(Rc::clone(input.consumed()));
 
-        let shared_summary = Rc::new(RefCell::new(connection));
+        let shared_summary = Rc::new(RefCell::new(connection.into()));
         self.summaries.push(Rc::clone(&shared_summary));
 
         new_input_handle(input, Rc::clone(&self.internal), shared_summary, self.logging.clone())
@@ -123,7 +123,7 @@ impl<G: Scope> OperatorBuilder<G> {
         self.produced.push(Rc::clone(buffer.inner().produced()));
 
         for (summary, connection) in self.summaries.iter().zip(connection.into_iter()) {
-            summary.borrow_mut().push(connection.clone());
+            summary.borrow_mut().add_port(connection.clone());
         }
 
         (OutputWrapper::new(buffer, internal), stream)

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -6,10 +6,10 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use crate::progress::Antichain;
 use crate::progress::Timestamp;
 use crate::progress::ChangeBatch;
 use crate::progress::frontier::MutableAntichain;
+use crate::progress::operate::PortConnectivity;
 use crate::dataflow::channels::pullers::Counter as PullCounter;
 use crate::dataflow::channels::pushers::Counter as PushCounter;
 use crate::dataflow::channels::pushers::buffer::{Buffer, Session};
@@ -30,7 +30,7 @@ pub struct InputHandleCore<T: Timestamp, C: Container, P: Pull<Message<T, C>>> {
     ///
     /// Each timestamp received through this input may only produce output timestamps
     /// greater or equal to the input timestamp subjected to at least one of these summaries.
-    summaries: Rc<RefCell<Vec<Antichain<T::Summary>>>>, 
+    summaries: Rc<RefCell<PortConnectivity<T::Summary>>>, 
     logging: Option<Logger>,
 }
 
@@ -149,7 +149,7 @@ pub fn _access_pull_counter<T: Timestamp, C: Container, P: Pull<Message<T, C>>>(
 pub fn new_input_handle<T: Timestamp, C: Container, P: Pull<Message<T, C>>>(
     pull_counter: PullCounter<T, C, P>, 
     internal: Rc<RefCell<Vec<Rc<RefCell<ChangeBatch<T>>>>>>, 
-    summaries: Rc<RefCell<Vec<Antichain<T::Summary>>>>, 
+    summaries: Rc<RefCell<PortConnectivity<T::Summary>>>, 
     logging: Option<Logger>
 ) -> InputHandleCore<T, C, P> {
     InputHandleCore {

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use crate::Container;
 use crate::container::CapacityContainerBuilder;
 use crate::dataflow::operators::capture::{Event, EventPusher};
+use crate::progress::operate::Connectivity;
 
 /// Logs events as a timely stream, with progress statements.
 pub struct BatchLogger<P, C> where P: EventPusher<Duration, C> {
@@ -76,7 +77,7 @@ pub struct OperatesSummaryEvent<TS> {
     /// Worker-unique identifier for the operator.
     pub id: usize,
     /// Timestamp action summaries for (input, output) pairs.
-    pub summary: Vec<Vec<crate::progress::Antichain<TS>>>,
+    pub summary: Connectivity<TS>,
 }
 
 #[derive(Serialize, Deserialize, Columnar, Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]

--- a/timely/src/progress/operate.rs
+++ b/timely/src/progress/operate.rs
@@ -80,29 +80,30 @@ impl<TS> PortConnectivity<TS> {
         Self { list }
     }
     /// Ensures an entry exists at `index` and returns a mutable reference to it.
-    pub fn ensure(&mut self, index: usize) -> &mut Antichain<TS> {
-        while self.next_port() <= index { self.add_port(Antichain::new()); }
+    fn ensure(&mut self, index: usize) -> &mut Antichain<TS> {
+        while self.list.len() <= index { self.add_port(self.list.len(), Antichain::new()); }
         &mut self.list[index]
+    }
+    /// Inserts an element by reference, ensuring that the index exists.
+    pub fn insert(&mut self, index: usize, element: TS) -> bool where TS : crate::PartialOrder + Clone {
+        self.ensure(index).insert(element)
     }
     /// Inserts an element by reference, ensuring that the index exists.
     pub fn insert_ref(&mut self, index: usize, element: &TS) -> bool where TS : crate::PartialOrder + Clone {
         self.ensure(index).insert_ref(element)
     }
-    /// Introduces a summary for the port `self.next_port()`.
-    pub fn add_port(&mut self, summary: Antichain<TS>) {
+    /// Introduces a summary for `port`. Panics if a summary already exists.
+    pub fn add_port(&mut self, port: usize, summary: Antichain<TS>) {
+        assert_eq!(self.list.len(), port);
         self.list.push(summary);
     }
     /// Borrowing iterator of port identifiers and antichains.
     pub fn iter_ports(&self) -> impl Iterator<Item = (usize, &Antichain<TS>)> {
         self.list.iter().enumerate()
     }
-    /// Owning iterator of port identifiers and antichains.
-    pub fn into_iter_ports(self) -> impl Iterator<Item = (usize, Antichain<TS>)> {
-        self.list.into_iter().enumerate()
-    }
-    /// Announces the next output port identifier.
-    pub fn next_port(&self) -> usize {
-        self.list.len()
+    /// Announces the largest port identifier, largely for debug asserts.
+    pub fn max_port(&self) -> usize {
+        self.list.len() - 1
     }
 }
 

--- a/timely/src/progress/operate.rs
+++ b/timely/src/progress/operate.rs
@@ -44,7 +44,7 @@ pub trait Operate<T: Timestamp> : Schedule {
     ///
     /// The default behavior is to indicate that timestamps on any input can emerge unchanged on
     /// any output, and no initial capabilities are held.
-    fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<T::Summary>>>, Rc<RefCell<SharedProgress<T>>>);
+    fn get_internal_summary(&mut self) -> (Connectivity<T::Summary>, Rc<RefCell<SharedProgress<T>>>);
 
     /// Signals that external frontiers have been set.
     ///
@@ -57,6 +57,12 @@ pub trait Operate<T: Timestamp> : Schedule {
     /// Indicates of whether the operator requires `push_external_progress` information or not.
     fn notify_me(&self) -> bool { true }
 }
+
+/// Operator internal connectivity, from inputs to outputs.
+pub type Connectivity<TS> = Vec<PortConnectivity<TS>>;
+/// Internal connectivity from one port to any number of opposing ports.
+pub type PortConnectivity<TS> = Vec<Antichain<TS>>;
+
 
 /// Progress information shared between parent and child.
 #[derive(Debug)]

--- a/timely/src/progress/operate.rs
+++ b/timely/src/progress/operate.rs
@@ -74,7 +74,7 @@ impl<TS> Default for PortConnectivity<TS> {
 
 impl<TS> PortConnectivity<TS> {
     /// Inserts an element by reference, ensuring that the index exists.
-    pub fn insert(&mut self, index: usize, element: TS) -> bool where TS : crate::PartialOrder + Clone {
+    pub fn insert(&mut self, index: usize, element: TS) -> bool where TS : crate::PartialOrder {
         self.tree.entry(index).or_default().insert(element)
     }
     /// Inserts an element by reference, ensuring that the index exists.

--- a/timely/src/progress/operate.rs
+++ b/timely/src/progress/operate.rs
@@ -73,12 +73,6 @@ impl<TS> Default for PortConnectivity<TS> {
 }
 
 impl<TS> PortConnectivity<TS> {
-    /// Introduces default summaries for `0 .. count` ports.
-    pub fn default_for(count: usize) -> Self {
-        let mut list = Vec::with_capacity(count);
-        for _ in 0 .. count { list.push(Default::default()) }
-        Self { list }
-    }
     /// Ensures an entry exists at `index` and returns a mutable reference to it.
     fn ensure(&mut self, index: usize) -> &mut Antichain<TS> {
         while self.list.len() <= index { self.add_port(self.list.len(), Antichain::new()); }
@@ -105,18 +99,15 @@ impl<TS> PortConnectivity<TS> {
     pub fn max_port(&self) -> usize {
         self.list.len() - 1
     }
+    /// Returns the associated path summary, if it exists.
+    pub fn get(&self, index: usize) -> Option<&Antichain<TS>> {
+        self.list.get(index)
+    }
 }
 
 impl<TS> From<Vec<Antichain<TS>>> for PortConnectivity<TS> {
     fn from(list: Vec<Antichain<TS>>) -> Self {
         Self { list }
-    }
-}
-
-impl<TS> std::ops::Index<usize> for PortConnectivity<TS> {
-    type Output = Antichain<TS>;
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.list[index]
     }
 }
 

--- a/timely/src/progress/operate.rs
+++ b/timely/src/progress/operate.rs
@@ -101,9 +101,9 @@ impl<TS> PortConnectivity<TS> {
     }
 }
 
-impl<TS> From<Vec<Antichain<TS>>> for PortConnectivity<TS> {
-    fn from(list: Vec<Antichain<TS>>) -> Self {
-        Self { tree: list.into_iter().enumerate().filter(|(_,p)| !p.is_empty()).collect() }
+impl<TS> FromIterator<(usize, Antichain<TS>)> for PortConnectivity<TS> {
+    fn from_iter<T>(iter: T) -> Self where T: IntoIterator<Item = (usize, Antichain<TS>)> {
+        Self { tree: iter.into_iter().filter(|(_,p)| !p.is_empty()).collect() }
     }
 }
 

--- a/timely/src/progress/reachability.rs
+++ b/timely/src/progress/reachability.rs
@@ -781,10 +781,12 @@ fn summarize_outputs<T: Timestamp>(
                     let antichains = results.entry(location).or_default();
 
                     // Combine each operator-internal summary to the output with `summary`.
-                    for operator_summary in summaries[output_port].elements().iter() {
-                        if let Some(combined) = operator_summary.followed_by(&summary) {
-                            if antichains.insert_ref(output, &combined) {
-                                worklist.push_back((location, output, combined));
+                    if let Some(connection) = summaries.get(output_port) {
+                        for operator_summary in connection.elements().iter() {
+                            if let Some(combined) = operator_summary.followed_by(&summary) {
+                                if antichains.insert_ref(output, &combined) {
+                                    worklist.push_back((location, output, combined));
+                                }
                             }
                         }
                     }

--- a/timely/src/progress/reachability.rs
+++ b/timely/src/progress/reachability.rs
@@ -17,9 +17,9 @@
 //! let mut builder = Builder::<usize>::new();
 //!
 //! // Each node with one input connected to one output.
-//! builder.add_node(0, 1, 1, vec![vec![Antichain::from_elem(0)].into()]);
-//! builder.add_node(1, 1, 1, vec![vec![Antichain::from_elem(0)].into()]);
-//! builder.add_node(2, 1, 1, vec![vec![Antichain::from_elem(1)].into()]);
+//! builder.add_node(0, 1, 1, vec![[(0, Antichain::from_elem(0))].into_iter().collect()]);
+//! builder.add_node(1, 1, 1, vec![[(0, Antichain::from_elem(0))].into_iter().collect()]);
+//! builder.add_node(2, 1, 1, vec![[(0, Antichain::from_elem(1))].into_iter().collect()]);
 //!
 //! // Connect nodes in sequence, looping around to the first from the last.
 //! builder.add_edge(Source::new(0, 0), Target::new(1, 0));
@@ -113,9 +113,9 @@ use crate::progress::timestamp::PathSummary;
 /// let mut builder = Builder::<usize>::new();
 ///
 /// // Each node with one input connected to one output.
-/// builder.add_node(0, 1, 1, vec![vec![Antichain::from_elem(0)].into()]);
-/// builder.add_node(1, 1, 1, vec![vec![Antichain::from_elem(0)].into()]);
-/// builder.add_node(2, 1, 1, vec![vec![Antichain::from_elem(1)].into()]);
+/// builder.add_node(0, 1, 1, vec![[(0, Antichain::from_elem(0))].into_iter().collect()]);
+/// builder.add_node(1, 1, 1, vec![[(0, Antichain::from_elem(0))].into_iter().collect()]);
+/// builder.add_node(2, 1, 1, vec![[(0, Antichain::from_elem(1))].into_iter().collect()]);
 ///
 /// // Connect nodes in sequence, looping around to the first from the last.
 /// builder.add_edge(Source::new(0, 0), Target::new(1, 0));
@@ -224,9 +224,9 @@ impl<T: Timestamp> Builder<T> {
     /// let mut builder = Builder::<usize>::new();
     ///
     /// // Each node with one input connected to one output.
-    /// builder.add_node(0, 1, 1, vec![vec![Antichain::from_elem(0)].into()]);
-    /// builder.add_node(1, 1, 1, vec![vec![Antichain::from_elem(0)].into()]);
-    /// builder.add_node(2, 1, 1, vec![vec![Antichain::from_elem(0)].into()]);
+    /// builder.add_node(0, 1, 1, vec![[(0, Antichain::from_elem(0))].into_iter().collect()]);
+    /// builder.add_node(1, 1, 1, vec![[(0, Antichain::from_elem(0))].into_iter().collect()]);
+    /// builder.add_node(2, 1, 1, vec![[(0, Antichain::from_elem(0))].into_iter().collect()]);
     ///
     /// // Connect nodes in sequence, looping around to the first from the last.
     /// builder.add_edge(Source::new(0, 0), Target::new(1, 0));
@@ -253,8 +253,8 @@ impl<T: Timestamp> Builder<T> {
     ///
     /// // Two inputs and outputs, only one of which advances.
     /// builder.add_node(0, 2, 2, vec![
-    ///     vec![Antichain::from_elem(0),Antichain::new(),].into(),
-    ///     vec![Antichain::new(),Antichain::from_elem(1),].into(),
+    ///     [(0,Antichain::from_elem(0)),(1,Antichain::new())].into_iter().collect(),
+    ///     [(0,Antichain::new()),(1,Antichain::from_elem(1))].into_iter().collect(),
     /// ]);
     ///
     /// // Connect each output to the opposite input.

--- a/timely/src/progress/reachability.rs
+++ b/timely/src/progress/reachability.rs
@@ -160,7 +160,7 @@ impl<T: Timestamp> Builder<T> {
 
         // Assert that all summaries exist.
         debug_assert_eq!(inputs, summary.len());
-        for x in summary.iter() { debug_assert_eq!(outputs, x.next_port()); }
+        debug_assert!(summary.iter().all(|os| os.iter_ports().all(|(o,_)| o < outputs)));
 
         while self.nodes.len() <= index {
             self.nodes.push(Vec::new());
@@ -779,8 +779,6 @@ fn summarize_outputs<T: Timestamp>(
                     // Determine the current path summaries from the input port.
                     let location = Location { node: location.node, port: Port::Target(input_port) };
                     let antichains = results.entry(location).or_default();
-                    // TODO: This is redundant with `insert_ref` below.
-                    antichains.ensure(output);
 
                     // Combine each operator-internal summary to the output with `summary`.
                     for operator_summary in summaries[output_port].elements().iter() {
@@ -801,8 +799,6 @@ fn summarize_outputs<T: Timestamp>(
                 // Each target should have (at most) one source.
                 if let Some(&source) = reverse.get(&location) {
                     let antichains = results.entry(source).or_default();
-                    // TODO: This is redundant with `insert_ref` below.
-                    antichains.ensure(output);
 
                     if antichains.insert_ref(output, &summary) {
                         worklist.push_back((source, output, summary.clone()));

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -16,10 +16,10 @@ use crate::logging::TimelySummaryLogger as SummaryLogger;
 use crate::scheduling::Schedule;
 use crate::scheduling::activate::Activations;
 
-use crate::progress::frontier::{Antichain, MutableAntichain, MutableAntichainFilter};
+use crate::progress::frontier::{MutableAntichain, MutableAntichainFilter};
 use crate::progress::{Timestamp, Operate, operate::SharedProgress};
 use crate::progress::{Location, Port, Source, Target};
-use crate::progress::operate::Connectivity;
+use crate::progress::operate::{Connectivity, PortConnectivity};
 use crate::progress::ChangeBatch;
 use crate::progress::broadcast::Progcaster;
 use crate::progress::reachability;
@@ -168,7 +168,7 @@ where
         let mut builder = reachability::Builder::new();
 
         // Child 0 has `inputs` outputs and `outputs` inputs, not yet connected.
-        let summary = (0..outputs).map(|_| (0..inputs).map(|_| Antichain::new()).collect()).collect();
+        let summary = (0..outputs).map(|_| PortConnectivity::default_for(inputs)).collect();
         builder.add_node(0, outputs, inputs, summary);
         for (index, child) in self.children.iter().enumerate().skip(1) {
             builder.add_node(index, child.inputs, child.outputs, child.internal_summary.clone());
@@ -555,10 +555,10 @@ where
         // Note that we need to have `self.inputs()` elements in the summary
         // with each element containing `self.outputs()` antichains regardless
         // of how long `self.scope_summary` is
-        let mut internal_summary = vec![vec![Antichain::new(); self.outputs()]; self.inputs()];
+        let mut internal_summary = vec![PortConnectivity::default_for(self.outputs); self.inputs()];
         for (input_idx, input) in self.scope_summary.iter().enumerate() {
-            for (output_idx, output) in input.iter().enumerate() {
-                let antichain = &mut internal_summary[input_idx][output_idx];
+            for (output_idx, output) in input.iter_ports() {
+                let antichain = internal_summary[input_idx].ensure(output_idx);
                 antichain.reserve(output.elements().len());
                 antichain.extend(output.elements().iter().cloned().map(TInner::summarize));
             }
@@ -570,7 +570,7 @@ where
             "the internal summary should have as many elements as there are inputs",
         );
         debug_assert!(
-            internal_summary.iter().all(|summary| summary.len() == self.outputs()),
+            internal_summary.iter().all(|summary| summary.next_port() == self.outputs()),
             "each element of the internal summary should have as many elements as there are outputs",
         );
 
@@ -671,7 +671,7 @@ impl<T: Timestamp> PerOperatorState<T> {
             inputs,
         );
         assert!(
-            !internal_summary.iter().any(|x| x.len() != outputs),
+            !internal_summary.iter().any(|x| x.next_port() != outputs),
             "operator summary had too few outputs",
         );
 

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -168,7 +168,7 @@ where
         let mut builder = reachability::Builder::new();
 
         // Child 0 has `inputs` outputs and `outputs` inputs, not yet connected.
-        let summary = (0..outputs).map(|_| PortConnectivity::default_for(inputs)).collect();
+        let summary = (0..outputs).map(|_| PortConnectivity::default()).collect();
         builder.add_node(0, outputs, inputs, summary);
         for (index, child) in self.children.iter().enumerate().skip(1) {
             builder.add_node(index, child.inputs, child.outputs, child.internal_summary.clone());
@@ -555,7 +555,7 @@ where
         // Note that we need to have `self.inputs()` elements in the summary
         // with each element containing `self.outputs()` antichains regardless
         // of how long `self.scope_summary` is
-        let mut internal_summary = vec![PortConnectivity::default_for(self.outputs); self.inputs()];
+        let mut internal_summary = vec![PortConnectivity::default(); self.inputs()];
         for (input_idx, input) in self.scope_summary.iter().enumerate() {
             for (output_idx, output) in input.iter_ports() {
                 for outer in output.elements().iter().cloned().map(TInner::summarize) {

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -19,7 +19,7 @@ use crate::scheduling::activate::Activations;
 use crate::progress::frontier::{Antichain, MutableAntichain, MutableAntichainFilter};
 use crate::progress::{Timestamp, Operate, operate::SharedProgress};
 use crate::progress::{Location, Port, Source, Target};
-
+use crate::progress::operate::Connectivity;
 use crate::progress::ChangeBatch;
 use crate::progress::broadcast::Progcaster;
 use crate::progress::reachability;
@@ -270,7 +270,7 @@ where
     progcaster: Progcaster<TInner>,
 
     shared_progress: Rc<RefCell<SharedProgress<TOuter>>>,
-    scope_summary: Vec<Vec<Antichain<TInner::Summary>>>,
+    scope_summary: Connectivity<TInner::Summary>,
 
     progress_mode: ProgressMode,
 }
@@ -546,7 +546,7 @@ where
 
     // produces connectivity summaries from inputs to outputs, and reports initial internal
     // capabilities on each of the outputs (projecting capabilities from contained scopes).
-    fn get_internal_summary(&mut self) -> (Vec<Vec<Antichain<TOuter::Summary>>>, Rc<RefCell<SharedProgress<TOuter>>>) {
+    fn get_internal_summary(&mut self) -> (Connectivity<TOuter::Summary>, Rc<RefCell<SharedProgress<TOuter>>>) {
 
         // double-check that child 0 (the outside world) is correctly shaped.
         assert_eq!(self.children[0].outputs, self.inputs());
@@ -614,7 +614,7 @@ struct PerOperatorState<T: Timestamp> {
 
     shared_progress: Rc<RefCell<SharedProgress<T>>>,
 
-    internal_summary: Vec<Vec<Antichain<T::Summary>>>,   // cached result from get_internal_summary.
+    internal_summary: Connectivity<T::Summary>,   // cached result from get_internal_summary.
 
     logging: Option<Logger>,
 }

--- a/timely/tests/shape_scaling.rs
+++ b/timely/tests/shape_scaling.rs
@@ -1,0 +1,79 @@
+use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::Input;
+use timely::dataflow::InputHandle;
+use timely::Config;
+
+#[test] fn operator_scaling_1() { operator_scaling(1); }
+#[test] fn operator_scaling_10() { operator_scaling(10); }
+#[test] fn operator_scaling_100() { operator_scaling(100); }
+#[test] #[cfg_attr(miri, ignore)] fn operator_scaling_1000() { operator_scaling(1000); }
+#[test] #[cfg_attr(miri, ignore)] fn operator_scaling_10000() { operator_scaling(10000); }
+#[test] #[cfg_attr(miri, ignore)] fn operator_scaling_100000() { operator_scaling(100000); }
+
+fn operator_scaling(scale: u64) {
+    timely::execute(Config::thread(), move |worker| {
+        let mut input = InputHandle::new();
+        worker.dataflow::<u64, _, _>(|scope| {
+            use timely::dataflow::operators::Partition;
+            let parts =
+            scope
+                .input_from(&mut input)
+                .partition(scale, |()| (0, ()));
+
+            use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
+            let mut builder = OperatorBuilder::new("OpScaling".to_owned(), scope.clone());
+            let mut handles = Vec::with_capacity(parts.len());
+            let mut outputs = Vec::with_capacity(parts.len());
+            for (index, part) in parts.into_iter().enumerate() {
+                use timely::container::CapacityContainerBuilder;
+                let (output, stream) = builder.new_output_connection::<CapacityContainerBuilder<Vec<()>>,_>([]);
+                use timely::progress::Antichain;
+                let connectivity = [(index, Antichain::from_elem(Default::default()))];
+                handles.push((builder.new_input_connection(&part, Pipeline, connectivity), output));
+                outputs.push(stream);
+            }
+
+            builder.build(move |_| {
+                move |_frontiers| {
+                    for (input, output) in handles.iter_mut() {
+                        let mut output = output.activate();
+                        input.for_each(|time, data| {
+                            let mut output = output.session_with_builder(&time);
+                            for datum in data.drain(..) {
+                                output.give(datum);
+                            }
+                        });
+                    }
+                }
+            });
+        });
+    })
+    .unwrap();
+}
+
+#[test] fn subgraph_scaling_1() { subgraph_scaling(1); }
+#[test] fn subgraph_scaling_10() { subgraph_scaling(10); }
+#[test] fn subgraph_scaling_100() { subgraph_scaling(100); }
+#[test] #[cfg_attr(miri, ignore)] fn subgraph_scaling_1000() { subgraph_scaling(1000); }
+#[test] #[cfg_attr(miri, ignore)] fn subgraph_scaling_10000() { subgraph_scaling(10000); }
+#[test] #[cfg_attr(miri, ignore)] fn subgraph_scaling_100000() { subgraph_scaling(100000); }
+
+fn subgraph_scaling(scale: u64) {
+    timely::execute(Config::thread(), move |worker| {
+        let mut input = InputHandle::new();
+        worker.dataflow::<u64, _, _>(|scope| {
+            use timely::dataflow::operators::Partition;
+            let parts =
+            scope
+                .input_from(&mut input)
+                .partition(scale, |()| (0, ()));
+
+            use timely::dataflow::Scope;
+            let _outputs = scope.region(|inner| {
+                use timely::dataflow::operators::{Enter, Leave};
+                parts.into_iter().map(|part| part.enter(inner).leave()).collect::<Vec<_>>()
+            });
+        });
+    })
+    .unwrap();
+}


### PR DESCRIPTION
Slowly building up more confidence in changing our internal operator reachability implementation. This is a more careful version of #651, which in particular avoids a shadowing bug that seemed to be at the root of #654.

The external facing changes are that customer operator input/output creation no longer take a `Vec<Antichain<_>>`, but rather an `I: IntoIterator<Item=(usize, Antichain<_>)>`. This allows a sparse description of connectivity, in cases where it would be expensive to produce a large number of `Antichain::default()` empty antichains.

The new behavior is scale-tested in `tests/shape_scaling.rs`, where we test operators and subgraphs up to 100,000 x 100,000.
