### PR TITLE
Optionally flush container builders

### DIFF
--- a/container/src/lib.rs
+++ b/container/src/lib.rs
@@ -126,9 +126,11 @@ pub trait ContainerBuilder: Default + 'static {
         container.clear();
     }
 
-    /// Indicates a good moment to release resources. By default, does nothing. Callers should
-    /// not rely on this method releasing any internal state though, i.e., the caller first
-    /// needs to drain the contents using [`Self::finish`].
+    /// Indicates a good moment to release resources.
+    ///
+    /// By default, does nothing. Callers first needs to drain the contents using [`Self::finish`]
+    /// before calling this function. The implementation should not change the contents of the
+    /// builder.
     #[inline]
     fn relax(&mut self) { }
 }

--- a/container/src/lib.rs
+++ b/container/src/lib.rs
@@ -130,7 +130,7 @@ pub trait ContainerBuilder: Default + 'static {
     /// not rely on this method releasing any internal state though, i.e., the caller first
     /// needs to drain the contents using [`Self::finish`].
     #[inline]
-    fn flush(&mut self) { }
+    fn relax(&mut self) { }
 }
 
 /// A wrapper trait indicating that the container building will preserve the number of records.

--- a/container/src/lib.rs
+++ b/container/src/lib.rs
@@ -125,6 +125,12 @@ pub trait ContainerBuilder: Default + 'static {
         }
         container.clear();
     }
+
+    /// Indicates a good moment to release resources. By default, does nothing. Callers should
+    /// not rely on this method releasing any internal state though, i.e., the caller first
+    /// needs to drain the contents using [`Self::finish`].
+    #[inline]
+    fn flush(&mut self) { }
 }
 
 /// A wrapper trait indicating that the container building will preserve the number of records.

--- a/timely/examples/columnar.rs
+++ b/timely/examples/columnar.rs
@@ -335,6 +335,10 @@ mod builder {
 
         #[inline]
         fn relax(&mut self) {
+            /// The caller is responsible for draining all contents; assert that we are empty.
+            /// The assertion is not strictly necessary, but it helps catch bugs.
+            debug_assert!(self.current.is_empty());
+            debug_assert!(self.pending.is_empty());
             *self = Self::default();
         }
     }

