### PR TITLE
Await on multiple addresses

### DIFF
--- a/communication/src/networking.rs
+++ b/communication/src/networking.rs
@@ -150,7 +150,7 @@ pub fn await_connections(addresses: Arc<Vec<String>>, my_index: usize, noisy: bo
     let mut results: Vec<_> = (0..(addresses.len() - my_index - 1)).map(|_| None).collect();
 
     // We may have multiple addresses to bind to, and will listen on each of them until all received.
-    let listeners = addresses[my_index].split_whitespace().map(|addr| TcpListener::bind(addr)).collect::<Result<Vec<_>>>()?;
+    let listeners = addresses[my_index].split_whitespace().map(TcpListener::bind).collect::<Result<Vec<_>>>()?;
     for listener in listeners.iter() { listener.set_nonblocking(true).expect("Couldn't set nonblocking"); }
 
     // Until we have all intended connections, poll each listener, sleeping briefly if none have accepted a new stream.


### PR DESCRIPTION
This PR updates the networking setup to allow the `--hostfile` to list multiple `addr:port` on each line, separated by whitespace, and then to listen on each and await the connections from any of them.

The main change this introduces for folks who don't use this feature is that the the awaiting happens without blocking, and has a 1s sleep between each `accept()` call that doesn't return a socket. This is not unlike the other end of the set-up, where connection attempts are re-attempted each second. In the worst case, this could delay the full connection by a second, where the existing code would by blocking connect as soon as sockets arrive.

It wouldn't be too hard to leave the old behavior when there is a single address to listen on, by keeping both methods.

One risk of the PR is that there may be a `ToSocketAddrs` for `&str` that allows whitespace, and [the documentation](https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html) is a bit confusing to me:

> the string should be either a string representation of a [SocketAddr](https://doc.rust-lang.org/std/net/enum.SocketAddr.html) as expected by its [FromStr](https://doc.rust-lang.org/std/str/trait.FromStr.html) implementation or a string like `<host_name>:<port>` pair where `<port>` is a [u16](https://doc.rust-lang.org/std/primitive.u16.html) value.

The "as expected by its `FromStr` implementation ..." fragment is .. idk.