### PR TITLE
Box pipeline pact behind dyn Push/Pull

### DIFF
--- a/communication/src/allocator/generic.rs
+++ b/communication/src/allocator/generic.rs
@@ -94,11 +94,12 @@ impl Allocator {
     ///
     /// By default, this method uses the thread-local channel constructor
     /// based on a shared `VecDeque` which updates the event queue.
-    pub fn pipeline<T: 'static>(&mut self, identifier: usize) ->
-        (crate::allocator::thread::ThreadPusher<T>,
-         crate::allocator::thread::ThreadPuller<T>)
-    {
-        crate::allocator::thread::Thread::new_from(identifier, Rc::clone(self.events()))
+    pub fn pipeline<T: 'static>(&mut self, identifier: usize) -> (Box<dyn Push<T>>, Box<dyn Pull<T>>) {
+        match self {
+            Allocator::Thread(t) => t.pipeline(identifier),
+            Allocator::Process(p) => p.pipeline(identifier),
+            Allocator::Tcp(z) => z.pipeline(identifier),
+        }
     }
 }
 

--- a/communication/src/allocator/generic.rs
+++ b/communication/src/allocator/generic.rs
@@ -92,8 +92,10 @@ impl Allocator {
 
     /// Constructs a pipeline channel from the worker to itself.
     ///
-    /// By default, this method uses the thread-local channel constructor
-    /// based on a shared `VecDeque` which updates the event queue.
+    /// Dispatches to the inner allocator's [`Allocate::pipeline`], which by default
+    /// returns a thread-local channel backed by a shared `VecDeque` that updates the
+    /// event queue. The concrete pusher and puller types are erased behind
+    /// `Box<dyn Push>` / `Box<dyn Pull>`.
     pub fn pipeline<T: 'static>(&mut self, identifier: usize) -> (Box<dyn Push<T>>, Box<dyn Pull<T>>) {
         match self {
             Allocator::Thread(t) => t.pipeline(identifier),

--- a/communication/src/allocator/mod.rs
+++ b/communication/src/allocator/mod.rs
@@ -2,6 +2,7 @@
 
 use std::rc::Rc;
 use std::cell::RefCell;
+use std::sync::Arc;
 use std::time::Duration;
 
 pub use self::thread::Thread;
@@ -17,8 +18,20 @@ pub mod counters;
 pub mod zero_copy;
 
 use crate::{Bytesable, Push, Pull};
+use crate::allocator::counters::{Pusher as CountPusher, Puller as CountPuller};
 use crate::allocator::process::{Process as TypedProcess, ProcessBuilder as TypedProcessBuilder};
 use crate::allocator::zero_copy::allocator_process::{ProcessAllocator as BytesProcess, ProcessBuilder as BytesProcessBuilder};
+
+/// A factory for runtime-supplied pipeline channels.
+///
+/// Keyed by `TypeId::of::<T>()` for the `T` that the pipeline channel will carry.
+/// The returned `Box<dyn Any>` must downcast to
+/// `(Box<dyn Push<T>>, Box<dyn Pull<T>>)`; the allocator wraps the resulting
+/// pusher and puller with the standard event-counter so the worker's event
+/// queue stays consistent. Return `None` to fall through to the default
+/// thread-local channel.
+pub type PipelineFactoryFn =
+    Arc<dyn Fn(std::any::TypeId) -> Option<Box<dyn Any>> + Send + Sync>;
 
 /// A proto-allocator, which implements `Send` and can be completed with `build`.
 ///
@@ -93,13 +106,36 @@ pub(crate) trait Allocate {
         (Box::new(Broadcaster { spare: None, pushers }), pull)
     }
 
+    /// Returns the runtime-supplied pipeline factory, if any.
+    ///
+    /// The default implementation returns `None`. Allocators that carry a
+    /// [`PipelineFactoryFn`] should override this to expose it; the default
+    /// [`Allocate::pipeline`] body consults it before falling back to the
+    /// thread-local channel.
+    fn pipeline_factory(&self) -> Option<&PipelineFactoryFn> { None }
+
     /// Allocates a pipeline channel from the worker to itself.
     ///
-    /// The default implementation returns a thread-local channel backed by a shared
-    /// `VecDeque` (see [`thread::Thread::new_from`]). Implementors may override this
-    /// to return any pair of pusher and puller that satisfy `Push<T>` / `Pull<T>`,
-    /// erased behind `Box<dyn ..>` so callers do not need to name the concrete type.
+    /// Consults [`Allocate::pipeline_factory`] first: if a factory is installed
+    /// and produces a pair for `T`, the pair is wrapped with the standard event
+    /// counter and returned. Otherwise returns a thread-local channel backed by
+    /// a shared `VecDeque` (see [`thread::Thread::new_from`]).
     fn pipeline<T: 'static>(&mut self, identifier: usize) -> (Box<dyn Push<T>>, Box<dyn Pull<T>>) {
+        if let Some(factory) = self.pipeline_factory() {
+            if let Some(any) = factory(std::any::TypeId::of::<T>()) {
+                let pair = any
+                    .downcast::<(Box<dyn Push<T>>, Box<dyn Pull<T>>)>()
+                    .unwrap_or_else(|_| panic!(
+                        "pipeline_factory returned wrong shape for {}",
+                        std::any::type_name::<T>(),
+                    ));
+                let (push, pull) = *pair;
+                let events = Rc::clone(self.events());
+                let push = CountPusher::new(push, identifier, Rc::clone(&events));
+                let pull = CountPuller::new(pull, identifier, events);
+                return (Box::new(push), Box::new(pull));
+            }
+        }
         let (push, pull) = Thread::new_from(identifier, Rc::clone(self.events()));
         (Box::new(push), Box::new(pull))
     }
@@ -139,8 +175,15 @@ pub(crate) trait PeerBuilder {
     /// `spill` is an optional factory for spill policies; one fresh policy
     /// per `MergeQueue` that the resulting peers construct. Implementors
     /// that don't use `MergeQueue` (e.g. `Typed` mpsc-based intra-process)
-    /// ignore it.
-    fn new_vector(peers: usize, refill: BytesRefill, spill: Option<SpillPolicyFn>) -> Vec<Self::Peer>;
+    /// ignore it. `pipeline_factory` is an optional `TypeId`-keyed factory
+    /// that each peer's allocator consults from [`Allocate::pipeline`] before
+    /// falling back to the default thread-local channel.
+    fn new_vector(
+        peers: usize,
+        refill: BytesRefill,
+        spill: Option<SpillPolicyFn>,
+        pipeline_factory: Option<PipelineFactoryFn>,
+    ) -> Vec<Self::Peer>;
 }
 
 
@@ -163,16 +206,26 @@ impl ProcessBuilder {
     }
 
     /// Constructs a vector of regular (mpsc-based, "Typed") intra-process builders.
-    pub fn new_typed_vector(peers: usize, refill: BytesRefill, spill: Option<SpillPolicyFn>) -> Vec<Self> {
-        <TypedProcess as PeerBuilder>::new_vector(peers, refill, spill)
+    pub fn new_typed_vector(
+        peers: usize,
+        refill: BytesRefill,
+        spill: Option<SpillPolicyFn>,
+        pipeline_factory: Option<PipelineFactoryFn>,
+    ) -> Vec<Self> {
+        <TypedProcess as PeerBuilder>::new_vector(peers, refill, spill, pipeline_factory)
             .into_iter()
             .map(ProcessBuilder::Typed)
             .collect()
     }
 
     /// Constructs a vector of binary (zero-copy serialized, "Bytes") intra-process builders.
-    pub fn new_bytes_vector(peers: usize, refill: BytesRefill, spill: Option<SpillPolicyFn>) -> Vec<Self> {
-        <BytesProcessBuilder as PeerBuilder>::new_vector(peers, refill, spill)
+    pub fn new_bytes_vector(
+        peers: usize,
+        refill: BytesRefill,
+        spill: Option<SpillPolicyFn>,
+        pipeline_factory: Option<PipelineFactoryFn>,
+    ) -> Vec<Self> {
+        <BytesProcessBuilder as PeerBuilder>::new_vector(peers, refill, spill, pipeline_factory)
             .into_iter()
             .map(ProcessBuilder::Bytes)
             .collect()
@@ -250,6 +303,13 @@ impl Process {
         match self {
             Process::Typed(p) => p.pipeline(identifier),
             Process::Bytes(pb) => pb.pipeline(identifier),
+        }
+    }
+    /// Returns the inner variant's [`Allocate::pipeline_factory`].
+    pub(crate) fn pipeline_factory(&self) -> Option<&PipelineFactoryFn> {
+        match self {
+            Process::Typed(p) => p.pipeline_factory(),
+            Process::Bytes(pb) => pb.pipeline_factory(),
         }
     }
 }

--- a/communication/src/allocator/mod.rs
+++ b/communication/src/allocator/mod.rs
@@ -93,7 +93,12 @@ pub(crate) trait Allocate {
         (Box::new(Broadcaster { spare: None, pushers }), pull)
     }
 
-    /// Allocates a pipeline channel where each message is received by the worker-local receiver.
+    /// Allocates a pipeline channel from the worker to itself.
+    ///
+    /// The default implementation returns a thread-local channel backed by a shared
+    /// `VecDeque` (see [`thread::Thread::new_from`]). Implementors may override this
+    /// to return any pair of pusher and puller that satisfy `Push<T>` / `Pull<T>`,
+    /// erased behind `Box<dyn ..>` so callers do not need to name the concrete type.
     fn pipeline<T: 'static>(&mut self, identifier: usize) -> (Box<dyn Push<T>>, Box<dyn Pull<T>>) {
         let (push, pull) = Thread::new_from(identifier, Rc::clone(self.events()));
         (Box::new(push), Box::new(pull))
@@ -238,7 +243,9 @@ impl Process {
             Process::Bytes(pb) => pb.await_events(duration),
         }
     }
-    /// Allocates a pipeline channel where each message is received by the worker-local receiver.
+    /// Allocates a pipeline channel from the worker to itself.
+    ///
+    /// Dispatches to the inner `Process` variant's [`Allocate::pipeline`].
     pub(crate) fn pipeline<T: 'static>(&mut self, identifier: usize) -> (Box<dyn Push<T>>, Box<dyn Pull<T>>) {
         match self {
             Process::Typed(p) => p.pipeline(identifier),

--- a/communication/src/allocator/mod.rs
+++ b/communication/src/allocator/mod.rs
@@ -92,6 +92,12 @@ pub(crate) trait Allocate {
         let (pushers, pull) = self.allocate(identifier);
         (Box::new(Broadcaster { spare: None, pushers }), pull)
     }
+
+    /// Allocates a pipeline channel where each message is received by the worker-local receiver.
+    fn pipeline<T: 'static>(&mut self, identifier: usize) -> (Box<dyn Push<T>>, Box<dyn Pull<T>>) {
+        let (push, pull) = Thread::new_from(identifier, Rc::clone(self.events()));
+        (Box::new(push), Box::new(pull))
+    }
 }
 
 /// An adapter to broadcast any pushed element.
@@ -230,6 +236,13 @@ impl Process {
         match self {
             Process::Typed(p) => p.await_events(duration),
             Process::Bytes(pb) => pb.await_events(duration),
+        }
+    }
+    /// Allocates a pipeline channel where each message is received by the worker-local receiver.
+    pub(crate) fn pipeline<T: 'static>(&mut self, identifier: usize) -> (Box<dyn Push<T>>, Box<dyn Pull<T>>) {
+        match self {
+            Process::Typed(p) => p.pipeline(identifier),
+            Process::Bytes(pb) => pb.pipeline(identifier),
         }
     }
 }

