### PR TITLE
Consuming iterators for `PortConnectivity` and less cloning.

### DIFF
--- a/timely/src/progress/operate.rs
+++ b/timely/src/progress/operate.rs
@@ -153,6 +153,13 @@ impl<TS> Default for PortConnectivity<TS> {
     }
 }
 
+impl<TS> IntoIterator for PortConnectivity<TS> {
+    type Item = (usize, Antichain<TS>);
+    type IntoIter = std::vec::IntoIter<(usize, Antichain<TS>)>;
+    /// Consumes the connectivity, yielding each port and its antichain.
+    fn into_iter(self) -> Self::IntoIter { self.entries.into_iter() }
+}
+
 impl<TS> PortConnectivity<TS> {
     /// Borrowing iterator of port identifiers and antichains.
     pub fn iter_ports(&self) -> impl Iterator<Item = (usize, &Antichain<TS>)> {

--- a/timely/src/progress/reachability.rs
+++ b/timely/src/progress/reachability.rs
@@ -579,10 +579,10 @@ impl<T:Timestamp> Tracker<T> {
         }
 
         // Build columnar nodes: Vecs<Vecs<Vec<(usize, T::Summary)>>>.
-        let nodes = build_nested_vecs(builder.nodes.iter().map(|connectivity| {
-            connectivity.iter().map(|port_conn| {
-                port_conn.iter_ports().flat_map(|(port, antichain)| {
-                    antichain.elements().iter().map(move |s| (port, s.clone()))
+        let nodes = build_nested_vecs(builder.nodes.into_iter().map(|connectivity| {
+            connectivity.into_iter().map(|port_conn| {
+                port_conn.into_iter().flat_map(|(port, antichain)| {
+                    antichain.into_iter().map(move |s| (port, s))
                 })
             })
         }));
@@ -593,17 +593,17 @@ impl<T:Timestamp> Tracker<T> {
         }));
 
         // Build columnar target and source summaries.
-        let target_summaries = build_nested_vecs(target_sum.iter().map(|ports| {
-            ports.iter().map(|port_conn| {
-                port_conn.iter_ports().flat_map(|(port, antichain)| {
-                    antichain.elements().iter().map(move |s| (port, s.clone()))
+        let target_summaries = build_nested_vecs(target_sum.into_iter().map(|ports| {
+            ports.into_iter().map(|port_conn| {
+                port_conn.into_iter().flat_map(|(port, antichain)| {
+                    antichain.into_iter().map(move |s| (port, s))
                 })
             })
         }));
-        let source_summaries = build_nested_vecs(source_sum.iter().map(|ports| {
-            ports.iter().map(|port_conn| {
-                port_conn.iter_ports().flat_map(|(port, antichain)| {
-                    antichain.elements().iter().map(move |s| (port, s.clone()))
+        let source_summaries = build_nested_vecs(source_sum.into_iter().map(|ports| {
+            ports.into_iter().map(|port_conn| {
+                port_conn.into_iter().flat_map(|(port, antichain)| {
+                    antichain.into_iter().map(move |s| (port, s))
                 })
             })
         }));

--- a/timely/src/progress/subgraph.rs
+++ b/timely/src/progress/subgraph.rs
@@ -566,9 +566,9 @@ where
         // with each element containing `self.outputs()` antichains regardless
         // of how long `self.scope_summary` is
         let mut internal_summary = vec![PortConnectivityBuilder::default(); self.inputs()];
-        for (input_idx, input) in self.scope_summary.iter().enumerate() {
-            for (output_idx, output) in input.iter_ports() {
-                for outer in output.elements().iter().cloned().map(TInner::summarize) {
+        for (input_idx, input) in std::mem::take(&mut self.scope_summary).into_iter().enumerate() {
+            for (output_idx, output) in input {
+                for outer in output.into_iter().map(TInner::summarize) {
                     internal_summary[input_idx].insert(output_idx, outer);
                 }
             }


### PR DESCRIPTION
`Tracker::allocate_from` now moves builder and computed summaries into its columnar form rather than cloning every element, and `Subgraph::initialize` takes `self.scope_summary` (read only here) and moves its elements through `TInner::summarize`, releasing the compiled scope summary at initialization.