### PR TITLE
docs(mdbook): minor typo fixes

### DIFF
--- a/mdbook/src/chapter_2/chapter_2_1.md
+++ b/mdbook/src/chapter_2/chapter_2_1.md
@@ -34,7 +34,7 @@ There will be more to do to get data into `input`, and we aren't going to worry 
 At this point you may also have questions about the `container()` method with many symbols.
 Rust is statically typed, and needs to know the type of things that each program will manipulate.
 Timely dataflow bundles your individual data atoms into batches backed by a "container" type, and we need to communicate this type to Rust as well.
-In our first case, we've said we have an input but we haven't provided any clues about the type of data, and must do so to compile the program even thought we don't care for the example.
+In our first case, we've said we have an input but we haven't provided any clues about the type of data, and must do so to compile the program even though we don't care for the example.
 In our second case, we've shown some data (integers) but we haven't revealed how we want to hold on to them, as we communicate the `Vec` structure and leave the data type unspecified with `_` (which Rust can fill in from the type of the integers).
 
 ## Other sources

--- a/mdbook/src/chapter_4/chapter_4_4.md
+++ b/mdbook/src/chapter_4/chapter_4_4.md
@@ -6,7 +6,7 @@ Timely dataflow has two fairly handy operators, `capture_into` and `replay_into`
 
 At its core, `capture_into` records everything it sees about the stream it is attached to. If some data arrive, it records that. If there is a change in the possibility that timestamps might arrive on its input, it records that.
 
-The `capture_into` method is relative simple, and we can just look at it:
+The `capture_into` method is relatively simple, and we can just look at it:
 
 ```rust,ignore
     fn capture_into<P: EventPusher<S::Timestamp, C>+'static>(&self, mut event_pusher: P) {


### PR DESCRIPTION
Was reading through the `mdbook` to get a grasp of the systems and noticed a small typo.

Typo `thought` to `though` in Chapter 2: Creating Inputs.

> In our first case, we've said we have an input but we haven't provided any clues about the type of data, and must do so to compile the program even though~~t~~ we don't care for the example.

Edit: Found another typo as I was going along so I figured I'd include it.
Added an `ly` to fix `relative` in `mdbook/src/chapter_4/chapter_4_4.md`

> The `capture_into` method is relative***ly*** simple, and we can just look at it: