### PR TITLE
Remove crossbeam uses

### DIFF
--- a/timely/Cargo.toml
+++ b/timely/Cargo.toml
@@ -32,7 +32,6 @@ timely_bytes = { path = "../bytes", version = "0.13" }
 timely_logging = { path = "../logging", version = "0.13" }
 timely_communication = { path = "../communication", version = "0.19", default-features = false }
 timely_container = { path = "../container", version = "0.15" }
-crossbeam-channel = "0.5"
 smallvec = { version = "1.13.2", features = ["serde", "const_generics"] }
 
 [dev-dependencies]

--- a/timely/src/scheduling/activate.rs
+++ b/timely/src/scheduling/activate.rs
@@ -6,7 +6,7 @@ use std::thread::Thread;
 use std::collections::BinaryHeap;
 use std::time::{Duration, Instant};
 use std::cmp::Reverse;
-use crossbeam_channel::{Sender, Receiver};
+use std::sync::mpsc::{Sender, Receiver};
 
 /// Methods required to act as a timely scheduler.
 ///
@@ -56,7 +56,7 @@ impl Activations {
 
     /// Creates a new activation tracker.
     pub fn new(timer: Option<Instant>) -> Self {
-        let (tx, rx) = crossbeam_channel::unbounded();
+        let (tx, rx) = std::sync::mpsc::channel();
         Self {
             clean: 0,
             bounds: Vec::new(),


### PR DESCRIPTION
We had one use of a crossbeam channel, in the activator. Swapping that for a `mpsc::channel()` allows us to remove crossbeam as a dependency.