### PR TITLE
Remove IterContainer

### DIFF
--- a/timely/src/dataflow/operators/core/input.rs
+++ b/timely/src/dataflow/operators/core/input.rs
@@ -75,7 +75,7 @@ pub trait Input : Scope {
     /// ```
     /// use std::rc::Rc;
     /// use timely::*;
-    /// use timely::dataflow::operators::core::{Input, Inspect};
+    /// use timely::dataflow::operators::core::{Input, InspectCore};
     /// use timely::container::CapacityContainerBuilder;
     ///
     /// // construct and execute a timely dataflow
@@ -84,7 +84,7 @@ pub trait Input : Scope {
     ///     // add an input and base computation off of it
     ///     let mut input = worker.dataflow(|scope| {
     ///         let (input, stream) = scope.new_input_with_builder::<CapacityContainerBuilder<Rc<Vec<_>>>>();
-    ///         stream.inspect(|x| println!("hello {:?}", x));
+    ///         stream.inspect_container(|x| println!("hello {:?}", x));
     ///         input
     ///     });
     ///

--- a/timely/src/dataflow/operators/core/rc.rs
+++ b/timely/src/dataflow/operators/core/rc.rs
@@ -12,13 +12,13 @@ pub trait SharedStream<S: Scope, C> {
     ///
     /// # Examples
     /// ```
-    /// use timely::dataflow::operators::{ToStream, Inspect};
+    /// use timely::dataflow::operators::{ToStream, InspectCore};
     /// use timely::dataflow::operators::rc::SharedStream;
     ///
     /// timely::example(|scope| {
     ///     (0..10).to_stream(scope)
     ///            .shared()
-    ///            .inspect(|x| println!("seen: {:?}", x));
+    ///            .inspect_container(|x| println!("seen: {:?}", x));
     /// });
     /// ```
     fn shared(&self) -> StreamCore<S, Rc<C>>;
@@ -43,12 +43,13 @@ mod test {
     use crate::dataflow::channels::pact::Pipeline;
     use crate::dataflow::operators::capture::Extract;
     use crate::dataflow::operators::rc::SharedStream;
-    use crate::dataflow::operators::{Capture, Concatenate, Operator, ToStream};
+    use crate::dataflow::operators::{Capture, Concatenate, InspectCore, Operator, ToStream};
 
     #[test]
     fn test_shared() {
         let output = crate::example(|scope| {
             let shared = vec![Ok(0), Err(())].to_stream(scope).container::<Vec<_>>().shared();
+            let shared = shared.inspect_container(|x| println!("seen: {x:?}"));
             scope
                 .concatenate([
                     shared.unary(Pipeline, "read shared 1", |_, _| {


### PR DESCRIPTION
This change removes the IterContainer type and reworks other types and
implementations to function independently. Notably, this is a breaking
change for users of exotic containers:
* The `Inspect` trait defers to `&C: IntoIterator` to reveal items in
  containers. Not all currently used containers provide this. Vec does,
  but Rc/Arc and Column don't and do not plan to in the future. Users
  should pivot to `inspect_container` instead and internalize the iteration
  in the closure.
* The `DrainContainer` implementaiton for Rc/Arc depends on the wrapped
  type implementing `IntoIterator` for references. This limits where
  wrapped containers that do not provide this can be used. It's mostly
  limited to the core Timely layer that doesn't provide element-by-element
  functionality.

I feel this change is net positive as it defers to the Rust API to iterate
existing types, instead of us providing our own infrastructure. It comes
at a cost of potentially breaking existing code, which seems acceptable.
