### PR TITLE
Remove Clone from Scope; OperatorBuilder takes &mut Scope

### DIFF
--- a/mdbook/src/chapter_2/chapter_2_4.md
+++ b/mdbook/src/chapter_2/chapter_2_4.md
@@ -79,15 +79,19 @@ extern crate timely;
 
 use timely::dataflow::operators::Inspect;
 use timely::dataflow::operators::generic::operator::source;
+use timely::scheduling::Scheduler;
 
 fn main() {
     timely::example(|scope| {
 
+        // Acquire activations before borrowing scope mutably.
+        let activations = scope.activations();
+
         source(scope, "Source", |capability, info| {
 
             // Acquire a re-activator for this operator.
-            use timely::scheduling::Scheduler;
-            let activator = scope.activator_for(info.address);
+            use timely::scheduling::activate::Activator;
+            let activator = Activator::new(info.address, activations);
 
             let mut cap = Some(capability);
             move |output| {

--- a/mdbook/src/chapter_4/chapter_4_1.md
+++ b/mdbook/src/chapter_4/chapter_4_1.md
@@ -23,7 +23,7 @@ fn main() {
     timely::example(|scope| {
 
         // Create a new scope with the same (u64) timestamp.
-        scope.scoped::<u64,_,_>("SubScope", |subscope| {
+        scope.scoped::<u64,_,_>("SubScope", |_outer, subscope| {
             // probably want something here
         })
 
@@ -56,10 +56,10 @@ fn main() {
         let stream = (0 .. 10).to_stream(scope).container::<Vec<_>>();
 
         // Create a new scope with the same (u64) timestamp.
-        let result = scope.scoped::<u64,_,_>("SubScope", |subscope| {
+        let result = scope.scoped::<u64,_,_>("SubScope", |outer, subscope| {
             stream.enter(subscope)
                   .inspect_batch(|t, xs| println!("{:?}, {:?}", t, xs))
-                  .leave(scope)
+                  .leave(outer)
         });
 
     });
@@ -88,10 +88,10 @@ fn main() {
         let stream = (0 .. 10).to_stream(scope).container::<Vec<_>>();
 
         // Create a new scope with the same (u64) timestamp.
-        let result = scope.region(|subscope| {
+        let result = scope.region(|outer, subscope| {
             stream.enter(subscope)
                   .inspect_batch(|t, xs| println!("{:?}, {:?}", t, xs))
-                  .leave(scope)
+                  .leave(outer)
         });
 
     });
@@ -120,10 +120,10 @@ fn main() {
         let stream = (0 .. 10).to_stream(scope).container::<Vec<_>>();
 
         // Create a new scope with a (u64, u32) timestamp.
-        let result = scope.iterative::<u32,_,_>(|subscope| {
+        let result = scope.iterative::<u32,_,_>(|outer, subscope| {
             stream.enter(subscope)
                   .inspect_batch(|t, xs| println!("{:?}, {:?}", t, xs))
-                  .leave(scope)
+                  .leave(outer)
         });
 
     });

--- a/mdbook/src/chapter_4/chapter_4_2.md
+++ b/mdbook/src/chapter_4/chapter_4_2.md
@@ -100,7 +100,7 @@ fn main() {
 
         // Create a nested iterative scope.
         // Rust needs help understanding the iteration counter type.
-        scope.iterative::<u64,_,_>(|subscope| {
+        scope.iterative::<u64,_,_>(|_outer, subscope| {
 
             let (handle, stream) = subscope.loop_variable(1);
 

--- a/timely/examples/event_driven.rs
+++ b/timely/examples/event_driven.rs
@@ -21,7 +21,7 @@ fn main() {
         for _dataflow in 0 .. dataflows {
             worker.dataflow(|scope| {
                 let (input, stream) = scope.new_input();
-                let stream = scope.region(|inner| {
+                let stream = scope.region(|scope, inner| {
                     let mut stream = stream.enter(inner);
                     for _step in 0 .. length {
                         stream = stream.map(|x: ()| x);

--- a/timely/src/dataflow/operators/core/capture/capture.rs
+++ b/timely/src/dataflow/operators/core/capture/capture.rs
@@ -5,6 +5,8 @@
 //! and there are several default implementations, including a linked-list, Rust's MPSC
 //! queue, and a binary serializer wrapping any `W: Write`.
 
+use std::rc::Rc;
+
 use crate::dataflow::Stream;
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::channels::pullers::Counter as PullCounter;
@@ -118,7 +120,7 @@ pub trait Capture<T: Timestamp, C: Container> : Sized {
 impl<T: Timestamp, C: Container> Capture<T, C> for Stream<T, C> {
     fn capture_into<P: EventPusher<T, C>+'static>(self, mut event_pusher: P) {
 
-        let mut builder = OperatorBuilder::new("Capture".to_owned(), self.scope());
+        let mut builder = OperatorBuilder::new_from("Capture".to_owned(), Rc::clone(&self.subgraph), self.worker.clone());
         let mut input = PullCounter::new(builder.new_input(self, Pipeline));
         let mut started = false;
 

--- a/timely/src/dataflow/operators/core/capture/mod.rs
+++ b/timely/src/dataflow/operators/core/capture/mod.rs
@@ -61,8 +61,8 @@
 //! # #[cfg(not(miri))]
 //! # fn main() {
 //! timely::execute(timely::Config::thread(), |worker| {
-//!     let list = TcpListener::bind("127.0.0.1:8000").unwrap();
-//!     let send = TcpStream::connect("127.0.0.1:8000").unwrap();
+//!     let list = TcpListener::bind("127.0.0.1:0").unwrap();
+//!     let send = TcpStream::connect(list.local_addr().unwrap()).unwrap();
 //!     let recv = list.incoming().next().unwrap().unwrap();
 //!
 //!     recv.set_nonblocking(true).unwrap();

--- a/timely/src/dataflow/operators/core/capture/replay.rs
+++ b/timely/src/dataflow/operators/core/capture/replay.rs
@@ -70,7 +70,7 @@ where
 {
     fn replay_core(self, scope: &mut Scope<T>, period: Option<std::time::Duration>) -> Stream<T, C>{
 
-        let mut builder = OperatorBuilder::new("Replay".to_owned(), scope.clone());
+        let mut builder = OperatorBuilder::new("Replay".to_owned(), scope);
 
         let address = builder.operator_info().address;
         let activator = scope.activator_for(address);

--- a/timely/src/dataflow/operators/core/concat.rs
+++ b/timely/src/dataflow/operators/core/concat.rs
@@ -1,5 +1,7 @@
 //! Merges the contents of multiple streams.
 
+use std::rc::Rc;
+
 use crate::Container;
 use crate::progress::Timestamp;
 use crate::dataflow::channels::pact::Pipeline;
@@ -27,7 +29,30 @@ pub trait Concat<T: Timestamp, C> {
 
 impl<T: Timestamp, C: Container> Concat<T, C> for Stream<T, C> {
     fn concat(self, other: Stream<T, C>) -> Stream<T, C> {
-        self.scope().concatenate([self, other])
+        use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
+
+        let mut builder = OperatorBuilder::new_from(
+            "Concatenate".to_string(),
+            Rc::clone(&self.subgraph),
+            self.worker.clone(),
+        );
+
+        let mut handles = [self, other].into_iter().map(|s| builder.new_input(s, Pipeline)).collect::<Vec<_>>();
+        for i in 0 .. handles.len() { builder.set_notify_for(i, crate::progress::operate::FrontierInterest::Never); }
+        let (mut output, result) = builder.new_output();
+
+        builder.build(move |_capability| {
+            move |_frontier| {
+                let mut output = output.activate();
+                for handle in handles.iter_mut() {
+                    handle.for_each(|time, data| {
+                        output.give(&time, data);
+                    })
+                }
+            }
+        });
+
+        result
     }
 }
 
@@ -50,20 +75,20 @@ pub trait Concatenate<T: Timestamp, C> {
     ///          .inspect(|x| println!("seen: {:?}", x));
     /// });
     /// ```
-    fn concatenate<I>(&self, sources: I) -> Stream<T, C>
+    fn concatenate<I>(&mut self, sources: I) -> Stream<T, C>
     where
         I: IntoIterator<Item=Stream<T, C>>;
 }
 
 impl<T: Timestamp, C: Container> Concatenate<T, C> for Scope<T> {
-    fn concatenate<I>(&self, sources: I) -> Stream<T, C>
+    fn concatenate<I>(&mut self, sources: I) -> Stream<T, C>
     where
         I: IntoIterator<Item=Stream<T, C>>
     {
 
         // create an operator builder.
         use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
-        let mut builder = OperatorBuilder::new("Concatenate".to_string(), self.clone());
+        let mut builder = OperatorBuilder::new("Concatenate".to_string(), self);
 
         // create new input handles for each input stream.
         let mut handles = sources.into_iter().map(|s| builder.new_input(s, Pipeline)).collect::<Vec<_>>();

--- a/timely/src/dataflow/operators/core/enterleave.rs
+++ b/timely/src/dataflow/operators/core/enterleave.rs
@@ -11,7 +11,7 @@
 //!
 //! timely::example(|outer| {
 //!     let stream = (0..9).to_stream(outer).container::<Vec<_>>();
-//!     let output = outer.region(|inner| {
+//!     let output = outer.region(|outer, inner| {
 //!         stream.enter(inner)
 //!               .inspect(|x| println!("in nested scope: {:?}", x))
 //!               .leave(outer)
@@ -46,12 +46,12 @@ pub trait Enter<TOuter: Timestamp, TInner: Timestamp+Refines<TOuter>, C> {
     ///
     /// timely::example(|outer| {
     ///     let stream = (0..9).to_stream(outer).container::<Vec<_>>();
-    ///     let output = outer.region(|inner| {
+    ///     let output = outer.region(|outer, inner| {
     ///         stream.enter(inner).leave(outer)
     ///     });
     /// });
     /// ```
-    fn enter(self, inner: &Scope<TInner>) -> Stream<TInner, C>;
+    fn enter(self, inner: &mut Scope<TInner>) -> Stream<TInner, C>;
 }
 
 impl<TOuter, TInner, C> Enter<TOuter, TInner, C> for Stream<TOuter, C>
@@ -60,13 +60,13 @@ where
     TInner: Timestamp + Refines<TOuter>,
     C: Container,
 {
-    fn enter(self, inner: &Scope<TInner>) -> Stream<TInner, C> {
+    fn enter(self, inner: &mut Scope<TInner>) -> Stream<TInner, C> {
 
         use crate::scheduling::Scheduler;
 
         // Validate that `inner` is a child of `self`'s scope.
         let inner_addr = inner.addr();
-        let outer_addr = self.scope().addr();
+        let outer_addr: Rc<[usize]> = Rc::clone(&self.subgraph.borrow().path);
         assert!(
             inner_addr.len() == outer_addr.len() + 1
                 && inner_addr[..outer_addr.len()] == outer_addr[..],
@@ -85,7 +85,7 @@ where
         };
         let produced = Rc::clone(ingress.targets.produced());
         let input = inner.subgraph.borrow_mut().new_input(produced);
-        let channel_id = inner.clone().new_identifier();
+        let channel_id = inner.new_identifier();
 
         if let Some(logger) = inner.logging() {
             let pusher = LogPusher::new(ingress, channel_id, inner.index(), logger);
@@ -97,7 +97,8 @@ where
         Stream::new(
             Source::new(0, input.port),
             registrar,
-            inner.clone(),
+            Rc::clone(&inner.subgraph),
+            inner.worker.clone(),
         )
     }
 }
@@ -117,7 +118,7 @@ pub trait Leave<TOuter: Timestamp, C> {
     ///
     /// timely::example(|outer| {
     ///     let stream = (0..9).to_stream(outer).container::<Vec<_>>();
-    ///     let output = outer.region(|inner| {
+    ///     let output = outer.region(|outer, inner| {
     ///         stream.enter(inner).leave(outer)
     ///     });
     /// });
@@ -131,12 +132,10 @@ where
     TInner: Timestamp + Refines<TOuter>,
     C: Container,
 {
-    fn leave(self, outer: &Scope<TOuter>) -> Stream<TOuter, C> {
-
-        let scope = self.scope();
+    fn leave(mut self, outer: &Scope<TOuter>) -> Stream<TOuter, C> {
 
         // Validate that `self`'s scope is a child of `outer`.
-        let inner_addr = scope.addr();
+        let inner_addr: Rc<[usize]> = Rc::clone(&self.subgraph.borrow().path);
         let outer_addr = outer.addr();
         assert!(
             inner_addr.len() == outer_addr.len() + 1
@@ -147,14 +146,14 @@ where
             outer_addr,
         );
 
-        let output = scope.subgraph.borrow_mut().new_output();
+        let output = self.subgraph.borrow_mut().new_output();
         let target = Target::new(0, output.port);
         let (targets, registrar) = Tee::<TOuter, C>::new();
         let egress = EgressNub { targets, phantom: PhantomData };
-        let channel_id = scope.clone().new_identifier();
+        let channel_id = self.worker.new_identifier();
 
-        if let Some(logger) = scope.logging() {
-            let pusher = LogPusher::new(egress, channel_id, scope.index(), logger);
+        if let Some(logger) = AsWorker::logging(&self.worker) {
+            let pusher = LogPusher::new(egress, channel_id, self.worker.index(), logger);
             self.connect_to(target, pusher, channel_id);
         } else {
             self.connect_to(target, egress, channel_id);
@@ -163,7 +162,8 @@ where
         Stream::new(
             output,
             registrar,
-            outer.clone(),
+            Rc::clone(&outer.subgraph),
+            outer.worker.clone(),
         )
     }
 }
@@ -297,10 +297,10 @@ mod test {
             worker.dataflow(|scope| {
                 let data = scope.input_from(&mut input);
 
-                scope.region(|inner| {
+                scope.region(|scope, inner| {
 
                     let data = data.enter(inner);
-                    inner.region(|inner2| data.enter(inner2).leave(inner)).leave(scope)
+                    inner.region(|inner, inner2| data.enter(inner2).leave(inner)).leave(scope)
                 })
                     .inspect(move |x| println!("worker {}:\thello {}", index, x))
                     .probe_with(&probe);

--- a/timely/src/dataflow/operators/core/feedback.rs
+++ b/timely/src/dataflow/operators/core/feedback.rs
@@ -54,7 +54,7 @@ pub trait LoopVariable<TOuter: Timestamp, TInner: Timestamp> {
     ///
     /// timely::example(|scope| {
     ///     // circulate 0..10 for 100 iterations.
-    ///     scope.iterative::<usize,_,_>(|inner| {
+    ///     scope.iterative::<usize,_,_>(|_scope, inner| {
     ///         let (handle, cycle) = inner.loop_variable(1);
     ///         (0..10).to_stream(inner)
     ///                .container::<Vec<_>>()
@@ -72,7 +72,7 @@ impl<T: Timestamp> Feedback<T> for Scope<T> {
 
     fn feedback<C: Container>(&mut self, summary: <T as Timestamp>::Summary) -> (Handle<T, C>, Stream<T, C>) {
 
-        let mut builder = OperatorBuilder::new("Feedback".to_owned(), self.clone());
+        let mut builder = OperatorBuilder::new("Feedback".to_owned(), self);
         let (output, stream) = builder.new_output();
 
         (Handle { builder, summary, output }, stream)
@@ -132,7 +132,6 @@ impl<T: Timestamp, C: Container> ConnectLoop<T, C> for Stream<T, C> {
 }
 
 /// A handle used to bind the source of a loop variable.
-#[derive(Debug)]
 pub struct Handle<T: Timestamp, C: Container> {
     builder: OperatorBuilder<T>,
     summary: <T as Timestamp>::Summary,

--- a/timely/src/dataflow/operators/core/input.rs
+++ b/timely/src/dataflow/operators/core/input.rs
@@ -177,7 +177,7 @@ impl<T: Timestamp + TotalOrder> Input for Scope<T> {
             copies,
         }));
 
-        Stream::new(Source::new(index, 0), registrar, self.clone())
+        Stream::new(Source::new(index, 0), registrar, Rc::clone(&self.subgraph), self.worker.clone())
     }
 }
 

--- a/timely/src/dataflow/operators/core/ok_err.rs
+++ b/timely/src/dataflow/operators/core/ok_err.rs
@@ -1,5 +1,7 @@
 //! Operators that separate one stream into two streams based on some condition
 
+use std::rc::Rc;
+
 use crate::Container;
 use crate::progress::Timestamp;
 use crate::container::{DrainContainer, SizableContainer, PushInto};
@@ -52,7 +54,7 @@ impl<T: Timestamp, C: Container + DrainContainer> OkErr<T, C> for Stream<T, C> {
         C2: Container + SizableContainer + PushInto<D2>,
         L: FnMut(C::Item<'_>) -> Result<D1,D2>+'static
     {
-        let mut builder = OperatorBuilder::new("OkErr".to_owned(), self.scope());
+        let mut builder = OperatorBuilder::new_from("OkErr".to_owned(), Rc::clone(&self.subgraph), self.worker.clone());
 
         let mut input = builder.new_input(self, Pipeline);
         builder.set_notify_for(0, crate::progress::operate::FrontierInterest::Never);

--- a/timely/src/dataflow/operators/core/partition.rs
+++ b/timely/src/dataflow/operators/core/partition.rs
@@ -1,5 +1,6 @@
 //! Partition a stream of records into multiple streams.
 use std::collections::BTreeMap;
+use std::rc::Rc;
 
 use crate::container::{DrainContainer, PushInto};
 use crate::progress::Timestamp;
@@ -41,7 +42,7 @@ impl<T: Timestamp, C: Container + DrainContainer> Partition<T, C> for Stream<T, 
         CB: ContainerBuilder + PushInto<D2>,
         F: FnMut(C::Item<'_>) -> (u64, D2) + 'static,
     {
-        let mut builder = OperatorBuilder::new("Partition".to_owned(), self.scope());
+        let mut builder = OperatorBuilder::new_from("Partition".to_owned(), Rc::clone(&self.subgraph), self.worker.clone());
 
         let mut input = builder.new_input(self, Pipeline);
         builder.set_notify_for(0, crate::progress::operate::FrontierInterest::Never);

--- a/timely/src/dataflow/operators/core/probe.rs
+++ b/timely/src/dataflow/operators/core/probe.rs
@@ -91,7 +91,7 @@ impl<T: Timestamp, C: Container> Probe<T, C> for Stream<T, C> {
     }
     fn probe_with(self, handle: &Handle<T>) -> Stream<T, C> {
 
-        let mut builder = OperatorBuilder::new("Probe".to_owned(), self.scope());
+        let mut builder = OperatorBuilder::new_from("Probe".to_owned(), Rc::clone(&self.subgraph), self.worker.clone());
         let mut input = PullCounter::new(builder.new_input(self, Pipeline));
         let (tee, stream) = builder.new_output();
         let mut output = PushCounter::new(tee);

--- a/timely/src/dataflow/operators/core/to_stream.rs
+++ b/timely/src/dataflow/operators/core/to_stream.rs
@@ -36,10 +36,11 @@ pub trait ToStreamBuilder<CB: ContainerBuilder> {
 impl<CB: ContainerBuilder, I: IntoIterator+'static> ToStreamBuilder<CB> for I where CB: PushInto<I::Item> {
     fn to_stream_with_builder<T: Timestamp>(self, scope: &mut Scope<T>) -> Stream<T, CB::Container> {
 
+        let activations = scope.activations();
         source::<_, CB, _, _>(scope, "ToStreamBuilder", |capability, info| {
 
             // Acquire an activator, so that the operator can rescheduled itself.
-            let activator = scope.activator_for(info.address);
+            let activator = crate::scheduling::activate::Activator::new(info.address, activations);
 
             let mut iterator = self.into_iter().fuse();
             let mut capability = Some(capability);

--- a/timely/src/dataflow/operators/core/unordered_input.rs
+++ b/timely/src/dataflow/operators/core/unordered_input.rs
@@ -107,7 +107,7 @@ impl<T: Timestamp> UnorderedInput<T> for Scope<T> {
             peers,
         }));
 
-        ((helper, cap), Stream::new(Source::new(index, 0), registrar, self.clone()))
+        ((helper, cap), Stream::new(Source::new(index, 0), registrar, Rc::clone(&self.subgraph), self.worker.clone()))
     }
 }
 

--- a/timely/src/dataflow/operators/generic/builder_raw.rs
+++ b/timely/src/dataflow/operators/generic/builder_raw.rs
@@ -9,10 +9,10 @@ use std::rc::Rc;
 use std::cell::RefCell;
 
 use crate::scheduling::{Schedule, Activations};
-use crate::worker::AsWorker;
+use crate::worker::{AsWorker, Worker};
 use crate::scheduling::Scheduler;
 
-use crate::progress::{Source, Target};
+use crate::progress::{Source, Target, SubgraphBuilder};
 use crate::progress::{Timestamp, Operate, operate::SharedProgress, Antichain};
 use crate::progress::operate::{FrontierInterest, Connectivity, PortConnectivity};
 use crate::Container;
@@ -51,9 +51,9 @@ impl OperatorShape {
 }
 
 /// Builds operators with generic shape.
-#[derive(Debug)]
 pub struct OperatorBuilder<T: Timestamp> {
-    scope: Scope<T>,
+    subgraph: Rc<RefCell<SubgraphBuilder<T>>>,
+    worker: Worker,
     slot: OperatorSlot<T>,
     address: Rc<[usize]>,    // path to the operator (ending with index).
     shape: OperatorShape,
@@ -63,14 +63,21 @@ pub struct OperatorBuilder<T: Timestamp> {
 impl<T: Timestamp> OperatorBuilder<T> {
 
     /// Allocates a new generic operator builder from its containing scope.
-    pub fn new(name: String, mut scope: Scope<T>) -> Self {
+    pub fn new(name: String, scope: &mut Scope<T>) -> Self {
+        Self::new_from(name, Rc::clone(&scope.subgraph), scope.worker.clone())
+    }
 
-        let slot = scope.reserve_operator();
+    /// Allocates a new generic operator builder from the constituent parts of a scope.
+    pub(crate) fn new_from(name: String, subgraph: Rc<RefCell<SubgraphBuilder<T>>>, mut worker: Worker) -> Self {
+        let index = subgraph.borrow_mut().allocate_child_id();
+        let identifier = worker.new_identifier();
+        let slot = OperatorSlot::new(Rc::clone(&subgraph), index, identifier);
         let address = slot.addr();
-        let peers = scope.peers();
+        let peers = worker.peers();
 
         OperatorBuilder {
-            scope,
+            subgraph,
+            worker,
             slot,
             address,
             shape: OperatorShape::new(name, peers),
@@ -107,9 +114,9 @@ impl<T: Timestamp> OperatorBuilder<T> {
         P: ParallelizationContract<T, C>,
         I: IntoIterator<Item = (usize, Antichain<<T as Timestamp>::Summary>)>,
     {
-        let channel_id = self.scope.new_identifier();
-        let logging = self.scope.logging();
-        let (sender, receiver) = pact.connect(&mut self.scope, channel_id, Rc::clone(&self.address), logging);
+        let channel_id = self.worker.new_identifier();
+        let logging = self.worker.logging();
+        let (sender, receiver) = pact.connect(&mut self.worker, channel_id, Rc::clone(&self.address), logging);
         let target = Target::new(self.slot.index(), self.shape.inputs);
         stream.connect_to(target, sender, channel_id);
 
@@ -137,7 +144,7 @@ impl<T: Timestamp> OperatorBuilder<T> {
         self.shape.outputs += 1;
         let (target, registrar) = Tee::new();
         let source = Source::new(self.slot.index(), new_output);
-        let stream = Stream::new(source, registrar, self.scope.clone());
+        let stream = Stream::new(source, registrar, Rc::clone(&self.subgraph), self.worker.clone());
 
         for (input, entry) in connection {
             self.summary[input].add_port(new_output, entry);
@@ -157,7 +164,7 @@ impl<T: Timestamp> OperatorBuilder<T> {
         let operator = OperatorCore {
             shape: self.shape,
             address: self.address,
-            activations: self.scope.activations(),
+            activations: self.worker.activations(),
             logic,
             shared_progress: Rc::new(RefCell::new(SharedProgress::new(inputs, outputs))),
             summary: self.summary,

--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -11,6 +11,8 @@ use crate::progress::frontier::{Antichain, MutableAntichain};
 use crate::Container;
 use crate::dataflow::{Scope, Stream};
 use crate::dataflow::channels::pushers::Counter as PushCounter;
+use crate::progress::SubgraphBuilder;
+use crate::worker::Worker;
 use crate::dataflow::channels::pushers;
 use crate::dataflow::channels::pact::ParallelizationContract;
 use crate::dataflow::channels::pullers::Counter as PullCounter;
@@ -23,7 +25,6 @@ use crate::progress::operate::{FrontierInterest, PortConnectivity};
 use super::builder_raw::OperatorBuilder as OperatorBuilderRaw;
 
 /// Builds operators with generic shape.
-#[derive(Debug)]
 pub struct OperatorBuilder<T: Timestamp> {
     builder: OperatorBuilderRaw<T>,
     frontier: Vec<MutableAntichain<T>>,
@@ -37,9 +38,14 @@ pub struct OperatorBuilder<T: Timestamp> {
 impl<T: Timestamp> OperatorBuilder<T> {
 
     /// Allocates a new generic operator builder from its containing scope.
-    pub fn new(name: String, scope: Scope<T>) -> Self {
+    pub fn new(name: String, scope: &mut Scope<T>) -> Self {
+        Self::new_from(name, Rc::clone(&scope.subgraph), scope.worker.clone())
+    }
+
+    /// Allocates a new generic operator builder from the constituent parts of a scope.
+    pub(crate) fn new_from(name: String, subgraph: Rc<RefCell<SubgraphBuilder<T>>>, worker: Worker) -> Self {
         OperatorBuilder {
-            builder: OperatorBuilderRaw::new(name, scope),
+            builder: OperatorBuilderRaw::new_from(name, subgraph, worker),
             frontier: Vec::new(),
             consumed: Vec::new(),
             internal: Rc::new(RefCell::new(Vec::new())),
@@ -225,7 +231,7 @@ mod tests {
 
         crate::example(|scope| {
 
-            let mut builder = OperatorBuilder::new("Failure".to_owned(), scope.clone());
+            let mut builder = OperatorBuilder::new("Failure".to_owned(), scope);
 
             let (output1, _stream1) = builder.new_output::<Vec<()>>();
             let (output2, _stream2) = builder.new_output::<Vec<()>>();
@@ -256,7 +262,7 @@ mod tests {
 
         crate::example(|scope| {
 
-            let mut builder = OperatorBuilder::new("Failure".to_owned(), scope.clone());
+            let mut builder = OperatorBuilder::new("Failure".to_owned(), scope);
 
             let (output1, _stream1) = builder.new_output::<Vec<()>>();
             let (output2, _stream2) = builder.new_output::<Vec<()>>();

--- a/timely/src/dataflow/operators/generic/operator.rs
+++ b/timely/src/dataflow/operators/generic/operator.rs
@@ -1,6 +1,8 @@
 
 //! Methods to construct generic streaming and blocking unary operators.
 
+use std::rc::Rc;
+
 use crate::progress::frontier::MutableAntichain;
 use crate::progress::Timestamp;
 use crate::dataflow::channels::pact::ParallelizationContract;
@@ -321,7 +323,7 @@ impl<T: Timestamp, C1: Container> Operator<T, C1> for Stream<T, C1> {
                  &mut OutputBuilderSession<'_, T, CB>)+'static,
         P: ParallelizationContract<T, C1> {
 
-        let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
+        let mut builder = OperatorBuilder::new_from(name.to_owned(), Rc::clone(&self.subgraph), self.worker.clone());
         let operator_info = builder.operator_info();
 
         let mut input = builder.new_input(self, pact);
@@ -370,7 +372,7 @@ impl<T: Timestamp, C1: Container> Operator<T, C1> for Stream<T, C1> {
                  &mut OutputBuilderSession<'_, T, CB>)+'static,
         P: ParallelizationContract<T, C1> {
 
-        let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
+        let mut builder = OperatorBuilder::new_from(name.to_owned(), Rc::clone(&self.subgraph), self.worker.clone());
         let operator_info = builder.operator_info();
 
         let mut input = builder.new_input(self, pact);
@@ -399,7 +401,7 @@ impl<T: Timestamp, C1: Container> Operator<T, C1> for Stream<T, C1> {
         P1: ParallelizationContract<T, C1>,
         P2: ParallelizationContract<T, C2> {
 
-        let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
+        let mut builder = OperatorBuilder::new_from(name.to_owned(), Rc::clone(&self.subgraph), self.worker.clone());
         let operator_info = builder.operator_info();
 
         let mut input1 = builder.new_input(self, pact1);
@@ -457,7 +459,7 @@ impl<T: Timestamp, C1: Container> Operator<T, C1> for Stream<T, C1> {
         P1: ParallelizationContract<T, C1>,
         P2: ParallelizationContract<T, C2> {
 
-        let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
+        let mut builder = OperatorBuilder::new_from(name.to_owned(), Rc::clone(&self.subgraph), self.worker.clone());
         let operator_info = builder.operator_info();
 
         let mut input1 = builder.new_input(self, pact1);
@@ -485,7 +487,7 @@ impl<T: Timestamp, C1: Container> Operator<T, C1> for Stream<T, C1> {
         L: FnMut((&mut InputHandleCore<T, C1, P::Puller>, &MutableAntichain<T>))+'static,
         P: ParallelizationContract<T, C1> {
 
-        let mut builder = OperatorBuilder::new(name.to_owned(), self.scope());
+        let mut builder = OperatorBuilder::new_from(name.to_owned(), Rc::clone(&self.subgraph), self.worker.clone());
         let mut input = builder.new_input(self, pact);
 
         builder.build(|_capabilities| {
@@ -505,15 +507,18 @@ impl<T: Timestamp, C1: Container> Operator<T, C1> for Stream<T, C1> {
 /// # Examples
 /// ```
 /// use timely::scheduling::Scheduler;
+/// use timely::scheduling::activate::Activator;
 /// use timely::dataflow::operators::Inspect;
 /// use timely::dataflow::operators::generic::operator::source;
 /// use timely::dataflow::Scope;
 ///
 /// timely::example(|scope| {
 ///
+///     let activations = scope.activations();
+///
 ///     source(scope, "Source", |capability, info| {
 ///
-///         let activator = scope.activator_for(info.address);
+///         let activator = Activator::new(info.address, activations);
 ///
 ///         let mut cap = Some(capability);
 ///         move |output| {
@@ -538,13 +543,13 @@ impl<T: Timestamp, C1: Container> Operator<T, C1> for Stream<T, C1> {
 ///     .inspect(|x| println!("number: {:?}", x));
 /// });
 /// ```
-pub fn source<T: Timestamp, CB, B, L>(scope: &Scope<T>, name: &str, constructor: B) -> Stream<T, CB::Container>
+pub fn source<T: Timestamp, CB, B, L>(scope: &mut Scope<T>, name: &str, constructor: B) -> Stream<T, CB::Container>
 where
     CB: ContainerBuilder,
     B: FnOnce(Capability<T>, OperatorInfo) -> L,
     L: FnMut(&mut OutputBuilderSession<'_, T, CB>)+'static {
 
-    let mut builder = OperatorBuilder::new(name.to_owned(), scope.clone());
+    let mut builder = OperatorBuilder::new(name.to_owned(), scope);
     let operator_info = builder.operator_info();
 
     let (output, stream) = builder.new_output();
@@ -582,7 +587,7 @@ where
 ///
 /// });
 /// ```
-pub fn empty<T: Timestamp, C: Container>(scope: &Scope<T>) -> Stream<T, C> {
+pub fn empty<T: Timestamp, C: Container>(scope: &mut Scope<T>) -> Stream<T, C> {
     source::<_, CapacityContainerBuilder<C>, _, _>(scope, "Empty", |_capability, _info| |_output| {
         // drop capability, do nothing
     })

--- a/timely/src/dataflow/operators/vec/branch.rs
+++ b/timely/src/dataflow/operators/vec/branch.rs
@@ -1,5 +1,7 @@
 //! Operators that separate one stream into two streams based on some condition
 
+use std::rc::Rc;
+
 use crate::dataflow::channels::pact::Pipeline;
 use crate::progress::Timestamp;
 use crate::dataflow::operators::generic::OutputBuilder;
@@ -41,7 +43,7 @@ impl<T: Timestamp, D: 'static> Branch<T, D> for StreamVec<T, D> {
         self,
         condition: impl Fn(&T, &D) -> bool + 'static,
     ) -> (StreamVec<T, D>, StreamVec<T, D>) {
-        let mut builder = OperatorBuilder::new("Branch".to_owned(), self.scope());
+        let mut builder = OperatorBuilder::new_from("Branch".to_owned(), Rc::clone(&self.subgraph), self.worker.clone());
 
         let mut input = builder.new_input(self, Pipeline);
         builder.set_notify_for(0, crate::progress::operate::FrontierInterest::Never);
@@ -102,7 +104,7 @@ pub trait BranchWhen<T>: Sized {
 
 impl<T: Timestamp, C: Container> BranchWhen<T> for Stream<T, C> {
     fn branch_when(self, condition: impl Fn(&T) -> bool + 'static) -> (Self, Self) {
-        let mut builder = OperatorBuilder::new("Branch".to_owned(), self.scope());
+        let mut builder = OperatorBuilder::new_from("Branch".to_owned(), Rc::clone(&self.subgraph), self.worker.clone());
 
         let mut input = builder.new_input(self, Pipeline);
         builder.set_notify_for(0, crate::progress::operate::FrontierInterest::Never);

--- a/timely/src/dataflow/operators/vec/broadcast.rs
+++ b/timely/src/dataflow/operators/vec/broadcast.rs
@@ -28,7 +28,7 @@ impl<T: Timestamp, D: ExchangeData + Clone> Broadcast<D> for StreamVec<T, D> {
         // NOTE: Simplified implementation due to underlying motion
         // in timely dataflow internals. Optimize once they have
         // settled down.
-        let peers = self.scope().peers() as u64;
+        let peers = self.peers() as u64;
         self.flat_map(move |x| (0 .. peers).map(move |i| (i,x.clone())))
             .exchange(|ix| ix.0)
             .map(|(_i,x)| x)

--- a/timely/src/dataflow/operators/vec/flow_controlled.rs
+++ b/timely/src/dataflow/operators/vec/flow_controlled.rs
@@ -75,16 +75,17 @@ pub fn iterator_source<
     DI: IntoIterator<Item=D>,
     I: IntoIterator<Item=(T, DI)>,
     F: FnMut(&T)->Option<IteratorSourceInput<T, D, DI, I>>+'static>(
-        scope: &Scope<T>,
+        scope: &mut Scope<T>,
         name: &str,
         mut input_f: F,
         probe: Handle<T>,
         ) -> StreamVec<T, D> where T: TotalOrder {
 
     let mut target = T::minimum();
-    source(scope, name, |cap, info| {
+    let activations = scope.activations();
+    source(scope, name, |cap: crate::dataflow::operators::capability::Capability<T>, info| {
         let mut cap = Some(cap);
-        let activator = scope.activator_for(info.address);
+        let activator = crate::scheduling::activate::Activator::new(info.address, activations);
         move |output| {
             cap = cap.take().and_then(|mut cap| {
                 loop {

--- a/timely/src/dataflow/scope.rs
+++ b/timely/src/dataflow/scope.rs
@@ -12,7 +12,6 @@ use crate::progress::{Source, Target};
 use crate::progress::timestamp::Refines;
 use crate::order::Product;
 use crate::logging::TimelyLogger as Logger;
-use crate::logging::TimelyProgressLogger as ProgressLogger;
 use crate::worker::{AsWorker, Config, Worker};
 
 /// Type alias for an iterative scope.
@@ -37,8 +36,6 @@ pub struct Scope<T: Timestamp> {
     pub(crate) worker:   Worker,
     /// The log writer for this scope.
     pub(crate) logging:  Option<Logger>,
-    /// The progress log writer for this scope.
-    pub(crate) progress_logging:  Option<ProgressLogger<T>>,
 }
 
 impl<T: Timestamp> Scope<T> {
@@ -69,7 +66,7 @@ impl<T: Timestamp> Scope<T> {
         let index = self.subgraph.borrow_mut().allocate_child_id();
         let identifier = self.new_identifier();
         OperatorSlot {
-            scope: self.clone(),
+            subgraph: Rc::clone(&self.subgraph),
             index,
             identifier,
             installed: false,
@@ -88,26 +85,22 @@ impl<T: Timestamp> Scope<T> {
     /// around `new_subscope` that install the built subgraph directly. Direct
     /// callers of `new_subscope` may interpose, e.g. by wrapping the built
     /// subgraph in a decorator that intercepts scheduling.
-    pub fn new_subscope<T2>(&self, name: &str) -> (Scope<T2>, OperatorSlot<T>)
+    pub fn new_subscope<T2>(&mut self, name: &str) -> (Scope<T2>, OperatorSlot<T>)
     where
         T2: Timestamp + Refines<T>,
     {
-        let mut parent = self.clone();
-        let slot = parent.reserve_operator();
+        let slot = self.reserve_operator();
         let path = slot.addr();
         let identifier = slot.identifier();
 
-        let type_name = std::any::type_name::<T2>();
-        let progress_logging = parent.logger_for(&format!("timely/progress/{type_name}"));
-        let summary_logging  = parent.logger_for(&format!("timely/summary/{type_name}"));
+        let summary_logging  = self.logger_for(&crate::logging::summary_log_name::<T2>());
 
         let child = Scope {
             subgraph: Rc::new(RefCell::new(SubgraphBuilder::new_from(
                 path, identifier, self.logging(), summary_logging, name,
             ))),
-            worker: parent.worker.clone(),
-            logging: parent.logging.clone(),
-            progress_logging,
+            worker: self.worker.clone(),
+            logging: self.logging.clone(),
         };
 
         (child, slot)
@@ -132,9 +125,8 @@ impl<T: Timestamp> Scope<T> {
         Rc::try_unwrap(builder)
             .map_err(|_| ())
             .expect(
-                "Cannot consume subscope: an outstanding `Scope` clone is still alive. \
-                 This usually means the child `Scope` was cloned and a clone was held \
-                 past the build() call."
+                "Cannot consume subscope: an outstanding `Rc` reference to the \
+                 subgraph builder is still alive."
             )
             .into_inner()
             .build(parent)
@@ -157,7 +149,7 @@ impl<T: Timestamp> Scope<T> {
     ///     // must specify types as nothing else drives inference.
     ///     let input = worker.dataflow::<u64,_,_>(|child1| {
     ///         let (input, stream) = child1.new_input::<Vec<String>>();
-    ///         let output = child1.scoped::<Product<u64,u32>,_,_>("ScopeName", |child2| {
+    ///         let output = child1.scoped::<Product<u64,u32>,_,_>("ScopeName", |child1, child2| {
     ///             stream.enter(child2).leave(child1)
     ///         });
     ///         input
@@ -165,14 +157,14 @@ impl<T: Timestamp> Scope<T> {
     /// });
     /// ```
     #[inline]
-    pub fn scoped<T2, R, F>(&self, name: &str, func: F) -> R
+    pub fn scoped<T2, R, F>(&mut self, name: &str, func: F) -> R
     where
         T2: Timestamp + Refines<T>,
-        F: FnOnce(&mut Scope<T2>) -> R,
+        F: FnOnce(&Scope<T>, &mut Scope<T2>) -> R,
     {
-        let (mut child, mut slot) = self.new_subscope::<T2>(name);
-        let result = func(&mut child);
-        let subgraph = child.build(slot.scope_mut());
+        let (mut child, slot) = self.new_subscope::<T2>(name);
+        let result = func(&*self, &mut child);
+        let subgraph = child.build(self);
         slot.install(Box::new(subgraph));
         result
     }
@@ -191,17 +183,17 @@ impl<T: Timestamp> Scope<T> {
     ///     // must specify types as nothing else drives inference.
     ///     let input = worker.dataflow::<u64,_,_>(|child1| {
     ///         let (input, stream) = child1.new_input::<Vec<String>>();
-    ///         let output = child1.iterative::<u32,_,_>(|child2| {
+    ///         let output = child1.iterative::<u32,_,_>(|child1, child2| {
     ///             stream.enter(child2).leave(child1)
     ///         });
     ///         input
     ///     });
     /// });
     /// ```
-    pub fn iterative<T2, R, F>(&self, func: F) -> R
+    pub fn iterative<T2, R, F>(&mut self, func: F) -> R
     where
         T2: Timestamp,
-        F: FnOnce(&mut Scope<Product<T, T2>>) -> R,
+        F: FnOnce(&Scope<T>, &mut Scope<Product<T, T2>>) -> R,
     {
         self.scoped::<Product<T, T2>, R, F>("Iterative", func)
     }
@@ -220,16 +212,16 @@ impl<T: Timestamp> Scope<T> {
     ///     // must specify types as nothing else drives inference.
     ///     let input = worker.dataflow::<u64,_,_>(|child1| {
     ///         let (input, stream) = child1.new_input::<Vec<String>>();
-    ///         let output = child1.region(|child2| {
+    ///         let output = child1.region(|child1, child2| {
     ///             stream.enter(child2).leave(child1)
     ///         });
     ///         input
     ///     });
     /// });
     /// ```
-    pub fn region<R, F>(&self, func: F) -> R
+    pub fn region<R, F>(&mut self, func: F) -> R
     where
-        F: FnOnce(&mut Scope<T>) -> R,
+        F: FnOnce(&Scope<T>, &mut Scope<T>) -> R,
     {
         self.region_named("Region", func)
     }
@@ -251,16 +243,16 @@ impl<T: Timestamp> Scope<T> {
     ///     // must specify types as nothing else drives inference.
     ///     let input = worker.dataflow::<u64,_,_>(|child1| {
     ///         let (input, stream) = child1.new_input::<Vec<String>>();
-    ///         let output = child1.region_named("region", |child2| {
+    ///         let output = child1.region_named("region", |child1, child2| {
     ///             stream.enter(child2).leave(child1)
     ///         });
     ///         input
     ///     });
     /// });
     /// ```
-    pub fn region_named<R, F>(&self, name: &str, func: F) -> R
+    pub fn region_named<R, F>(&mut self, name: &str, func: F) -> R
     where
-        F: FnOnce(&mut Scope<T>) -> R,
+        F: FnOnce(&Scope<T>, &mut Scope<T>) -> R,
     {
         self.scoped::<T, R, F>(name, func)
     }
@@ -282,16 +274,6 @@ impl<T: Timestamp> Scheduler for Scope<T> {
     fn activations(&self) -> Rc<RefCell<Activations>> { self.worker.activations() }
 }
 
-impl<T: Timestamp> Clone for Scope<T> {
-    fn clone(&self) -> Self {
-        Scope {
-            subgraph: Rc::clone(&self.subgraph),
-            worker: self.worker.clone(),
-            logging: self.logging.clone(),
-            progress_logging: self.progress_logging.clone(),
-        }
-    }
-}
 
 impl<T: Timestamp> std::fmt::Debug for Scope<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -309,15 +291,19 @@ impl<T: Timestamp> std::fmt::Debug for Scope<T> {
 /// operator-to-be. It must be consumed by [`OperatorSlot::install`] before
 /// being dropped; dropping an unfilled slot panics, since the parent scope
 /// expects the reserved index to eventually be filled.
-#[derive(Debug)]
 pub struct OperatorSlot<T: Timestamp> {
-    scope: Scope<T>,
+    subgraph: Rc<RefCell<SubgraphBuilder<T>>>,
     index: usize,
     identifier: usize,
     installed: bool,
 }
 
 impl<T: Timestamp> OperatorSlot<T> {
+    /// Creates a new operator slot from parts.
+    pub(crate) fn new(subgraph: Rc<RefCell<SubgraphBuilder<T>>>, index: usize, identifier: usize) -> Self {
+        OperatorSlot { subgraph, index, identifier, installed: false }
+    }
+
     /// The scope-local index reserved for the operator.
     pub fn index(&self) -> usize { self.index }
 
@@ -326,7 +312,7 @@ impl<T: Timestamp> OperatorSlot<T> {
 
     /// The address (path from the worker root) at which the operator will live.
     pub fn addr(&self) -> Rc<[usize]> {
-        let scope_path = &self.scope.subgraph.borrow().path[..];
+        let scope_path = &self.subgraph.borrow().path[..];
         let mut addr = Vec::with_capacity(scope_path.len() + 1);
         addr.extend_from_slice(scope_path);
         addr.push(self.index);
@@ -335,13 +321,9 @@ impl<T: Timestamp> OperatorSlot<T> {
 
     /// Installs `operator` at this slot, consuming the slot.
     pub fn install(mut self, operator: Box<dyn Operate<T>>) {
-        self.scope.subgraph.borrow_mut().add_child(operator, self.index, self.identifier);
+        self.subgraph.borrow_mut().add_child(operator, self.index, self.identifier);
         self.installed = true;
     }
-
-    /// Mutable access to the containing scope. Used to register a built [`Subgraph`]
-    /// before [`OperatorSlot::install`].
-    pub fn scope_mut(&mut self) -> &mut Scope<T> { &mut self.scope }
 }
 
 impl<T: Timestamp> Drop for OperatorSlot<T> {

--- a/timely/src/dataflow/stream.rs
+++ b/timely/src/dataflow/stream.rs
@@ -4,13 +4,15 @@
 //! operator output. Extension methods on the `Stream` type provide the appearance of higher-level
 //! declarative programming, while constructing a dataflow graph underneath.
 
-use crate::progress::{Source, Target, Timestamp};
+use std::rc::Rc;
+use std::cell::RefCell;
+
+use crate::progress::{Source, Target, Timestamp, SubgraphBuilder};
 
 use crate::communication::Push;
-use crate::dataflow::Scope;
 use crate::dataflow::channels::pushers::tee::TeeHelper;
 use crate::dataflow::channels::Message;
-use crate::worker::AsWorker;
+use crate::worker::{AsWorker, Worker};
 use std::fmt::{self, Debug};
 
 /// Abstraction of a stream of `C: Container` records timestamped with `T`.
@@ -20,8 +22,10 @@ use std::fmt::{self, Debug};
 pub struct Stream<T: Timestamp, C> {
     /// The progress identifier of the stream's data source.
     name: Source,
-    /// The `Scope` containing the stream.
-    scope: Scope<T>,
+    /// The subgraph containing this stream.
+    pub(crate) subgraph: Rc<RefCell<SubgraphBuilder<T>>>,
+    /// The worker hosting this stream.
+    pub(crate) worker: Worker,
     /// Maintains a list of Push<Message<T, C>> interested in the stream's output.
     ports: TeeHelper<T, C>,
 }
@@ -30,14 +34,16 @@ impl<T: Timestamp, C: Clone+'static> Clone for Stream<T, C> {
     fn clone(&self) -> Self {
         Self {
             name: self.name,
-            scope: self.scope.clone(),
+            subgraph: Rc::clone(&self.subgraph),
+            worker: self.worker.clone(),
             ports: self.ports.clone(),
         }
     }
 
     fn clone_from(&mut self, source: &Self) {
         self.name.clone_from(&source.name);
-        self.scope.clone_from(&source.scope);
+        self.subgraph.clone_from(&source.subgraph);
+        self.worker.clone_from(&source.worker);
         self.ports.clone_from(&source.ports);
     }
 }
@@ -52,26 +58,26 @@ impl<T: Timestamp, C> Stream<T, C> {
     /// records should actually be sent. The identifier is unique to the edge and is used only for logging purposes.
     pub fn connect_to<P: Push<Message<T, C>>+'static>(self, target: Target, pusher: P, identifier: usize) where C: 'static {
 
-        let mut logging: Option<crate::logging::TimelyLogger> = AsWorker::logging(&self.scope());
+        let mut logging: Option<crate::logging::TimelyLogger> = AsWorker::logging(&self.worker);
         logging.as_mut().map(|l| l.log(crate::logging::ChannelsEvent {
             id: identifier,
-            scope_addr: self.scope.addr().to_vec(),
+            scope_addr: self.subgraph.borrow().path.to_vec(),
             source: (self.name.node, self.name.port),
             target: (target.node, target.port),
             typ: std::any::type_name::<C>().to_string(),
         }));
 
-        self.scope.add_edge(self.name, target);
+        self.subgraph.borrow_mut().connect(self.name, target);
         self.ports.add_pusher(pusher);
     }
     /// Allocates a `Stream` from a supplied `Source` name and rendezvous point.
-    pub fn new(source: Source, output: TeeHelper<T, C>, scope: Scope<T>) -> Self {
-        Self { name: source, ports: output, scope }
+    pub fn new(source: Source, output: TeeHelper<T, C>, subgraph: Rc<RefCell<SubgraphBuilder<T>>>, worker: Worker) -> Self {
+        Self { name: source, ports: output, subgraph, worker }
     }
     /// The name of the stream's source operator.
     pub fn name(&self) -> &Source { &self.name }
-    /// The scope immediately containing the stream.
-    pub fn scope(&self) -> Scope<T> { self.scope.clone() }
+    /// The number of workers in the computation.
+    pub fn peers(&self) -> usize { self.worker.peers() }
 
     /// Allows the assertion of a container type, for the benefit of type inference.
     ///

--- a/timely/src/logging.rs
+++ b/timely/src/logging.rs
@@ -15,6 +15,27 @@ pub type TimelySummaryEventBuilder<TS> = CapacityContainerBuilder<Vec<(Duration,
 /// Logger for timely dataflow operator summary events (the "timely/summary/*" log streams).
 pub type TimelySummaryLogger<TS> = crate::logging_core::Logger<TimelySummaryEventBuilder<TS>>;
 
+/// Returns the log stream name for progress events of timestamp type `T`.
+///
+/// For example, `progress_log_name::<usize>()` returns `"timely/progress/usize"`.
+pub fn progress_log_name<T: 'static>() -> String {
+    format!("timely/progress/{}", std::any::type_name::<T>())
+}
+
+/// Returns the log stream name for operator summary events of timestamp type `T`.
+///
+/// For example, `summary_log_name::<usize>()` returns `"timely/summary/usize"`.
+pub fn summary_log_name<T: 'static>() -> String {
+    format!("timely/summary/{}", std::any::type_name::<T>())
+}
+
+/// Returns the log stream name for reachability events of timestamp type `T`.
+///
+/// For example, `reachability_log_name::<usize>()` returns `"timely/reachability/usize"`.
+pub fn reachability_log_name<T: 'static>() -> String {
+    format!("timely/reachability/{}", std::any::type_name::<T>())
+}
+
 use std::time::Duration;
 use columnar::Columnar;
 use serde::{Deserialize, Serialize};

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -179,11 +179,10 @@ where
         }
 
         // The `None` argument is optional logging infrastructure.
-        let type_name = std::any::type_name::<TInner>();
         let reachability_logging =
-        worker.logger_for(&format!("timely/reachability/{type_name}"))
+        worker.logger_for(&crate::logging::reachability_log_name::<TInner>())
               .map(|logger| reachability::logging::TrackerLogger::new(self.identifier, logger));
-        let progress_logging = worker.logger_for(&format!("timely/progress/{type_name}"));
+        let progress_logging = worker.logger_for(&crate::logging::progress_log_name::<TInner>());
         let (tracker, scope_summary) = builder.build(reachability_logging);
 
         let progcaster = Progcaster::new(worker, Rc::clone(&self.path), self.identifier, self.logging.clone(), progress_logging);

--- a/timely/src/synchronization/sequence.rs
+++ b/timely/src/synchronization/sequence.rs
@@ -112,7 +112,7 @@ impl<T: ExchangeData+Clone> Sequencer<T> {
         // build a dataflow used to serialize and circulate commands
         worker.dataflow::<Duration,_,_>(move |dataflow| {
 
-            let scope = dataflow.clone();
+            let worker = dataflow.worker.clone();
             let peers = dataflow.peers();
 
             let mut recvd = Vec::new();
@@ -127,7 +127,7 @@ impl<T: ExchangeData+Clone> Sequencer<T> {
                 activator_source
                     .borrow_mut()
                     .replace(CatchupActivator {
-                        activator: scope.activator_for(info.address),
+                        activator: worker.activator_for(info.address),
                         catchup_until: None,
                     });
 

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -652,9 +652,7 @@ impl Worker {
         let addr = vec![dataflow_index].into();
         let identifier = self.new_identifier();
 
-        let type_name = std::any::type_name::<T>();
-        let progress_logging = self.logger_for(&format!("timely/progress/{}", type_name));
-        let summary_logging  = self.logger_for(&format!("timely/summary/{}", type_name));
+        let summary_logging  = self.logger_for(&crate::logging::summary_log_name::<T>());
         let subscope = SubgraphBuilder::new_from(addr, identifier, logging.clone(), summary_logging, name);
         let subscope = Rc::new(RefCell::new(subscope));
 
@@ -663,7 +661,6 @@ impl Worker {
                 subgraph: Rc::clone(&subscope),
                 worker: self.clone(),
                 logging: logging.clone(),
-                progress_logging,
             };
             func(&mut resources, &mut builder)
         };

--- a/timely/tests/logging.rs
+++ b/timely/tests/logging.rs
@@ -1,0 +1,233 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use timely::Config;
+use timely::dataflow::InputHandle;
+use timely::dataflow::operators::{Input, Exchange, Probe, Enter, Leave};
+use timely::logging::{self, TimelyProgressEventBuilder, TimelyProgressEvent, TimelySummaryEventBuilder, OperatesSummaryEvent};
+use timely::order::Product;
+
+/// Collects log events into a shared vector during `timely::execute`.
+fn collect_events<T: Send + 'static>(
+) -> (Arc<Mutex<Vec<(Duration, T)>>>, impl Fn(&Duration, &mut Option<Vec<(Duration, T)>>) + Clone) {
+    let events: Arc<Mutex<Vec<(Duration, T)>>> = Arc::new(Mutex::new(Vec::new()));
+    let events2 = Arc::clone(&events);
+    let callback = move |_time: &Duration, data: &mut Option<Vec<(Duration, T)>>| {
+        if let Some(data) = data {
+            events2.lock().unwrap().extend(data.drain(..));
+        }
+    };
+    (events, callback)
+}
+
+// ------------------------------------------------------------------
+// Flat dataflow: Input -> Exchange -> Probe
+// ------------------------------------------------------------------
+
+#[test]
+fn progress_logging() {
+    let (events, callback) = collect_events::<TimelyProgressEvent<usize>>();
+
+    timely::execute(Config::thread(), move |worker| {
+        worker.log_register().unwrap().insert::<TimelyProgressEventBuilder<usize>, _>(
+            &logging::progress_log_name::<usize>(), callback.clone(),
+        );
+
+        let mut input = InputHandle::new();
+        let probe = timely::dataflow::ProbeHandle::new();
+
+        worker.dataflow::<usize, _, _>(|scope| {
+            scope.input_from(&mut input)
+                .container::<Vec<_>>()
+                .exchange(|&x: &usize| x as u64)
+                .probe_with(&probe);
+        });
+
+        input.send(0usize);
+        input.advance_to(1);
+        while probe.less_than(input.time()) {
+            worker.step();
+        }
+    })
+    .unwrap();
+
+    let events = events.lock().unwrap();
+
+    // Both send and receive progress events must be present.
+    let sends: Vec<_> = events.iter().filter(|(_, e)| e.is_send).collect();
+    let recvs: Vec<_> = events.iter().filter(|(_, e)| !e.is_send).collect();
+    assert!(!sends.is_empty(), "Expected at least one progress send event");
+    assert!(!recvs.is_empty(), "Expected at least one progress recv event");
+
+    // Every send should be mirrored by a receive with the same seq_no.
+    for (_, send) in &sends {
+        let matched = recvs.iter().any(|(_, r)| r.seq_no == send.seq_no && r.channel == send.channel);
+        assert!(matched, "Send event seq_no={} channel={} has no matching recv", send.seq_no, send.channel);
+    }
+
+    // The input advances from 0 to 1, so we expect internal capability changes
+    // that mention timestamp 0 (release) and/or 1 (acquire).
+    let has_internal = events.iter().any(|(_, e)| !e.internal.is_empty());
+    assert!(has_internal, "Expected at least one event with internal capability changes");
+}
+
+#[test]
+fn summary_logging() {
+    let (events, callback) = collect_events::<OperatesSummaryEvent<usize>>();
+
+    timely::execute(Config::thread(), move |worker| {
+        worker.log_register().unwrap().insert::<TimelySummaryEventBuilder<usize>, _>(
+            &logging::summary_log_name::<usize>(), callback.clone(),
+        );
+
+        let mut input = InputHandle::new();
+        worker.dataflow::<usize, _, _>(|scope| {
+            scope.input_from(&mut input)
+                .container::<Vec<_>>()
+                .exchange(|&x: &usize| x as u64)
+                .probe_with(&timely::dataflow::ProbeHandle::new());
+        });
+
+        input.advance_to(1);
+        worker.step();
+    })
+    .unwrap();
+
+    let events = events.lock().unwrap();
+
+    // The dataflow has Input (0 inputs), Exchange (1 input -> 1 output), and Probe
+    // (1 input -> 1 output). We should see summary events for each.
+    // Operators with inputs have non-empty summaries (one PortConnectivity per input).
+    let nonempty: Vec<_> = events.iter().filter(|(_, e)| !e.summary.is_empty()).collect();
+    assert!(nonempty.len() >= 2, "Expected at least 2 operators with non-empty summaries (Exchange, Probe), got {}", nonempty.len());
+
+    // Each non-empty summary should have exactly 1 entry (one input port).
+    for (_, e) in &nonempty {
+        assert_eq!(e.summary.len(), 1, "Operator {} should have 1 input, got {}", e.id, e.summary.len());
+    }
+
+    // Every summary entry should map input -> output 0 with the identity summary.
+    for (_, e) in &nonempty {
+        for port_conn in &e.summary {
+            let ports: Vec<_> = port_conn.iter_ports().collect();
+            assert!(!ports.is_empty(), "Operator {} has a PortConnectivity with no output mapping", e.id);
+            for (output, antichain) in &ports {
+                assert_eq!(*output, 0, "Expected output port 0, got {}", output);
+                // The default (identity) summary for usize is 0.
+                assert!(antichain.elements().contains(&0usize),
+                    "Expected identity summary (0) for operator {}, got {:?}", e.id, antichain);
+            }
+        }
+    }
+
+    // All operator ids should be distinct.
+    let mut ids: Vec<_> = events.iter().map(|(_, e)| e.id).collect();
+    ids.sort();
+    ids.dedup();
+    assert_eq!(ids.len(), events.len(), "Duplicate operator ids in summary events");
+}
+
+// ------------------------------------------------------------------
+// Nested (iterative) dataflow: Input -> [Enter -> Exchange -> Leave] -> Probe
+// ------------------------------------------------------------------
+
+#[test]
+fn progress_logging_iterative() {
+    type Inner = Product<usize, usize>;
+
+    let (outer_events, outer_cb) = collect_events::<TimelyProgressEvent<usize>>();
+    let (inner_events, inner_cb) = collect_events::<TimelyProgressEvent<Inner>>();
+
+    timely::execute(Config::thread(), move |worker| {
+        worker.log_register().unwrap().insert::<TimelyProgressEventBuilder<usize>, _>(
+            &logging::progress_log_name::<usize>(), outer_cb.clone(),
+        );
+        worker.log_register().unwrap().insert::<TimelyProgressEventBuilder<Inner>, _>(
+            &logging::progress_log_name::<Inner>(), inner_cb.clone(),
+        );
+
+        let mut input = InputHandle::new();
+        let probe = timely::dataflow::ProbeHandle::new();
+
+        worker.dataflow::<usize, _, _>(|scope| {
+            let stream = scope.input_from(&mut input).container::<Vec<_>>();
+            scope.iterative::<usize, _, _>(|outer, inner| {
+                stream.enter(inner)
+                    .exchange(|&x: &usize| x as u64)
+                    .leave(outer)
+            })
+            .probe_with(&probe);
+        });
+
+        input.send(0usize);
+        input.advance_to(1);
+        while probe.less_than(input.time()) {
+            worker.step();
+        }
+    })
+    .unwrap();
+
+    let outer = outer_events.lock().unwrap();
+    let inner = inner_events.lock().unwrap();
+    assert!(!outer.is_empty(), "Expected outer scope progress events");
+    assert!(!inner.is_empty(), "Expected inner scope progress events");
+
+    // Inner progress events should carry Product timestamps.
+    // The internal updates should reference Product<0,0> being released.
+    let has_product_ts = inner.iter().any(|(_, e)|
+        e.internal.iter().any(|(_, _, t, _)| *t == Product::new(0, 0))
+    );
+    assert!(has_product_ts, "Expected inner progress events with Product<0,0> timestamps");
+}
+
+#[test]
+fn summary_logging_iterative() {
+    type Inner = Product<usize, usize>;
+    type InnerSummary = <Inner as timely::progress::Timestamp>::Summary;
+
+    let (outer_events, outer_cb) = collect_events::<OperatesSummaryEvent<usize>>();
+    let (inner_events, inner_cb) = collect_events::<OperatesSummaryEvent<InnerSummary>>();
+
+    timely::execute(Config::thread(), move |worker| {
+        worker.log_register().unwrap().insert::<TimelySummaryEventBuilder<usize>, _>(
+            &logging::summary_log_name::<usize>(), outer_cb.clone(),
+        );
+        worker.log_register().unwrap().insert::<TimelySummaryEventBuilder<InnerSummary>, _>(
+            &logging::summary_log_name::<Inner>(), inner_cb.clone(),
+        );
+
+        let mut input = InputHandle::new();
+        worker.dataflow::<usize, _, _>(|scope| {
+            let stream = scope.input_from(&mut input).container::<Vec<_>>();
+            scope.iterative::<usize, _, _>(|outer, inner| {
+                stream.enter(inner)
+                    .exchange(|&x: &usize| x as u64)
+                    .leave(outer)
+            });
+        });
+
+        input.advance_to(1);
+        worker.step();
+    })
+    .unwrap();
+
+    let outer = outer_events.lock().unwrap();
+    let inner = inner_events.lock().unwrap();
+    assert!(!outer.is_empty(), "Expected outer scope summary events");
+    assert!(!inner.is_empty(), "Expected inner scope summary events");
+
+    // The outer scope should see the iterative subgraph as a single operator
+    // with a non-empty summary (it has inputs and outputs).
+    let outer_nonempty: Vec<_> = outer.iter().filter(|(_, e)| !e.summary.is_empty()).collect();
+    assert!(!outer_nonempty.is_empty(), "Expected the subgraph operator to have a non-empty outer summary");
+
+    // The inner scope should have summary events for the Exchange operator at minimum.
+    let inner_nonempty: Vec<_> = inner.iter().filter(|(_, e)| !e.summary.is_empty()).collect();
+    assert!(!inner_nonempty.is_empty(), "Expected inner operators with non-empty summaries");
+
+    // All inner operator ids should be distinct.
+    let mut ids: Vec<_> = inner.iter().map(|(_, e)| e.id).collect();
+    ids.sort();
+    ids.dedup();
+    assert_eq!(ids.len(), inner.len(), "Duplicate operator ids in inner summary events");
+}

--- a/timely/tests/shape_scaling.rs
+++ b/timely/tests/shape_scaling.rs
@@ -21,7 +21,7 @@ fn operator_scaling(scale: u64) {
                 .partition(scale, |()| (0, ()));
 
             use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
-            let mut builder = OperatorBuilder::new("OpScaling".to_owned(), scope.clone());
+            let mut builder = OperatorBuilder::new("OpScaling".to_owned(), scope);
             let mut handles = Vec::with_capacity(parts.len());
             let mut outputs = Vec::with_capacity(parts.len());
             for (index, part) in parts.into_iter().enumerate() {
@@ -64,7 +64,7 @@ fn subgraph_scaling(scale: u64) {
                 .input_from(&mut input)
                 .partition(scale, |()| (0, ()));
 
-            let _outputs = scope.region(|inner| {
+            let _outputs = scope.region(|scope, inner| {
                 use timely::dataflow::operators::{Enter, Leave};
                 parts.into_iter().map(|part| part.enter(inner).leave(scope)).collect::<Vec<_>>()
             });


### PR DESCRIPTION
## Summary

- Remove `Clone` impl from `Scope<T>` to prevent accidental scope escape (which would cause `Rc::try_unwrap` to fail when finalising the subgraph)
- `OperatorBuilder::new()` takes `&mut Scope<T>` and extracts the inner `Rc<RefCell<SubgraphBuilder<T>>>` + `Worker` parts — no lifetime on the builder
- `Stream<T, C>` stores subgraph Rc + Worker directly instead of a `Scope`; removes `scope()` method
- `OperatorSlot<T>` stores subgraph Rc instead of a full `Scope`; removes `scope_mut()`
- `scoped`/`region`/`iterative` closures now receive the parent scope as the first argument: `scope.region(|outer, inner| { ... .leave(outer) })`, since the parent can no longer be captured via clone
- Remove unused `progress_logging` field from `Scope`
- Add `progress_log_name`/`summary_log_name`/`reachability_log_name` helpers in `logging.rs`
- Fix flaky capture doc test (hardcoded port 8000 → port 0)
- Add logging tests for progress and summary events (flat + nested/Product)

## Test plan

- [x] `cargo check` clean (no warnings)
- [x] `cargo test` passes (154/154, the only prior failure was the fixed port 8000 test)
- [x] New logging tests cover progress and summary events with content assertions
- [ ] Review API ergonomics of the new closure signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)