### PR TITLE
Remove guarded logging

### DIFF
--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -21,7 +21,6 @@ use crate::dataflow::operators::generic::handles::{InputHandleCore, new_input_ha
 use crate::dataflow::operators::generic::operator_info::OperatorInfo;
 use crate::dataflow::operators::generic::builder_raw::OperatorShape;
 use crate::progress::operate::PortConnectivity;
-use crate::logging::TimelyLogger as Logger;
 
 use super::builder_raw::OperatorBuilder as OperatorBuilderRaw;
 
@@ -35,14 +34,12 @@ pub struct OperatorBuilder<G: Scope> {
     /// For each input, a shared list of summaries to each output.
     summaries: Vec<Rc<RefCell<PortConnectivity<<G::Timestamp as Timestamp>::Summary>>>>,
     produced: Vec<Rc<RefCell<ChangeBatch<G::Timestamp>>>>,
-    logging: Option<Logger>,
 }
 
 impl<G: Scope> OperatorBuilder<G> {
 
     /// Allocates a new generic operator builder from its containing scope.
     pub fn new(name: String, scope: G) -> Self {
-        let logging = scope.logging();
         OperatorBuilder {
             builder: OperatorBuilderRaw::new(name, scope),
             frontier: Vec::new(),
@@ -50,7 +47,6 @@ impl<G: Scope> OperatorBuilder<G> {
             internal: Rc::new(RefCell::new(Vec::new())),
             summaries: Vec::new(),
             produced: Vec::new(),
-            logging,
         }
     }
 
@@ -90,7 +86,7 @@ impl<G: Scope> OperatorBuilder<G> {
         let shared_summary = Rc::new(RefCell::new(connection.into_iter().collect()));
         self.summaries.push(Rc::clone(&shared_summary));
 
-        new_input_handle(input, Rc::clone(&self.internal), shared_summary, self.logging.clone())
+        new_input_handle(input, Rc::clone(&self.internal), shared_summary)
     }
 
     /// Adds a new output to a generic operator builder, returning the `Push` implementor to use.

--- a/timely/src/dataflow/operators/generic/operator.rs
+++ b/timely/src/dataflow/operators/generic/operator.rs
@@ -350,10 +350,9 @@ impl<G: Scope, C1: Container + Data> Operator<G, C1> for StreamCore<G, C1> {
                 notificator.notify_at(capability.delayed(&time));
             }
 
-            let logging = self.scope().logging();
             move |input, output| {
                 let frontier = &[input.frontier()];
-                let notificator = &mut Notificator::new(frontier, &mut notificator, &logging);
+                let notificator = &mut Notificator::new(frontier, &mut notificator);
                 logic(input.handle, output, notificator);
             }
         })
@@ -436,10 +435,9 @@ impl<G: Scope, C1: Container + Data> Operator<G, C1> for StreamCore<G, C1> {
                 notificator.notify_at(capability.delayed(&time));
             }
 
-            let logging = self.scope().logging();
             move |input1, input2, output| {
                 let frontiers = &[input1.frontier(), input2.frontier()];
-                let notificator = &mut Notificator::new(frontiers, &mut notificator, &logging);
+                let notificator = &mut Notificator::new(frontiers, &mut notificator);
                 logic(input1.handle, input2.handle, output, notificator);
             }
         })

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -181,20 +181,6 @@ pub struct ApplicationEvent {
     pub is_start: bool,
 }
 
-#[derive(Serialize, Deserialize, Columnar, Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
-/// Application-defined code start or stop
-pub struct GuardedMessageEvent {
-    /// `true` when activity begins, `false` when it stops
-    pub is_start: bool,
-}
-
-#[derive(Serialize, Deserialize, Columnar, Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
-/// Application-defined code start or stop
-pub struct GuardedProgressEvent {
-    /// `true` when activity begins, `false` when it stops
-    pub is_start: bool,
-}
-
 #[derive(Serialize, Deserialize, Columnar, Debug, PartialEq, Eq, Hash, Clone, Copy)]
 /// Identifier of the worker that generated a log line
 pub struct TimelySetup {
@@ -260,10 +246,6 @@ pub enum TimelyEvent {
     Shutdown(ShutdownEvent),
     /// No clue.
     Application(ApplicationEvent),
-    /// Per-message computation.
-    GuardedMessage(GuardedMessageEvent),
-    /// Per-notification computation.
-    GuardedProgress(GuardedProgressEvent),
     /// Communication channel event.
     CommChannels(CommChannelsEvent),
     /// Input event.
@@ -300,14 +282,6 @@ impl From<ShutdownEvent> for TimelyEvent {
 
 impl From<ApplicationEvent> for TimelyEvent {
     fn from(v: ApplicationEvent) -> TimelyEvent { TimelyEvent::Application(v) }
-}
-
-impl From<GuardedMessageEvent> for TimelyEvent {
-    fn from(v: GuardedMessageEvent) -> TimelyEvent { TimelyEvent::GuardedMessage(v) }
-}
-
-impl From<GuardedProgressEvent> for TimelyEvent {
-    fn from(v: GuardedProgressEvent) -> TimelyEvent { TimelyEvent::GuardedProgress(v) }
 }
 
 impl From<CommChannelsEvent> for TimelyEvent {


### PR DESCRIPTION
Remove `Guarded` events from logging, as they seem to be more of a logging performance trap than useful at the moment. Their historical use was that with busy scheduling we'd rather see only those events when we have data to process, but with event-driven scheduling we the guarded events are a larger proportion of the logged events.