--- a/communication/src/allocator/process.rs
+++ b/communication/src/allocator/process.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap};
 use std::sync::mpsc::{Sender, Receiver};
 
 use crate::allocator::thread::{ThreadBuilder};
-use crate::allocator::{Allocate, AllocateBuilder, PeerBuilder, Thread};
+use crate::allocator::{Allocate, AllocateBuilder, PeerBuilder, PipelineFactoryFn, Thread};
 use crate::{Push, Pull};
 use crate::buzzer::Buzzer;
 
@@ -79,6 +79,7 @@ impl PeerBuilder for Process {
         peers: usize,
         _refill: crate::allocator::BytesRefill,
         _spill: Option<crate::allocator::zero_copy::spill::SpillPolicyFn>,
+        pipeline_factory: Option<PipelineFactoryFn>,
     ) -> Vec<ProcessBuilder> {
 
         let mut counters_send = Vec::with_capacity(peers);
@@ -101,7 +102,7 @@ impl PeerBuilder for Process {
             .enumerate()
             .map(|(index, ((recv, bsend), brecv))| {
                 ProcessBuilder {
-                    inner: ThreadBuilder,
+                    inner: ThreadBuilder { pipeline_factory: pipeline_factory.clone() },
                     index,
                     peers,
                     buzzers_send: bsend,
@@ -196,6 +197,8 @@ impl Allocate for Process {
             events.push(index);
         }
     }
+
+    fn pipeline_factory(&self) -> Option<&PipelineFactoryFn> { self.inner.pipeline_factory() }
 }
 
 /// The push half of an intra-process channel.

--- a/communication/src/allocator/thread.rs
+++ b/communication/src/allocator/thread.rs
@@ -5,17 +5,26 @@ use std::cell::RefCell;
 use std::time::Duration;
 use std::collections::VecDeque;
 
-use crate::allocator::{Allocate, AllocateBuilder};
+use crate::allocator::{Allocate, AllocateBuilder, PipelineFactoryFn};
 use crate::allocator::counters::Pusher as CountPusher;
 use crate::allocator::counters::Puller as CountPuller;
 use crate::{Push, Pull};
 
 /// Builder for single-threaded allocator.
-pub struct ThreadBuilder;
+#[derive(Default)]
+pub struct ThreadBuilder {
+    /// Optional factory for runtime-supplied pipeline channels.
+    pub pipeline_factory: Option<PipelineFactoryFn>,
+}
 
 impl AllocateBuilder for ThreadBuilder {
     type Allocator = Thread;
-    fn build(self) -> Self::Allocator { Thread::default() }
+    fn build(self) -> Self::Allocator {
+        Thread {
+            events: Default::default(),
+            pipeline_factory: self.pipeline_factory,
+        }
+    }
 }
 
 
@@ -24,6 +33,8 @@ impl AllocateBuilder for ThreadBuilder {
 pub struct Thread {
     /// Shared counts of messages in channels.
     events: Rc<RefCell<Vec<usize>>>,
+    /// Optional factory for runtime-supplied pipeline channels.
+    pipeline_factory: Option<PipelineFactoryFn>,
 }
 
 impl Allocate for Thread {
@@ -46,6 +57,7 @@ impl Allocate for Thread {
             }
         }
     }
+    fn pipeline_factory(&self) -> Option<&PipelineFactoryFn> { self.pipeline_factory.as_ref() }
 }
 
 /// Thread-local counting channel push endpoint.

--- a/communication/src/allocator/zero_copy/allocator.rs
+++ b/communication/src/allocator/zero_copy/allocator.rs
@@ -9,7 +9,7 @@ use timely_bytes::arc::Bytes;
 use crate::networking::MessageHeader;
 
 use crate::{Allocate, Push, Pull};
-use crate::allocator::{Process, ProcessBuilder, Exchangeable};
+use crate::allocator::{PipelineFactoryFn, Process, ProcessBuilder, Exchangeable};
 use crate::allocator::canary::Canary;
 use crate::allocator::zero_copy::bytes_slab::BytesRefill;
 use crate::allocator::zero_copy::spill::SpillPolicyFn;
@@ -330,4 +330,5 @@ impl Allocate for TcpAllocator {
     fn await_events(&self, duration: Option<std::time::Duration>) {
         self.inner.await_events(duration);
     }
+    fn pipeline_factory(&self) -> Option<&PipelineFactoryFn> { self.inner.pipeline_factory() }
 }

--- a/communication/src/allocator/zero_copy/allocator_process.rs
+++ b/communication/src/allocator/zero_copy/allocator_process.rs
@@ -10,7 +10,7 @@ use timely_bytes::arc::Bytes;
 use crate::networking::MessageHeader;
 
 use crate::{Allocate, Push, Pull};
-use crate::allocator::{AllocateBuilder, Exchangeable, PeerBuilder};
+use crate::allocator::{AllocateBuilder, Exchangeable, PeerBuilder, PipelineFactoryFn};
 use crate::allocator::canary::Canary;
 use crate::allocator::zero_copy::bytes_slab::BytesRefill;
 use crate::allocator::zero_copy::spill::SpillPolicyFn;
@@ -31,6 +31,7 @@ pub struct ProcessBuilder {
     pullers: Vec<Sender<MergeQueue>>,   // for pulling bytes from other workers.
     refill: BytesRefill,
     spill: Option<SpillPolicyFn>,       // optional spill factory for recv queues.
+    pipeline_factory: Option<PipelineFactoryFn>,
 }
 
 impl PeerBuilder for ProcessBuilder {
@@ -38,7 +39,12 @@ impl PeerBuilder for ProcessBuilder {
     /// Creates a vector of builders, sharing appropriate state.
     ///
     /// This method requires access to a byte exchanger, from which it mints channels.
-    fn new_vector(count: usize, refill: BytesRefill, spill: Option<SpillPolicyFn>) -> Vec<ProcessBuilder> {
+    fn new_vector(
+        count: usize,
+        refill: BytesRefill,
+        spill: Option<SpillPolicyFn>,
+        pipeline_factory: Option<PipelineFactoryFn>,
+    ) -> Vec<ProcessBuilder> {
 
         // Channels for the exchange of `MergeQueue` endpoints.
         let (pullers_vec, pushers_vec) = crate::promise_futures(count, count);
@@ -55,6 +61,7 @@ impl PeerBuilder for ProcessBuilder {
                     pullers,
                     refill: refill.clone(),
                     spill: spill.clone(),
+                    pipeline_factory: pipeline_factory.clone(),
                 }
             )
             .collect()
@@ -100,6 +107,7 @@ impl ProcessBuilder {
             sends,
             recvs,
             to_local: HashMap::new(),
+            pipeline_factory: self.pipeline_factory,
         }
     }
 }
@@ -130,6 +138,7 @@ pub struct ProcessAllocator {
     sends:      Vec<Rc<RefCell<SendEndpoint<MergeQueue>>>>, // sends[x] -> goes to thread x.
     recvs:      Vec<MergeQueue>,                            // recvs[x] <- from thread x.
     to_local:   HashMap<usize, Rc<RefCell<VecDeque<Bytes>>>>,          // to worker-local typed pullers.
+    pipeline_factory: Option<PipelineFactoryFn>,
 }
 
 impl Allocate for ProcessAllocator {
@@ -263,4 +272,6 @@ impl Allocate for ProcessAllocator {
             }
         }
     }
+
+    fn pipeline_factory(&self) -> Option<&PipelineFactoryFn> { self.pipeline_factory.as_ref() }
 }

--- a/communication/src/initialize.rs
+++ b/communication/src/initialize.rs
@@ -70,6 +70,8 @@ pub struct Hooks {
     pub refill: BytesRefill,
     /// A mechanism to get a matched pair of spill policies (writer, reader) per queue.
     pub spill: Option<crate::allocator::zero_copy::spill::SpillPolicyFn>,
+    /// Optional `TypeId`-keyed factory consulted by [`crate::Allocate::pipeline`].
+    pub pipeline_factory: Option<crate::allocator::PipelineFactoryFn>,
 }
 
 impl Default for Hooks {
@@ -81,6 +83,7 @@ impl Default for Hooks {
                 limit: None,
             },
             spill: None,
+            pipeline_factory: None,
         }
     }
 }
