### PR TITLE
Update for Columnar 0.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           - windows
         toolchain:
           - stable
-          - 1.78
+          - 1.79
     name: cargo test on ${{ matrix.os }}, rust ${{ matrix.toolchain }}
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 edition = "2021"
 
 [workspace.dependencies]
-columnar = "0.6"
+columnar = "0.7"
 
 [workspace.lints.clippy]
 type_complexity = "allow"


### PR DESCRIPTION
Changes required to target `columnar`'s changes in 0.7. Combined with a few clean-ups, `examples/columnar.rs` gets a fair bit nicer in my opinion!

Columnar 0.7 isn't live yet, so this should fail until it is released.