### PR TITLE
Efficient Exchange::new

### DIFF
--- a/timely/src/dataflow/channels/pushers/exchange.rs
+++ b/timely/src/dataflow/channels/pushers/exchange.rs
@@ -27,10 +27,7 @@ where
 {
     /// Allocates a new `Exchange` from a supplied set of pushers and a distribution function.
     pub fn new(pushers: Vec<P>, key: H) -> Exchange<T, CB, P, H> {
-        let mut builders = vec![];
-        for _ in 0..pushers.len() {
-            builders.push(Default::default());
-        }
+        let builders = std::iter::repeat_with(Default::default).take(pushers.len()).collect();
         Exchange {
             pushers,
             hash_func: key,


### PR DESCRIPTION
Construct the container builder vector directly instead of pushing at it.
