### PR TITLE
Log channel container type

### DIFF
--- a/timely/src/dataflow/stream.rs
+++ b/timely/src/dataflow/stream.rs
@@ -60,6 +60,7 @@ impl<S: Scope, C: Container> StreamCore<S, C> {
             scope_addr: self.scope.addr().to_vec(),
             source: (self.name.node, self.name.port),
             target: (target.node, target.port),
+            typ: std::any::type_name::<C>().to_string(),
         }));
 
         self.scope.add_edge(self.name, target);

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -91,6 +91,8 @@ pub struct ChannelsEvent {
     pub source: (usize, usize),
     /// Target descriptor, indicating operator index and input port.
     pub target: (usize, usize),
+    /// The type of data on the channel, as a string.
+    pub typ: String,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Logs the channel container type as part of the `ChannelsEvent`. This allows us to surface the channel container type in debug data.
