### PR TITLE
Remove some quadratic behavior from `propagate_all`

### DIFF
--- a/timely/Cargo.toml
+++ b/timely/Cargo.toml
@@ -27,6 +27,7 @@ columnation = "0.1"
 getopts = { version = "0.2.21", optional = true }
 bincode = { version = "1.0" }
 byteorder = "1.5"
+itertools = "0.14.0"
 serde = { version = "1.0", features = ["derive"] }
 timely_bytes = { path = "../bytes", version = "0.22" }
 timely_logging = { path = "../logging", version = "0.22" }


### PR DESCRIPTION
An alternate approach to the problem identified in #702. This version avoids some other quadratic behavior (repeatedly draining a prefix of a list) through some peekable iterator shenanigans. It might be worth writing the iterator combinator that does this manually, just for clarity, but we can discuss. It was surprisingly grotty to get what felt like pretty simple behavior, but .. maybe that's a me problem.

Up next, putting together a test that reveals the bad behavior, and its absence.

@antiguru 