### PR TITLE
Make `std::time::Instant` optional

### DIFF
--- a/timely/examples/logging-send.rs
+++ b/timely/examples/logging-send.rs
@@ -16,7 +16,7 @@ fn main() {
         let probe = ProbeHandle::new();
 
         // Register timely worker logging.
-        worker.log_register().insert::<TimelyEventBuilder,_>("timely", |time, data|
+        worker.log_register().unwrap().insert::<TimelyEventBuilder,_>("timely", |time, data|
             if let Some(data) = data {
                 data.iter().for_each(|x| println!("LOG1: {:?}", x))
             }
@@ -28,7 +28,7 @@ fn main() {
         // Register timely progress logging.
         // Less generally useful: intended for debugging advanced custom operators or timely
         // internals.
-        worker.log_register().insert::<TimelyProgressEventBuilder<usize>,_>("timely/progress/usize", |time, data|
+        worker.log_register().unwrap().insert::<TimelyProgressEventBuilder<usize>,_>("timely/progress/usize", |time, data|
             if let Some(data) = data {
                 data.iter().for_each(|x| {
                     println!("PROGRESS: {:?}", x);
@@ -50,7 +50,7 @@ fn main() {
             }
         );
 
-        worker.log_register().insert::<TrackerEventBuilder<usize>,_>("timely/reachability/usize", |time, data|
+        worker.log_register().unwrap().insert::<TrackerEventBuilder<usize>,_>("timely/reachability/usize", |time, data|
             if let Some(data) = data {
                 data.iter().for_each(|x| {
                     println!("REACHABILITY: {:?}", x);
@@ -61,7 +61,7 @@ fn main() {
             }
         );
 
-        worker.log_register().insert::<TimelySummaryEventBuilder<usize>,_>("timely/summary/usize", |time, data|
+        worker.log_register().unwrap().insert::<TimelySummaryEventBuilder<usize>,_>("timely/summary/usize", |time, data|
             if let Some(data) = data {
                 data.iter().for_each(|(_, x)| {
                     println!("SUMMARY: {:?}", x);
@@ -81,7 +81,7 @@ fn main() {
         });
 
         // Register timely worker logging.
-        worker.log_register().insert::<TimelyEventBuilder,_>("timely", |time, data|
+        worker.log_register().unwrap().insert::<TimelyEventBuilder,_>("timely", |time, data|
             if let Some(data) = data {
                 data.iter().for_each(|x| println!("LOG2: {:?}", x))
             }
@@ -100,7 +100,7 @@ fn main() {
 
         // Register user-level logging.
         type MyBuilder = CapacityContainerBuilder<Vec<(Duration, ())>>;
-        worker.log_register().insert::<MyBuilder,_>("input", |time, data|
+        worker.log_register().unwrap().insert::<MyBuilder,_>("input", |time, data|
             if let Some(data) = data {
                 for element in data.iter() {
                     println!("Round tick at: {:?}", element.0);
@@ -111,7 +111,7 @@ fn main() {
             }
         );
 
-        let input_logger = worker.log_register().get::<MyBuilder>("input").expect("Input logger absent");
+        let input_logger = worker.log_register().unwrap().get::<MyBuilder>("input").expect("Input logger absent");
 
         let timer = std::time::Instant::now();
 

--- a/timely/examples/threadless.rs
+++ b/timely/examples/threadless.rs
@@ -6,7 +6,7 @@ fn main() {
 
     // create a naked single-threaded worker.
     let allocator = timely::communication::allocator::Thread::default();
-    let mut worker = timely::worker::Worker::new(WorkerConfig::default(), allocator);
+    let mut worker = timely::worker::Worker::new(WorkerConfig::default(), allocator, None);
 
     // create input and probe handles.
     let mut input = InputHandle::new();

--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -73,7 +73,7 @@ where
     fn peek_identifier(&self) -> usize {
         self.parent.peek_identifier()
     }
-    fn log_register(&self) -> ::std::cell::RefMut<crate::logging_core::Registry> {
+    fn log_register(&self) -> Option<::std::cell::RefMut<crate::logging_core::Registry>> {
         self.parent.log_register()
     }
 }
@@ -135,8 +135,8 @@ where
         let path = self.addr_for_child(index);
 
         let type_name = std::any::type_name::<T2>();
-        let progress_logging = self.log_register().get(&format!("timely/progress/{type_name}"));
-        let summary_logging = self.log_register().get(&format!("timely/summary/{type_name}"));
+        let progress_logging = self.log_register().as_ref().and_then(|l| l.get(&format!("timely/progress/{type_name}")));
+        let summary_logging  = self.log_register().as_ref().and_then(|l| l.get(&format!("timely/summary/{type_name}")));
 
         let subscope = RefCell::new(SubgraphBuilder::new_from(path, identifier, self.logging(), summary_logging, name));
         let result = {

--- a/timely/src/dataflow/scopes/child.rs
+++ b/timely/src/dataflow/scopes/child.rs
@@ -135,8 +135,8 @@ where
         let path = self.addr_for_child(index);
 
         let type_name = std::any::type_name::<T2>();
-        let progress_logging = self.log_register().as_ref().and_then(|l| l.get(&format!("timely/progress/{type_name}")));
-        let summary_logging  = self.log_register().as_ref().and_then(|l| l.get(&format!("timely/summary/{type_name}")));
+        let progress_logging = self.logger_for(&format!("timely/progress/{type_name}"));
+        let summary_logging  = self.logger_for(&format!("timely/summary/{type_name}"));
 
         let subscope = RefCell::new(SubgraphBuilder::new_from(path, identifier, self.logging(), summary_logging, name));
         let result = {

--- a/timely/src/execute.rs
+++ b/timely/src/execute.rs
@@ -154,7 +154,7 @@ where
     F: FnOnce(&mut Worker<crate::communication::allocator::thread::Thread>)->T+Send+Sync+'static
 {
     let alloc = crate::communication::allocator::thread::Thread::default();
-    let mut worker = crate::worker::Worker::new(WorkerConfig::default(), alloc);
+    let mut worker = crate::worker::Worker::new(WorkerConfig::default(), alloc, Some(std::time::Instant::now()));
     let result = func(&mut worker);
     while worker.has_dataflows() {
         worker.step_or_park(None);
@@ -320,7 +320,7 @@ where
     T: Send+'static,
     F: Fn(&mut Worker<<A as AllocateBuilder>::Allocator>)->T+Send+Sync+'static {
     initialize_from(builders, others, move |allocator| {
-        let mut worker = Worker::new(worker_config.clone(), allocator);
+        let mut worker = Worker::new(worker_config.clone(), allocator, Some(std::time::Instant::now()));
         let result = func(&mut worker);
         while worker.has_dataflows() {
             worker.step_or_park(None);

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -10,7 +10,7 @@ use std::cell::RefCell;
 use std::collections::BinaryHeap;
 use std::cmp::Reverse;
 
-use crate::logging::{TimelyLogger as Logger, TimelyProgressEventBuilder};
+use crate::logging::TimelyLogger as Logger;
 use crate::logging::TimelySummaryLogger as SummaryLogger;
 
 use crate::scheduling::Schedule;
@@ -182,13 +182,9 @@ where
         // The `None` argument is optional logging infrastructure.
         let type_name = std::any::type_name::<TInner>();
         let reachability_logging =
-        worker.log_register()
-            .as_ref()
-            .and_then(|l| 
-                l.get::<reachability::logging::TrackerEventBuilder<TInner>>(&format!("timely/reachability/{type_name}"))
-                .map(|logger| reachability::logging::TrackerLogger::new(self.identifier, logger))
-        );
-        let progress_logging = worker.log_register().as_ref().and_then(|l| l.get::<TimelyProgressEventBuilder<TInner>>(&format!("timely/progress/{type_name}")));
+        worker.logger_for(&format!("timely/reachability/{type_name}"))
+              .map(|logger| reachability::logging::TrackerLogger::new(self.identifier, logger));
+        let progress_logging = worker.logger_for(&format!("timely/progress/{type_name}"));
         let (tracker, scope_summary) = builder.build(reachability_logging);
 
         let progcaster = Progcaster::new(worker, Rc::clone(&self.path), self.identifier, self.logging.clone(), progress_logging);

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -183,9 +183,12 @@ where
         let type_name = std::any::type_name::<TInner>();
         let reachability_logging =
         worker.log_register()
-            .get::<reachability::logging::TrackerEventBuilder<TInner>>(&format!("timely/reachability/{type_name}"))
-            .map(|logger| reachability::logging::TrackerLogger::new(self.identifier, logger));
-        let progress_logging = worker.log_register().get::<TimelyProgressEventBuilder<TInner>>(&format!("timely/progress/{type_name}"));
+            .as_ref()
+            .and_then(|l| 
+                l.get::<reachability::logging::TrackerEventBuilder<TInner>>(&format!("timely/reachability/{type_name}"))
+                .map(|logger| reachability::logging::TrackerLogger::new(self.identifier, logger))
+        );
+        let progress_logging = worker.log_register().as_ref().and_then(|l| l.get::<TimelyProgressEventBuilder<TInner>>(&format!("timely/progress/{type_name}")));
         let (tracker, scope_summary) = builder.build(reachability_logging);
 
         let progcaster = Progcaster::new(worker, Rc::clone(&self.path), self.identifier, self.logging.clone(), progress_logging);

--- a/timely/src/scheduling/activate.rs
+++ b/timely/src/scheduling/activate.rs
@@ -48,14 +48,14 @@ pub struct Activations {
     rx: Receiver<Vec<usize>>,
 
     // Delayed activations.
-    timer: Instant,
+    timer: Option<Instant>,
     queue: BinaryHeap<Reverse<(Duration, Vec<usize>)>>,
 }
 
 impl Activations {
 
     /// Creates a new activation tracker.
-    pub fn new(timer: Instant) -> Self {
+    pub fn new(timer: Option<Instant>) -> Self {
         let (tx, rx) = crossbeam_channel::unbounded();
         Self {
             clean: 0,
@@ -77,13 +77,18 @@ impl Activations {
 
     /// Schedules a future activation for the task addressed by `path`.
     pub fn activate_after(&mut self, path: &[usize], delay: Duration) {
-        // TODO: We could have a minimum delay and immediately schedule anything less than that delay.
-        if delay == Duration::new(0, 0) {
-            self.activate(path);
-        }
+        if let Some(timer) = self.timer {
+            // TODO: We could have a minimum delay and immediately schedule anything less than that delay.
+            if delay == Duration::new(0, 0) {
+                self.activate(path);
+            }
+            else {
+                let moment = timer.elapsed() + delay;
+                self.queue.push(Reverse((moment, path.to_vec())));
+            }
+        } 
         else {
-            let moment = self.timer.elapsed() + delay;
-            self.queue.push(Reverse((moment, path.to_vec())));
+            self.activate(path);
         }
     }
 
@@ -96,11 +101,13 @@ impl Activations {
         }
 
         // Drain timer-based activations.
-        if !self.queue.is_empty() {
-            let now = self.timer.elapsed();
-            while self.queue.peek().map(|Reverse((t,_))| t <= &now) == Some(true) {
-                let Reverse((_time, path)) = self.queue.pop().unwrap();
-                self.activate(&path[..]);
+        if let Some(timer) = self.timer {
+            if !self.queue.is_empty() {
+                let now = timer.elapsed();
+                while self.queue.peek().map(|Reverse((t,_))| t <= &now) == Some(true) {
+                    let Reverse((_time, path)) = self.queue.pop().unwrap();
+                    self.activate(&path[..]);
+                }
             }
         }
 
@@ -173,12 +180,12 @@ impl Activations {
     /// indicates the amount of time before the thread should be unparked for the
     /// next scheduled activation.
     pub fn empty_for(&self) -> Option<Duration> {
-        if !self.bounds.is_empty() {
+        if !self.bounds.is_empty() || self.timer.is_none() {
             Some(Duration::new(0,0))
         }
         else {
             self.queue.peek().map(|Reverse((t,_a))| {
-                let elapsed = self.timer.elapsed();
+                let elapsed = self.timer.unwrap().elapsed();
                 if t < &elapsed { Duration::new(0,0) }
                 else { *t - elapsed }
             })


### PR DESCRIPTION
There are a few uses of `std::time::Instant` in the codebase which do not *need* to be there. This is the first commit from https://github.com/TimelyDataflow/timely-dataflow/pull/577, and something we can discuss independent of the follow-on commits that rework the scheduler.