### PR TITLE
Update to columnar 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 edition = "2021"
 
 [workspace.dependencies]
-columnar = "0.7"
+columnar = "0.8"
 
 [workspace.lints.clippy]
 type_complexity = "allow"


### PR DESCRIPTION
Columnar had a version upgrade, and it seems like its `columnar_derive` crate went out without a semver tick, even though it corresponds to 0.8 which is a semver break from 0.7. We'll need to merge this to fix the break, I think.

fixes #682 