### PR TITLE
Trim capacity of piggier allocations

### DIFF
--- a/timely/src/dataflow/operators/generic/builder_rc.rs
+++ b/timely/src/dataflow/operators/generic/builder_rc.rs
@@ -183,6 +183,15 @@ impl<'scope, T: Timestamp> OperatorBuilder<'scope, T> {
 
         let mut logic = constructor(self.mint_capabilities());
 
+        // These vectors grew by `push` from empty, reserving capacity four; ports
+        // are few and the vectors live as long as the operator, so trim the excess.
+        // The trade is one reallocation per vector at build time for memory
+        // proportional to ports, rather than capacity, thereafter.
+        self.frontier.shrink_to_fit();
+        self.consumed.shrink_to_fit();
+        self.produced.shrink_to_fit();
+        self.internal.borrow_mut().shrink_to_fit();
+
         let mut bookkeeping = ProgressBookkeeping {
             frontier: self.frontier,
             consumed: self.consumed,


### PR DESCRIPTION
## Measurements

  master @ `0823096c` vs this branch, release, Apple Silicon. RSS sampled
  via `ps` after construction completes (repeatable to ~0.1 MB); scaling
  tests 3 runs each.

  | `event_driven` 1000 × 1000 | master | branch |
  |---|---|---|
  | peak RSS | 4,320 MB | **3,742 MB (−13.4%)** |
  | dataflow build time | 1.53–1.56s | 1.60–1.65s (+4–5%) |

  | `shape_scaling` 100k | master | branch |
  |---|---|---|
  | `operator_scaling` | 0.26s | 0.25–0.26s |
  | `subgraph_scaling` | 0.29–0.30s | 0.29–0.30s |

  Per the heap profile, the trimmed vectors were the second-largest
  per-operator item: the `frontier` vector alone held 544 B (capacity 4 ×
  136 B `MutableAntichain`) to store one 136 B element. The build-time
  cost is the extra allocator round-trips from the shrink reallocs,
  visible only on the chain-heavy benchmark; scaling tests sit at parity.