### PR TITLE
Remove `Hash` from `Timestamp`

### DIFF
--- a/timely/src/dataflow/operators/aggregation/aggregate.rs
+++ b/timely/src/dataflow/operators/aggregation/aggregate.rs
@@ -67,7 +67,7 @@ pub trait Aggregate<S: Scope, K: ExchangeData+Hash, V: ExchangeData> {
         hash: H) -> Stream<S, R> where S::Timestamp: Eq;
 }
 
-impl<S: Scope, K: ExchangeData+Hash+Eq, V: ExchangeData> Aggregate<S, K, V> for Stream<S, (K, V)> {
+impl<S: Scope<Timestamp: ::std::hash::Hash>, K: ExchangeData+Hash+Eq, V: ExchangeData> Aggregate<S, K, V> for Stream<S, (K, V)> {
 
     fn aggregate<R: Data, D: Default+'static, F: Fn(&K, V, &mut D)+'static, E: Fn(K, D)->R+'static, H: Fn(&K)->u64+'static>(
         &self,

--- a/timely/src/dataflow/operators/capability.rs
+++ b/timely/src/dataflow/operators/capability.rs
@@ -205,7 +205,7 @@ impl<T: Timestamp> PartialOrder for Capability<T> {
     }
 }
 
-impl<T: Timestamp> ::std::hash::Hash for Capability<T> {
+impl<T: Timestamp+::std::hash::Hash> ::std::hash::Hash for Capability<T> {
     fn hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
         self.time.hash(state);
     }

--- a/timely/src/dataflow/operators/count.rs
+++ b/timely/src/dataflow/operators/count.rs
@@ -48,7 +48,7 @@ pub trait Accumulate<G: Scope, D: Data> {
     }
 }
 
-impl<G: Scope, D: Data> Accumulate<G, D> for Stream<G, D> {
+impl<G: Scope<Timestamp: ::std::hash::Hash>, D: Data> Accumulate<G, D> for Stream<G, D> {
     fn accumulate<A: Data>(&self, default: A, logic: impl Fn(&mut A, &mut Vec<D>)+'static) -> Stream<G, A> {
 
         let mut accums = HashMap::new();

--- a/timely/src/dataflow/operators/delay.rs
+++ b/timely/src/dataflow/operators/delay.rs
@@ -94,7 +94,7 @@ pub trait Delay<G: Scope, D: Data> {
     fn delay_batch<L: FnMut(&G::Timestamp)->G::Timestamp+'static>(&self, func: L) -> Self;
 }
 
-impl<G: Scope, D: Data> Delay<G, D> for Stream<G, D> {
+impl<G: Scope<Timestamp: ::std::hash::Hash>, D: Data> Delay<G, D> for Stream<G, D> {
     fn delay<L: FnMut(&D, &G::Timestamp)->G::Timestamp+'static>(&self, mut func: L) -> Self {
         let mut elements = HashMap::new();
         self.unary_notify(Pipeline, "Delay", vec![], move |input, output, notificator| {

--- a/timely/src/progress/timestamp.rs
+++ b/timely/src/progress/timestamp.rs
@@ -3,7 +3,6 @@
 use std::fmt::Debug;
 use std::any::Any;
 use std::default::Default;
-use std::hash::Hash;
 
 use crate::ExchangeData;
 use crate::order::PartialOrder;
@@ -12,7 +11,7 @@ use crate::order::PartialOrder;
 ///
 /// By implementing this trait, you promise that the type's [PartialOrder] implementation
 /// is compatible with [Ord], such that if `a.less_equal(b)` then `a <= b`.
-pub trait Timestamp: Clone+Eq+PartialOrder+Debug+Send+Any+ExchangeData+Hash+Ord {
+pub trait Timestamp: Clone+Eq+PartialOrder+Ord+Debug+Any+ExchangeData {
     /// A type summarizing action on a timestamp along a dataflow path.
     type Summary : PathSummary<Self> + 'static;
     /// A unique minimum value in our partial order.
@@ -22,7 +21,7 @@ pub trait Timestamp: Clone+Eq+PartialOrder+Debug+Send+Any+ExchangeData+Hash+Ord 
 }
 
 /// A summary of how a timestamp advances along a timely dataflow path.
-pub trait PathSummary<T> : Clone+'static+Eq+PartialOrder+Debug+Default {
+pub trait PathSummary<T> : Clone+Eq+PartialOrder+Debug+Default {
     /// Advances a timestamp according to the timestamp actions on the path.
     ///
     /// The path may advance the timestamp sufficiently that it is no longer valid, for example if


### PR DESCRIPTION
The `Hash` trait on timestamps was not used other than 1. to derive a `Hash` implementation for `Capability<T>` and 2. in support for various timestamp-indexed demo operators (delay, aggregate, etc). The bound is removed from the trait, and added to the implementations.

Part of an effort to minimize the per-record reasoning. Timestamps are an instance, not the main instance, but .. this came up.