### PR TITLE
Coalesce communication channel notifications

### DIFF
--- a/communication/src/allocator/counters.rs
+++ b/communication/src/allocator/counters.rs
@@ -34,6 +34,8 @@ impl<T, P: Push<T>> Push<T> for Pusher<T, P> {
         let done = element.is_none();
         self.pusher.push(element);
 
+        // An empty batch emits no event; a single message emits one prompt
+        // event; multi-message batches emit a second event when the batch ends.
         // Notify promptly for the first message, and once more at the end
         // if later messages may have arrived after the receiver drained.
         if done {
@@ -81,6 +83,8 @@ impl<T, P: Push<T>> Push<T> for ArcPusher<T, P> {
         let done = element.is_none();
         self.pusher.push(element);
 
+        // An empty batch emits no event; a single message emits one prompt
+        // event; multi-message batches emit a second event when the batch ends.
         // These three calls should happen in this order, to ensure that
         // we first enqueue data, second enqueue interest in the channel,
         // and finally awaken the thread. Other orders are defective when

--- a/communication/src/allocator/counters.rs
+++ b/communication/src/allocator/counters.rs
@@ -9,7 +9,7 @@ use crate::{Push, Pull};
 /// The push half of an intra-thread channel.
 pub struct Pusher<T, P: Push<T>> {
     index: usize,
-    // count: usize,
+    pushed: usize,
     events: Rc<RefCell<Vec<usize>>>,
     pusher: P,
     phantom: ::std::marker::PhantomData<T>,
@@ -20,7 +20,7 @@ impl<T, P: Push<T>>  Pusher<T, P> {
     pub fn new(pusher: P, index: usize, events: Rc<RefCell<Vec<usize>>>) -> Self {
         Pusher {
             index,
-            // count: 0,
+            pushed: 0,
             events,
             pusher,
             phantom: ::std::marker::PhantomData,
@@ -31,31 +31,30 @@ impl<T, P: Push<T>>  Pusher<T, P> {
 impl<T, P: Push<T>> Push<T> for Pusher<T, P> {
     #[inline]
     fn push(&mut self, element: &mut Option<T>) {
-        // if element.is_none() {
-        //     if self.count != 0 {
-        //         self.events
-        //             .borrow_mut()
-        //             .push_back(self.index);
-        //         self.count = 0;
-        //     }
-        // }
-        // else {
-        //     self.count += 1;
-        // }
-        // TODO: Version above is less chatty, but can be a bit late in
-        //       moving information along. Better, but needs cooperation.
-        self.events
-            .borrow_mut()
-            .push(self.index);
+        let done = element.is_none();
+        self.pusher.push(element);
 
-        self.pusher.push(element)
+        // Notify promptly for the first message, and once more at the end
+        // if later messages may have arrived after the receiver drained.
+        if done {
+            if self.pushed > 1 {
+                self.events.borrow_mut().push(self.index);
+            }
+            self.pushed = 0;
+        }
+        else {
+            if self.pushed == 0 {
+                self.events.borrow_mut().push(self.index);
+            }
+            self.pushed = self.pushed.saturating_add(1);
+        }
     }
 }
 
-/// The push half of an intra-thread channel.
+/// The push half of an inter-thread channel.
 pub struct ArcPusher<T, P: Push<T>> {
     index: usize,
-    // count: usize,
+    pushed: usize,
     events: Sender<usize>,
     pusher: P,
     phantom: ::std::marker::PhantomData<T>,
@@ -67,7 +66,7 @@ impl<T, P: Push<T>>  ArcPusher<T, P> {
     pub fn new(pusher: P, index: usize, events: Sender<usize>, buzzer: crate::buzzer::Buzzer) -> Self {
         ArcPusher {
             index,
-            // count: 0,
+            pushed: 0,
             events,
             pusher,
             phantom: ::std::marker::PhantomData,
@@ -79,27 +78,27 @@ impl<T, P: Push<T>>  ArcPusher<T, P> {
 impl<T, P: Push<T>> Push<T> for ArcPusher<T, P> {
     #[inline]
     fn push(&mut self, element: &mut Option<T>) {
-        // if element.is_none() {
-        //     if self.count != 0 {
-        //         self.events
-        //             .send((self.index, Event::Pushed(self.count)))
-        //             .expect("Failed to send message count");
-        //         self.count = 0;
-        //     }
-        // }
-        // else {
-        //     self.count += 1;
-        // }
+        let done = element.is_none();
+        self.pusher.push(element);
 
         // These three calls should happen in this order, to ensure that
         // we first enqueue data, second enqueue interest in the channel,
         // and finally awaken the thread. Other orders are defective when
         // multiple threads are involved.
-        self.pusher.push(element);
-        let _ = self.events.send(self.index);
-            // TODO : Perhaps this shouldn't be a fatal error (e.g. in shutdown).
-            // .expect("Failed to send message count");
-        self.buzzer.buzz();
+        if done {
+            if self.pushed > 1 {
+                let _ = self.events.send(self.index);
+                self.buzzer.buzz();
+            }
+            self.pushed = 0;
+        }
+        else {
+            if self.pushed == 0 {
+                let _ = self.events.send(self.index);
+                self.buzzer.buzz();
+            }
+            self.pushed = self.pushed.saturating_add(1);
+        }
     }
 }
 

--- a/communication/src/lib.rs
+++ b/communication/src/lib.rs
@@ -129,7 +129,8 @@ pub trait Bytesable {
 ///
 /// Conventionally, a sequence of calls to `push()` should conclude with
 /// a call of `push(&mut None)` or `done()` to signal to implementors that
-/// another call to `push()` may not be coming.
+/// another call to `push()` may not be coming. Implementors may coalesce
+/// notifications for subsequent messages until they observe this boundary.
 pub trait Push<T> {
     /// Pushes `element` with the opportunity to take ownership.
     fn push(&mut self, element: &mut Option<T>);

--- a/communication/tests/counters.rs
+++ b/communication/tests/counters.rs
@@ -1,0 +1,113 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::mpsc::{channel, TryRecvError};
+use std::time::Duration;
+
+use timely_communication::allocator::counters::{ArcPusher, Pusher};
+use timely_communication::Push;
+
+struct RecordingPusher<T> {
+    pushed: Rc<RefCell<Vec<Option<T>>>>,
+}
+
+impl<T> Push<T> for RecordingPusher<T> {
+    fn push(&mut self, element: &mut Option<T>) {
+        self.pushed.borrow_mut().push(element.take());
+    }
+}
+
+struct ChannelPusher<T>(std::sync::mpsc::Sender<T>);
+
+impl<T> Push<T> for ChannelPusher<T> {
+    fn push(&mut self, element: &mut Option<T>) {
+        if let Some(element) = element.take() {
+            let _ = self.0.send(element);
+        }
+    }
+}
+
+#[test]
+fn pusher_coalesces_non_empty_batches() {
+    let pushed = Rc::new(RefCell::new(Vec::new()));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let mut pusher = Pusher::new(
+        RecordingPusher {
+            pushed: Rc::clone(&pushed),
+        },
+        7,
+        Rc::clone(&events),
+    );
+
+    pusher.send(1);
+    pusher.send(2);
+    assert_eq!(&*events.borrow(), &[7]);
+
+    pusher.done();
+    assert_eq!(&*events.borrow(), &[7, 7]);
+    assert_eq!(&*pushed.borrow(), &[Some(1), Some(2), None]);
+
+    pusher.done();
+    assert_eq!(&*events.borrow(), &[7, 7]);
+
+    pusher.send(3);
+    assert_eq!(&*events.borrow(), &[7, 7, 7]);
+    pusher.done();
+    assert_eq!(&*events.borrow(), &[7, 7, 7]);
+}
+
+#[test]
+fn arc_pusher_coalesces_non_empty_batches() {
+    let pushed = Rc::new(RefCell::new(Vec::new()));
+    let (events_tx, events_rx) = channel();
+    let mut pusher = ArcPusher::new(
+        RecordingPusher {
+            pushed: Rc::clone(&pushed),
+        },
+        11,
+        events_tx,
+        timely_communication::buzzer::Buzzer::default(),
+    );
+
+    pusher.send(1);
+    assert_eq!(events_rx.recv().unwrap(), 11);
+    pusher.send(2);
+    assert_eq!(events_rx.try_recv(), Err(TryRecvError::Empty));
+
+    pusher.done();
+    assert_eq!(events_rx.recv().unwrap(), 11);
+    assert_eq!(events_rx.try_recv(), Err(TryRecvError::Empty));
+    assert_eq!(&*pushed.borrow(), &[Some(1), Some(2), None]);
+
+    pusher.done();
+    assert_eq!(events_rx.try_recv(), Err(TryRecvError::Empty));
+
+    pusher.send(3);
+    assert_eq!(events_rx.recv().unwrap(), 11);
+    pusher.done();
+    assert_eq!(events_rx.try_recv(), Err(TryRecvError::Empty));
+}
+
+#[test]
+fn arc_pusher_notifies_messages_arriving_after_the_first_wake() {
+    let timeout = Duration::from_secs(5);
+    let (data_tx, data_rx) = channel();
+    let (events_tx, events_rx) = channel();
+    let (continue_tx, continue_rx) = channel();
+    let buzzer = timely_communication::buzzer::Buzzer::default();
+
+    let sender = std::thread::spawn(move || {
+        let mut pusher = ArcPusher::new(ChannelPusher(data_tx), 13, events_tx, buzzer);
+        pusher.send(1);
+        continue_rx.recv_timeout(timeout).unwrap();
+        pusher.send(2);
+        pusher.done();
+    });
+
+    assert_eq!(events_rx.recv_timeout(timeout).unwrap(), 13);
+    assert_eq!(data_rx.recv_timeout(timeout).unwrap(), 1);
+    continue_tx.send(()).unwrap();
+    assert_eq!(events_rx.recv_timeout(timeout).unwrap(), 13);
+    assert_eq!(data_rx.recv_timeout(timeout).unwrap(), 2);
+
+    sender.join().unwrap();
+}

--- a/timely/src/dataflow/operators/core/input.rs
+++ b/timely/src/dataflow/operators/core/input.rs
@@ -368,9 +368,14 @@ impl<T: Timestamp, CB: ContainerBuilder<Container: Clone>> Handle<T, CB> {
         }
     }
 
-    /// Flush all contents and distribute to downstream operators.
+    /// Flush all contents, distribute them downstream, and close the current batch.
     #[inline]
     pub fn flush(&mut self) {
+        self.flush_builder();
+        self.flush_pushers();
+    }
+
+    fn flush_builder(&mut self) {
         while let Some(container) = self.builder.finish() {
             Self::send_container(container, &mut self.buffer, &mut self.pushers, &self.now_at);
         }
@@ -402,9 +407,6 @@ impl<T: Timestamp, CB: ContainerBuilder<Container: Clone>> Handle<T, CB> {
     // TODO: Find a better name for this function.
     fn close_epoch(&mut self) {
         self.flush();
-        for pusher in self.pushers.iter_mut() {
-            pusher.done();
-        }
         for progress in self.progress.iter() {
             progress.borrow_mut().update(self.now_at.clone(), -1);
         }
@@ -416,7 +418,8 @@ impl<T: Timestamp, CB: ContainerBuilder<Container: Clone>> Handle<T, CB> {
 
     /// Sends a batch of records into the corresponding timely dataflow [Stream], at the current epoch.
     ///
-    /// This method flushes single elements previously sent with `send`, to keep the insertion order.
+    /// This method flushes single elements previously sent with `send`, to keep the insertion order,
+    /// and closes the batch after sending it.
     ///
     /// # Examples
     /// ```
@@ -445,8 +448,15 @@ impl<T: Timestamp, CB: ContainerBuilder<Container: Clone>> Handle<T, CB> {
     pub fn send_batch(&mut self, buffer: &mut CB::Container) {
         if !buffer.is_empty() {
             // flush buffered elements to ensure local fifo.
-            self.flush();
+            self.flush_builder();
             Self::send_container(buffer, &mut self.buffer, &mut self.pushers, &self.now_at);
+            self.flush_pushers();
+        }
+    }
+
+    fn flush_pushers(&mut self) {
+        for pusher in self.pushers.iter_mut() {
+            pusher.done();
         }
     }
 

--- a/timely/tests/coalesced_input.rs
+++ b/timely/tests/coalesced_input.rs
@@ -1,0 +1,38 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use timely::dataflow::operators::{Input, Inspect};
+
+#[test]
+fn input_can_send_again_at_the_same_epoch_after_idle() {
+    timely::execute_directly(|worker| {
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let output = Rc::clone(&seen);
+        let (mut input, ()) = worker.dataflow::<u64, _, _>(|scope| {
+            let (input, stream) = scope.new_input::<Vec<u64>>();
+            stream.inspect(move |item| output.borrow_mut().push(*item));
+            (input, ())
+        });
+
+        input.send_batch(&mut vec![1]);
+        worker.step();
+        worker.step();
+        assert_eq!(&*seen.borrow(), &[1]);
+
+        input.send_batch(&mut vec![2]);
+        worker.step();
+        assert_eq!(&*seen.borrow(), &[1, 2]);
+
+        worker.step();
+        input.send(3);
+        input.flush();
+        worker.step();
+        assert_eq!(&*seen.borrow(), &[1, 2, 3]);
+
+        worker.step();
+        input.send(4);
+        input.flush();
+        worker.step();
+        assert_eq!(&*seen.borrow(), &[1, 2, 3, 4]);
+    });
+}


### PR DESCRIPTION
# Problem & Solution Overview

Timely's communication counters currently enqueue a channel activation for every pushed message and for the final `done()` call. The worker later sorts and deduplicates those channel IDs, so a batch of `N` messages creates `N + 1` notifications even though most collapse into one useful scheduling decision. This adds MPSC traffic, thread wake attempts, event-queue growth, and deduplication work under bursty or backpressured workloads.

Timely previously had done-only coalescing, but it was disabled because some producers did not reliably close batches and because waiting until `done()` delayed receiver pipelining. This change uses bounded coalescing instead: notify immediately for the first message, suppress intermediate notifications, and emit one trailing notification for a multi-message batch. Input `flush()` and `send_batch()` now establish explicit batch boundaries so same-epoch input remains responsive after a worker becomes idle.

## Summary

- Coalesce each pusher batch from `N + 1` notifications to one notification for a single-message batch or at most two for a multi-message batch.
- Preserve low latency by waking the receiver immediately on the first message.
- Preserve concurrent correctness with a trailing wake when later messages may arrive after the receiver drains the first wake.
- Make `InputHandle::flush()` and `send_batch()` close their batches; `send_batch()` closes exactly one combined buffered/direct batch.
- Document that `Push` implementations may coalesce follow-up notifications until `done()`.
- Add intra-thread, inter-thread, concurrent-tail, and same-epoch input regression tests.

## Details

- The first notification keeps producer/consumer pipelining intact. A done-only prototype roughly doubled latency in the large-batch `pingpong` scenario.
- A first-only design is not sufficient for inter-thread communication: the receiver can drain the first message and sleep before the rest of the batch arrives. The trailing notification closes that race.
- Empty `done()` calls produce no notification, and single-message batches do not need a trailing wake.
- Built-in output sessions already call `done()` when dropped. The input changes supply the missing boundaries identified in issue #243.
- Low-level callers that indefinitely ignore the documented `done()` boundary can still defer later messages after the first wake. Eliminating that requirement would need a more invasive receiver-acknowledged atomic state spanning allocator event delivery.
- The input change is intentionally coupled to counter coalescing. Under the new counters, closing `send_batch()` restores one notification per direct batch--the same useful activation behavior that per-message notification previously provided.

# Performance Results

The example syntax is `exchange <batch> <rounds> -w <workers>`:

- `batch` is the number of records inserted at each logical timestamp/epoch.
- `rounds` is the number of timestamps/epochs executed.
- `-w` is the number of Timely worker threads.

For example, `exchange 1 200000 -w 8` runs 200,000 one-record epochs across eight workers. This intentionally emphasizes per-batch notification and scheduling overhead rather than record-processing throughput.

Measurements used release builds on local macOS and alternated clean `master` and patched executions to reduce run-order bias.

## Notification hot-path microbenchmark

This synthetic benchmark wraps a no-op data pusher with the inter-thread counter and drains its notification channel on another thread. It measures only sender-side notification-channel sends and wake attempts; it does not execute Timely operators, progress tracking, exchange routing, serialization, or record processing.

| Metric | Clean `master` | Patched | Change |
|---|---:|---:|---:|
| Notifications per 64-message batch | 65 | 2 | **-96.9%** |
| Notifications over 100,000 batches | 6,500,000 | 200,000 | **-96.9%** |
| Sender-side elapsed time | approximately 43-60 ms | approximately 5-6 ms | **approximately 8-10x faster** |

This result establishes the direct mechanism-level saving. It is not an expected whole-dataflow speedup.

## End-to-end: controlled worker scaling

The batch size and epoch count are fixed at `exchange 1 200000`; only the worker count changes. Each row reports the median of ten runs per revision.

| Workers | Clean `master` median | Patched median | Change |
|---:|---:|---:|---:|
| 1 | 0.2398 s | 0.2369 s | **-1.2%** |
| 2 | 0.6334 s | 0.5685 s | **-10.3%** |
| 4 | 1.2820 s | 1.0093 s | **-21.3%** |
| 8 | 3.7745 s | 2.7881 s | **-26.1%** |

The near-neutral one-worker result is expected: it uses intra-thread delivery and avoids the MPSC sends and cross-thread wakeups targeted by the largest part of this change. The benefit grows with worker count as those costs become a larger share of each one-record epoch.

## End-to-end: larger record batch

This row reports the median of eight runs per revision and demonstrates that the change remains beneficial when useful record-processing work dominates notification overhead.

| Workload | Clean `master` median | Patched median | Change |
|---|---:|---:|---:|
| `exchange 100000 5000 -w 2` | 1.8094 s | 1.7709 s | **-2.1%** |

Steady-state `pingpong` remained neutral. The intended benefit is lower scheduling overhead and bounded notification backlog for frequent batch boundaries, bursty senders, and lagging receivers--not a claim that every Timely workload becomes faster.

## Result scope summary

| Benchmark | Scope measured | Result |
|---|---|---:|
| Notification microbenchmark | Counter event sends and wake attempts only | **approximately 8-10x faster** |
| `exchange 1 200000`, 1-8 workers | Complete notification-heavy Timely dataflow | **1.2% to 26.1% faster** |
| `exchange 100000 5000 -w 2` | Complete record-processing-heavy Timely dataflow | **2.1% faster** |
| Steady-state `pingpong` | Complete iterative latency workload | **Neutral** |

# Testing Done

This change added tests and was verified as follows:

## Testing Done

- [x] Local code review completed
- [x] Full Timely workspace test suite passes
- [x] Intra-thread and inter-thread notification batching covered
- [x] Concurrent tail-arrival race covered with bounded timeouts
- [x] Same-epoch `send_batch()` and explicit `flush()` reactivation covered

Validation completed:

- `cargo test --workspace --quiet`: **265 passed, 48 ignored, 0 failed**
- Clippy passes for `timely` and `timely_communication` with warnings denied after allowing only lint classes already present on clean `master` under the current Rust toolchain
- `cargo test -p timely_communication --test counters`
- `cargo test -p timely --test coalesced_input`
- `git diff --check`
- Controlled alternating clean-master/patched release sweep for 1, 2, 4, and 8 workers
- Larger-batch alternating clean-master/patched `exchange` benchmark
