### PR TITLE
Retire target and source changes in bulk

### DIFF
--- a/timely/src/progress/change_batch.rs
+++ b/timely/src/progress/change_batch.rs
@@ -56,6 +56,24 @@ impl<T, const X: usize> ChangeBatch<T, X> {
         }
     }
 
+    /// Constructs a `ChangeBatch` from updates.
+    ///
+    /// # Examples
+    ///
+    ///```
+    /// use timely::progress::ChangeBatch;
+    ///
+    /// let updates = [(5, 1), (5, -1)].into();
+    /// let mut batch = ChangeBatch::from_updates(updates);
+    /// assert!(batch.is_empty());
+    ///```
+    pub fn from_updates(updates: SmallVec<[(T, i64); X]>) -> Self {
+        Self {
+            updates,
+            clean: 0,
+        }
+    }
+
     /// Returns `true` if the change batch is not guaranteed compact.
     pub fn is_dirty(&self) -> bool {
         self.updates.len() > self.clean


### PR DESCRIPTION
If we have many updates per source or target, `propagate_all` will update
an operator's pointstamps as many times as there are updates. Updating
the mutable antichain behind pointstamps can be expensive.

This change extracts the updates from the target and source changes, and
applies them in bulk on the pointstamps in the hope of reducing the cost
of maintaining the antichain.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>