--- a/timely/examples/columnar.rs
+++ b/timely/examples/columnar.rs
@@ -300,6 +300,7 @@ mod builder {
     }
 
     impl<C: Columnar> Default for ColumnBuilder<C> {
+        #[inline]
         fn default() -> Self {
             ColumnBuilder {
                 current: Default::default(),
@@ -330,6 +331,11 @@ mod builder {
             }
             self.empty = self.pending.pop_front();
             self.empty.as_mut()
+        }
+
+        #[inline]
+        fn flush(&mut self) {
+            *self = Self::default();
         }
     }
 

--- a/timely/examples/columnar.rs
+++ b/timely/examples/columnar.rs
@@ -337,8 +337,8 @@ mod builder {
         fn relax(&mut self) {
             /// The caller is responsible for draining all contents; assert that we are empty.
             /// The assertion is not strictly necessary, but it helps catch bugs.
-            debug_assert!(self.current.is_empty());
-            debug_assert!(self.pending.is_empty());
+            assert!(self.current.is_empty());
+            assert!(self.pending.is_empty());
             *self = Self::default();
         }
     }

--- a/timely/examples/columnar.rs
+++ b/timely/examples/columnar.rs
@@ -334,7 +334,7 @@ mod builder {
         }
 
         #[inline]
-        fn flush(&mut self) {
+        fn relax(&mut self) {
             *self = Self::default();
         }
     }

--- a/timely/examples/columnar.rs
+++ b/timely/examples/columnar.rs
@@ -335,8 +335,8 @@ mod builder {
 
         #[inline]
         fn relax(&mut self) {
-            /// The caller is responsible for draining all contents; assert that we are empty.
-            /// The assertion is not strictly necessary, but it helps catch bugs.
+            // The caller is responsible for draining all contents; assert that we are empty.
+            // The assertion is not strictly necessary, but it helps catch bugs.
             assert!(self.current.is_empty());
             assert!(self.pending.is_empty());
             *self = Self::default();

--- a/timely/src/dataflow/channels/pushers/buffer.rs
+++ b/timely/src/dataflow/channels/pushers/buffer.rs
@@ -81,6 +81,7 @@ impl<T, CB: ContainerBuilder, P: Push<Message<T, CB::Container>>> Buffer<T, CB, 
     /// Flushes all data and pushes a `None` to `self.pusher`, indicating a flush.
     pub fn cease(&mut self) {
         self.flush();
+        self.builder.flush();
         self.pusher.push(&mut None);
     }
 

--- a/timely/src/dataflow/channels/pushers/buffer.rs
+++ b/timely/src/dataflow/channels/pushers/buffer.rs
@@ -81,7 +81,7 @@ impl<T, CB: ContainerBuilder, P: Push<Message<T, CB::Container>>> Buffer<T, CB, 
     /// Flushes all data and pushes a `None` to `self.pusher`, indicating a flush.
     pub fn cease(&mut self) {
         self.flush();
-        self.builder.flush();
+        self.builder.relax();
         self.pusher.push(&mut None);
     }
 

--- a/timely/src/dataflow/channels/pushers/exchange.rs
+++ b/timely/src/dataflow/channels/pushers/exchange.rs
@@ -96,7 +96,7 @@ where
             // flush
             for index in 0..self.pushers.len() {
                 self.flush(index);
-                self.builders[index].flush();
+                self.builders[index].relax();
                 self.pushers[index].push(&mut None);
             }
         }

--- a/timely/src/dataflow/channels/pushers/exchange.rs
+++ b/timely/src/dataflow/channels/pushers/exchange.rs
@@ -14,7 +14,7 @@ where
     for<'a> H: FnMut(&<CB::Container as Container>::Item<'a>) -> u64
 {
     pushers: Vec<P>,
-    buffers: Vec<CB>,
+    builders: Vec<CB>,
     current: Option<T>,
     hash_func: H,
 }
@@ -27,20 +27,20 @@ where
 {
     /// Allocates a new `Exchange` from a supplied set of pushers and a distribution function.
     pub fn new(pushers: Vec<P>, key: H) -> Exchange<T, CB, P, H> {
-        let mut buffers = vec![];
+        let mut builders = vec![];
         for _ in 0..pushers.len() {
-            buffers.push(Default::default());
+            builders.push(Default::default());
         }
         Exchange {
             pushers,
             hash_func: key,
-            buffers,
+            builders,
             current: None,
         }
     }
     #[inline]
     fn flush(&mut self, index: usize) {
-        while let Some(container) = self.buffers[index].finish() {
+        while let Some(container) = self.builders[index].finish() {
             if let Some(ref time) = self.current {
                 Message::push_at(container, time.clone(), &mut self.pushers[index]);
             }
@@ -79,14 +79,14 @@ where
             // if the number of pushers is a power of two, use a mask
             if self.pushers.len().is_power_of_two() {
                 let mask = (self.pushers.len() - 1) as u64;
-                CB::partition(data, &mut self.buffers, |datum| ((hash_func)(datum) & mask) as usize);
+                CB::partition(data, &mut self.builders, |datum| ((hash_func)(datum) & mask) as usize);
             }
             // as a last resort, use mod (%)
             else {
                 let num_pushers = self.pushers.len() as u64;
-                CB::partition(data, &mut self.buffers, |datum| ((hash_func)(datum) % num_pushers) as usize);
+                CB::partition(data, &mut self.builders, |datum| ((hash_func)(datum) % num_pushers) as usize);
             }
-            for (buffer, pusher) in self.buffers.iter_mut().zip(self.pushers.iter_mut()) {
+            for (buffer, pusher) in self.builders.iter_mut().zip(self.pushers.iter_mut()) {
                 while let Some(container) = buffer.extract() {
                     Message::push_at(container, time.clone(), pusher);
                 }
@@ -96,6 +96,7 @@ where
             // flush
             for index in 0..self.pushers.len() {
                 self.flush(index);
+                self.builders[index].flush();
                 self.pushers[index].push(&mut None);
             }
         }


### PR DESCRIPTION
Flush container builders in exchange channels and session buffers, if they need to. This avoids a problem where we'd have a quadratic amount of lingering memory in the exchange channel. The change adds a `relax` function to container builders, which by default does nothing. Container builders can use it to release resources when called, and Timely calls it when it believes it's a good moment to flush. This corresponds to pushing a `None` value, which happens once an operator ceases to produce data.

I don't like the solution very much because it seems to conflate different concepts, but it seems like a small API change without too much negative impact.

Edit: changed the name from `flush` to `relax` for the lack of a better term.