@@ -182,24 +185,24 @@ impl Config {
     pub fn try_build_with(self, hooks: Hooks) -> Result<(Vec<AllocatorBuilder>, Box<dyn Any+Send>), String> {
         match self {
             Config::Thread => {
-                Ok((vec![AllocatorBuilder::Thread(ThreadBuilder)], Box::new(())))
+                Ok((vec![AllocatorBuilder::Thread(ThreadBuilder { pipeline_factory: hooks.pipeline_factory })], Box::new(())))
             },
             Config::Process(threads) => {
-                let builders = ProcessBuilder::new_typed_vector(threads, hooks.refill, hooks.spill)
+                let builders = ProcessBuilder::new_typed_vector(threads, hooks.refill, hooks.spill, hooks.pipeline_factory)
                     .into_iter()
                     .map(AllocatorBuilder::Process)
                     .collect();
                 Ok((builders, Box::new(())))
             },
             Config::ProcessBinary(threads) => {
-                let builders = ProcessBuilder::new_bytes_vector(threads, hooks.refill, hooks.spill)
+                let builders = ProcessBuilder::new_bytes_vector(threads, hooks.refill, hooks.spill, hooks.pipeline_factory)
                     .into_iter()
                     .map(AllocatorBuilder::Process)
                     .collect();
                 Ok((builders, Box::new(())))
             },
             Config::Cluster { threads, process, addresses, report, zerocopy: false } => {
-                let process_allocators = ProcessBuilder::new_typed_vector(threads, hooks.refill.clone(), hooks.spill.clone());
+                let process_allocators = ProcessBuilder::new_typed_vector(threads, hooks.refill.clone(), hooks.spill.clone(), hooks.pipeline_factory.clone());
                 match initialize_networking(process_allocators, addresses, process, threads, report, hooks) {
                     Ok((stuff, guard)) => {
                         Ok((stuff.into_iter().map(AllocatorBuilder::Tcp).collect(), Box::new(guard)))
@@ -208,7 +211,7 @@ impl Config {
                 }
             },
             Config::Cluster { threads, process, addresses, report, zerocopy: true } => {
-                let process_allocators = ProcessBuilder::new_bytes_vector(threads, hooks.refill.clone(), hooks.spill.clone());
+                let process_allocators = ProcessBuilder::new_bytes_vector(threads, hooks.refill.clone(), hooks.spill.clone(), hooks.pipeline_factory.clone());
                 match initialize_networking(process_allocators, addresses, process, threads, report, hooks) {
                     Ok((stuff, guard)) => {
                         Ok((stuff.into_iter().map(AllocatorBuilder::Tcp).collect(), Box::new(guard)))

--- a/timely/src/dataflow/channels/pact.rs
+++ b/timely/src/dataflow/channels/pact.rs
@@ -11,7 +11,6 @@ use std::fmt::Debug;
 use std::rc::Rc;
 
 use crate::Accountable;
-use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
 use crate::communication::{Push, Pull};
 use crate::dataflow::channels::Message;
 use crate::logging::TimelyLogger as Logger;
@@ -32,8 +31,8 @@ pub trait ParallelizationContract<T, C> {
 pub struct Pipeline;
 
 impl<T: 'static, C: Accountable + 'static> ParallelizationContract<T, C> for Pipeline {
-    type Pusher = LogPusher<ThreadPusher<Message<T, C>>>;
-    type Puller = LogPuller<ThreadPuller<Message<T, C>>>;
+    type Pusher = LogPusher<Box<dyn Push<Message<T, C>>>>;
+    type Puller = LogPuller<Box<dyn Pull<Message<T, C>>>>;
     fn connect(self, worker: &Worker, identifier: usize, address: Rc<[usize]>, logging: Option<Logger>) -> (Self::Pusher, Self::Puller) {
         let (pusher, puller) = worker.pipeline::<Message<T, C>>(identifier, address);
         (LogPusher::new(pusher, worker.index(), worker.index(), identifier, logging.clone()),

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -10,7 +10,6 @@ use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
 use crate::communication::{Allocator, Exchangeable, Push, Pull};
-use crate::communication::allocator::thread::{ThreadPusher, ThreadPuller};
 use crate::scheduling::{Schedule, Activations, Activator, SyncActivator};
 use crate::progress::timestamp::{Refines};
 use crate::progress::SubgraphBuilder;
@@ -523,7 +522,7 @@ impl Worker {
     }
 
     /// Constructs a pipeline channel from the worker to itself.
-    pub fn pipeline<T: 'static>(&self, identifier: usize, address: Rc<[usize]>) -> (ThreadPusher<T>, ThreadPuller<T>) {
+    pub fn pipeline<T: 'static>(&self, identifier: usize, address: Rc<[usize]>) -> (Box<dyn Push<T>>, Box<dyn Pull<T>>) {
         if address.is_empty() { panic!("Unacceptable address: Length zero"); }
         let mut paths = self.paths.borrow_mut();
         paths.insert(identifier, address);


### PR DESCRIPTION
Add `Allocate::pipeline` default returning `(Box<dyn Push<T>>, Box<dyn Pull<T>>)`, dispatched through `Process::pipeline`, `Allocator::pipeline`, and `Worker::pipeline`.
Hides `ThreadPusher` / `ThreadPuller` from callers and lets each allocator override the pipeline constructor.

A/B benchmark on `event_driven 10 100 record -w1` (10s wall, 10 trials each): boxed ~256k rounds, concrete ~255k rounds. Vtable indirection invisible — `LogPusher::push` does not show up in the top 25 functions in a samply profile.