### PR TITLE
Cheaper coordination among workers: poll before parking, fewer signals, serialize broadcasts once

### DIFF
--- a/communication/src/allocator/counters.rs
+++ b/communication/src/allocator/counters.rs
@@ -44,9 +44,13 @@ impl<T, P: Push<T>> Push<T> for Pusher<T, P> {
         // }
         // TODO: Version above is less chatty, but can be a bit late in
         //       moving information along. Better, but needs cooperation.
-        self.events
-            .borrow_mut()
-            .push(self.index);
+        // A `None` is a flush, and the wrapped pusher is unbuffered: nothing
+        // is enqueued, and so there is nothing to announce.
+        if element.is_some() {
+            self.events
+                .borrow_mut()
+                .push(self.index);
+        }
 
         self.pusher.push(element)
     }
@@ -90,6 +94,10 @@ impl<T, P: Push<T>> Push<T> for ArcPusher<T, P> {
         // else {
         //     self.count += 1;
         // }
+
+        // A `None` is a flush, and the wrapped pusher is unbuffered: nothing
+        // is enqueued, and so there is nothing to announce or to awaken for.
+        if element.is_none() { return; }
 
         // These three calls should happen in this order, to ensure that
         // we first enqueue data, second enqueue interest in the channel,

--- a/communication/src/allocator/process.rs
+++ b/communication/src/allocator/process.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use std::collections::{HashMap};
 use std::sync::mpsc::{Sender, Receiver};
 
-use crate::allocator::thread::{ThreadBuilder};
+use crate::allocator::thread::{ThreadBuilder, ThreadPuller};
 use crate::allocator::{Allocate, AllocateBuilder, PeerBuilder, Thread};
 use crate::{Push, Pull};
 use crate::buzzer::Buzzer;
@@ -170,16 +170,30 @@ impl Allocate for Process {
         use crate::allocator::counters::ArcPusher as CountPusher;
         use crate::allocator::counters::Puller as CountPuller;
 
+        // Messages a worker sends to itself take a thread-local queue rather
+        // than the shared channel, which would cost two cross-thread sends,
+        // a self-unpark, and two cross-thread receives, all for no reason.
+        let (local_send, local_recv) = Thread::new_from(identifier, Rc::clone(self.inner.events()));
+        let mut local_send = Some(local_send);
+
         let sends =
         sends.into_iter()
              .zip(self.counters_send.iter())
-             .map(|((s,b), sender)| CountPusher::new(s, identifier, sender.clone(), b))
-             .map(|s| Box::new(s) as Box<dyn Push<T>>)
+             .enumerate()
+             .map(|(target, ((s,b), sender))| {
+                if target == self.index {
+                    Box::new(local_send.take().expect("self pusher used twice")) as Box<dyn Push<T>>
+                }
+                else {
+                    Box::new(CountPusher::new(s, identifier, sender.clone(), b)) as Box<dyn Push<T>>
+                }
+             })
              .collect::<Vec<_>>();
 
-        let recv = Box::new(CountPuller::new(recv, identifier, Rc::clone(self.inner.events()))) as Box<dyn Pull<T>>;
+        let remote = CountPuller::new(recv, identifier, Rc::clone(self.inner.events()));
+        let puller = Box::new(LocalFirst { local: local_recv, remote }) as Box<dyn Pull<T>>;
 
-        (sends, recv)
+        (sends, puller)
     }
 
     fn events(&self) -> &Rc<RefCell<Vec<usize>>> {
@@ -225,6 +239,20 @@ impl<T> Push<T> for Pusher<T> {
 struct Puller<T> {
     current: Option<T>,
     source: Receiver<T>,
+}
+
+/// A puller that drains the worker's own pushes before those of other workers.
+struct LocalFirst<T> {
+    local: ThreadPuller<T>,
+    remote: crate::allocator::counters::Puller<T, Puller<T>>,
+}
+
+impl<T> Pull<T> for LocalFirst<T> {
+    #[inline]
+    fn pull(&mut self) -> &mut Option<T> {
+        let local = self.local.pull();
+        if local.is_some() { local } else { self.remote.pull() }
+    }
 }
 
 impl<T> Pull<T> for Puller<T> {

--- a/communication/src/allocator/zero_copy/allocator_process.rs
+++ b/communication/src/allocator/zero_copy/allocator_process.rs
@@ -10,13 +10,14 @@ use timely_bytes::arc::Bytes;
 use crate::networking::MessageHeader;
 
 use crate::{Allocate, Push, Pull};
-use crate::allocator::{AllocateBuilder, Exchangeable, PeerBuilder};
+use crate::allocator::{AllocateBuilder, Exchangeable, PeerBuilder, Thread};
+use crate::allocator::thread::ThreadPusher;
 use crate::allocator::canary::Canary;
 use crate::allocator::zero_copy::bytes_slab::BytesRefill;
 use crate::allocator::zero_copy::spill::SpillPolicyFn;
-use super::bytes_exchange::{BytesPull, SendEndpoint, MergeQueue};
+use super::bytes_exchange::{BytesPush, BytesPull, SendEndpoint, MergeQueue};
 
-use super::push_pull::{Pusher, Puller};
+use super::push_pull::{Pusher, Puller, PullerInner};
 
 /// Builds an instance of a ProcessAllocator.
 ///
@@ -100,6 +101,7 @@ impl ProcessBuilder {
             sends,
             recvs,
             to_local: HashMap::new(),
+            refill: self.refill,
         }
     }
 }
@@ -130,6 +132,58 @@ pub struct ProcessAllocator {
     sends:      Vec<Rc<RefCell<SendEndpoint<MergeQueue>>>>, // sends[x] -> goes to thread x.
     recvs:      Vec<MergeQueue>,                            // recvs[x] <- from thread x.
     to_local:   HashMap<usize, Rc<RefCell<VecDeque<Bytes>>>>,          // to worker-local typed pullers.
+    refill:     BytesRefill,                                // for staging buffers allocated after construction.
+}
+
+/// Delivers each pushed `Bytes` to several destinations, sharing the allocation.
+///
+/// Each destination receives a clone of the handle, a reference count rather
+/// than a copy, through its own endpoint so that ordering and any spill policy
+/// toward that destination are unaffected.
+struct Fanout {
+    targets: Vec<Rc<RefCell<SendEndpoint<MergeQueue>>>>,
+}
+
+impl BytesPush for Fanout {
+    fn extend<I: IntoIterator<Item=Bytes>>(&mut self, iterator: I) {
+        for bytes in iterator {
+            for target in self.targets.iter() {
+                target.borrow_mut().push_bytes(bytes.clone());
+            }
+        }
+    }
+}
+
+/// A pusher that serializes once for all other workers, and hands the element itself to this worker.
+struct BroadcastPusher<T: Exchangeable> {
+    local: ThreadPusher<T>,
+    remote: Option<Pusher<T, Fanout>>,
+}
+
+impl<T: Exchangeable> Push<T> for BroadcastPusher<T> {
+    fn push(&mut self, element: &mut Option<T>) {
+        // The serializing pusher reads the element and leaves it in place.
+        if let Some(remote) = self.remote.as_mut() { remote.push(element); }
+        self.local.push(element);
+    }
+}
+
+impl ProcessAllocator {
+    /// A thread-local queue for messages to this worker, and the puller that
+    /// drains it ahead of the bytes other workers send.
+    ///
+    /// Used for progress broadcasts, whose messages are small and never worth
+    /// paging out. Data channels keep the shared byte queue for self-sends, so
+    /// that a spill policy can apply to them.
+    fn local_channel<T: Exchangeable>(&mut self, identifier: usize) -> (ThreadPusher<T>, Box<dyn Pull<T>>) {
+        let (local_send, local_recv) = Thread::new_from(identifier, Rc::clone(&self.events));
+        let channel = Rc::clone(self.to_local.entry(identifier).or_default());
+        use crate::allocator::counters::Puller as CountPuller;
+        let canary = Canary::new(identifier, Rc::clone(&self.canaries));
+        let puller = PullerInner::new(Box::new(local_recv), channel, canary);
+        let puller = Box::new(CountPuller::new(puller, identifier, Rc::clone(&self.events)));
+        (local_send, puller)
+    }
 }
 
 impl Allocate for ProcessAllocator {
@@ -168,6 +222,34 @@ impl Allocate for ProcessAllocator {
         let puller = Box::new(CountPuller::new(Puller::new(channel, canary), identifier, Rc::clone(self.events())));
 
         (pushes, puller)
+    }
+
+    fn broadcast<T: Exchangeable + Clone>(&mut self, identifier: usize) -> (Box<dyn Push<T>>, Box<dyn Pull<T>>) {
+
+        // Assume and enforce in-order identifier allocation.
+        if let Some(bound) = self.channel_id_bound {
+            assert!(bound < identifier);
+        }
+        self.channel_id_bound = Some(identifier);
+
+        let (local, puller) = self.local_channel::<T>(identifier);
+
+        // Serialize once, and hand every other worker a reference to the bytes.
+        let targets: Vec<_> = (0 .. self.peers).filter(|&target| target != self.index).map(|target| Rc::clone(&self.sends[target])).collect();
+        let remote = if targets.is_empty() { None } else {
+            let header = MessageHeader {
+                channel:        identifier,
+                source:         self.index,
+                target_lower:   0,
+                target_upper:   self.peers,
+                length:         0,
+                seqno:          0,
+            };
+            let endpoint = SendEndpoint::new(Fanout { targets }, self.refill.clone());
+            Some(Pusher::new(header, Rc::new(RefCell::new(endpoint))))
+        };
+
+        (Box::new(BroadcastPusher { local, remote }), puller)
     }
 
     // Perform preparatory work, most likely reading binary buffers from self.recv.

--- a/communication/src/allocator/zero_copy/bytes_exchange.rs
+++ b/communication/src/allocator/zero_copy/bytes_exchange.rs
@@ -227,6 +227,14 @@ impl<P: BytesPush> SendEndpoint<P> {
     pub fn publish(&mut self) {
         self.send_buffer();
     }
+    /// Sends already-formed bytes, after anything staged so far.
+    ///
+    /// Staged bytes are sent first, so that the order of messages toward
+    /// the destination is the order in which they were pushed.
+    pub fn push_bytes(&mut self, bytes: Bytes) {
+        self.send_buffer();
+        self.send.extend(Some(bytes));
+    }
 }
 
 impl<P: BytesPush> Drop for SendEndpoint<P> {

--- a/timely/src/lib.rs
+++ b/timely/src/lib.rs
@@ -145,8 +145,11 @@ mod encoding {
     impl<T: Data> Bytesable for Bincode<T> {
         fn from_bytes(bytes: Bytes) -> Self {
             let typed = ::bincode::deserialize(&bytes[..]).expect("bincode::deserialize() failed");
-            let typed_size = ::bincode::serialized_size(&typed).expect("bincode::serialized_size() failed") as usize;
-            assert_eq!(bytes.len(), (typed_size + 7) & !7);
+            // Measuring the payload again costs a second traversal of it, on every receive.
+            #[cfg(debug_assertions)] {
+                let typed_size = ::bincode::serialized_size(&typed).expect("bincode::serialized_size() failed") as usize;
+                assert_eq!(bytes.len(), (typed_size + 7) & !7);
+            }
             Bincode { payload: typed }
         }
 

--- a/timely/src/worker.rs
+++ b/timely/src/worker.rs
@@ -78,15 +78,42 @@ impl FromStr for ProgressMode {
 }
 
 /// Worker configuration.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct Config {
     /// The progress mode to use.
     pub(crate) progress_mode: ProgressMode,
+    /// How long an idle worker polls for new events before parking its thread.
+    ///
+    /// Parking a thread and waking it again costs several microseconds, which
+    /// dominates the cost of fine-grained coordination among workers (for
+    /// example, a barrier per iteration of a loop). A worker with nothing to do
+    /// first polls its channels for this long, and parks only if nothing arrives.
+    /// The polling occupies a core, so the duration bounds the CPU an idle worker
+    /// burns each time it goes idle.
+    pub(crate) idle_spin: Duration,
     /// A map from parameter name to typed parameter values.
     registry: HashMap<String, Arc<dyn Any + Send + Sync>>,
 }
 
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            progress_mode: ProgressMode::default(),
+            idle_spin: Duration::from_micros(Self::DEFAULT_IDLE_SPIN_MICROS),
+            registry: HashMap::new(),
+        }
+    }
+}
+
 impl Config {
+    /// The default `idle_spin`, in microseconds.
+    ///
+    /// Parking and unparking a thread costs a few microseconds on common
+    /// platforms, so a worker that polls for this long before parking avoids
+    /// that cost for the short waits typical of tightly coupled workers, at
+    /// the expense of at most this much CPU each time it goes idle.
+    pub const DEFAULT_IDLE_SPIN_MICROS: u64 = 10;
+
     /// Installs options into a [getopts::Options] struct that correspond
     /// to the parameters in the configuration.
     ///
@@ -99,6 +126,7 @@ impl Config {
     #[cfg(feature = "getopts")]
     pub fn install_options(opts: &mut getopts::Options) {
         opts.optopt("", "progress-mode", "progress tracking mode (eager or demand)", "MODE");
+        opts.optopt("", "idle-spin", "microseconds an idle worker polls before parking", "MICROS");
     }
 
     /// Instantiates a configuration based upon the parsed options in `matches`.
@@ -113,12 +141,22 @@ impl Config {
     pub fn from_matches(matches: &getopts::Matches) -> Result<Config, String> {
         let progress_mode = matches
             .opt_get_default("progress-mode", ProgressMode::Demand)?;
-        Ok(Config::default().progress_mode(progress_mode))
+        let mut config = Config::default().progress_mode(progress_mode);
+        if let Some(micros) = matches.opt_get::<u64>("idle-spin").map_err(|e| e.to_string())? {
+            config = config.idle_spin(Duration::from_micros(micros));
+        }
+        Ok(config)
     }
 
     /// Sets the progress mode to `progress_mode`.
     pub fn progress_mode(mut self, progress_mode: ProgressMode) -> Self {
         self.progress_mode = progress_mode;
+        self
+    }
+
+    /// Sets how long an idle worker polls for events before parking.
+    pub fn idle_spin(mut self, idle_spin: Duration) -> Self {
+        self.idle_spin = idle_spin;
         self
     }
 
@@ -266,40 +304,29 @@ impl Worker {
     /// ```
     pub fn step_or_park(&mut self, duration: Option<Duration>) -> bool {
 
-        {   // Process channel events. Activate responders.
-            let mut allocator = self.allocator.borrow_mut();
-            allocator.receive();
-            let events = allocator.events();
-            let mut borrow = events.borrow_mut();
-            let paths = self.paths.borrow();
-            borrow.sort_unstable();
-            borrow.dedup();
-            for channel in borrow.drain(..) {
-                // Consider tracking whether a channel
-                // in non-empty, and only activating
-                // on the basis of non-empty channels.
-                // TODO: This is a sloppy way to deal
-                // with channels that may not be alloc'd.
-                if let Some(path) = paths.get(&channel) {
-                    self.activations
-                        .borrow_mut()
-                        .activate(&path[..]);
+        // Determine the minimum park duration, where `None` are an absence of a constraint.
+        let mut delay = self.poll_events(duration);
+
+        // An idle worker polls for a while before parking, as parking and
+        // unparking a thread costs more than a short wait usually lasts.
+        if delay != Some(Duration::new(0,0)) {
+            let budget = match delay {
+                Some(delay) => std::cmp::min(delay, self.config.idle_spin),
+                None => self.config.idle_spin,
+            };
+            if budget > Duration::new(0,0) {
+                let start = Instant::now();
+                let mut polls = 0u32;
+                loop {
+                    std::hint::spin_loop();
+                    delay = self.poll_events(duration);
+                    if delay == Some(Duration::new(0,0)) { break; }
+                    // Consult the clock only occasionally, as it is not free.
+                    polls = polls.wrapping_add(1);
+                    if polls % 16 == 0 && start.elapsed() >= budget { break; }
                 }
             }
         }
-
-        // Organize activations.
-        self.activations
-            .borrow_mut()
-            .advance();
-
-        // Consider parking only if we have no pending events, some dataflows, and a non-zero duration.
-        let empty_for = self.activations.borrow().empty_for();
-        // Determine the minimum park duration, where `None` are an absence of a constraint.
-        let delay = match (duration, empty_for) {
-            (Some(x), Some(y)) => Some(std::cmp::min(x,y)),
-            (x, y) => x.or(y),
-        };
 
         if delay != Some(Duration::new(0,0)) {
 
@@ -344,6 +371,48 @@ impl Worker {
         self.logging.as_ref().map(|l| l.borrow_mut().flush());
         self.allocator.borrow_mut().release();
         !self.dataflows.borrow().is_empty()
+    }
+
+    /// Surfaces channel events as activations, and reports how long the worker may idle.
+    ///
+    /// Returns the minimum of `duration` and the time until the next scheduled
+    /// activation, where `None` is an absence of any constraint, and `Some(0)`
+    /// means there is work to do now.
+    fn poll_events(&self, duration: Option<Duration>) -> Option<Duration> {
+
+        {   // Process channel events. Activate responders.
+            let mut allocator = self.allocator.borrow_mut();
+            allocator.receive();
+            let events = allocator.events();
+            let mut borrow = events.borrow_mut();
+            let paths = self.paths.borrow();
+            borrow.sort_unstable();
+            borrow.dedup();
+            for channel in borrow.drain(..) {
+                // Consider tracking whether a channel
+                // in non-empty, and only activating
+                // on the basis of non-empty channels.
+                // TODO: This is a sloppy way to deal
+                // with channels that may not be alloc'd.
+                if let Some(path) = paths.get(&channel) {
+                    self.activations
+                        .borrow_mut()
+                        .activate(&path[..]);
+                }
+            }
+        }
+
+        // Organize activations.
+        self.activations
+            .borrow_mut()
+            .advance();
+
+        // Consider parking only if we have no pending events, some dataflows, and a non-zero duration.
+        let empty_for = self.activations.borrow().empty_for();
+        match (duration, empty_for) {
+            (Some(x), Some(y)) => Some(std::cmp::min(x,y)),
+            (x, y) => x.or(y),
+        }
     }
 
     /// Calls `self.step()` as long as `func` evaluates to `true`.


### PR DESCRIPTION
Reduces the cost of fine-grained coordination among workers, using `examples/barrier.rs` as the yardstick: a loop whose only work is a progress round per iteration.

## Where the time went

With two to four workers a barrier iteration took 2.5 to 3.1 microseconds, and almost all of it was the OS: each worker parked once per iteration after sending its progress update, and each wake cost one to four microseconds (macOS, M4). A pure spin barrier across four threads on the same machine is about 100 ns; a park/unpark barrier is about 3 µs. A single worker's step is about 0.6 µs, mostly progress tracking, and is unchanged here.

Two smaller things showed up along the way. `Progcaster::send` flushes after each broadcast, and the counting pushers announced the flush to every peer with an events message and an unpark, so each update woke every peer twice. And a worker's message to itself went through the shared mpsc channels, or on the zero-copy path through a serialization, its own byte queue, a self-unpark, and a deserialization.

## Changes, one commit each

- **Poll before parking.** `WorkerConfig::idle_spin`, default 10 µs, `--idle-spin MICROS`. An idle worker polls its channels for at most this long and parks only if nothing arrives; zero restores the old behavior. Callers of `step()` never spin. The prologue of `step_or_park` is now `poll_events`, so the polling loop reuses it.
- **No signal on `push(None)`** in `ArcPusher` and the thread-local `Pusher`: nothing was enqueued, so there is nothing to announce or to wake for.
- **Self-sends take a thread-local queue** in the typed `Process` allocator (`LocalFirst`). Those queues were never spillable, so nothing is lost.
- **Zero-copy broadcast serializes once for local peers.** `ProcessAllocator` implements `broadcast`: one serialization into a staging buffer, and each other worker gets a clone of the `Bytes` handle through its own `SendEndpoint` via the new `push_bytes`, so per-destination ordering and spill policies are untouched. This is what `TcpAllocator::broadcast` already did per remote process. The worker's own copy stays typed, which is fine for progress messages; data channels keep the shared byte queue for self-sends so they remain pageable.
- **`Bincode::from_bytes` size re-check is debug-only.** It re-serialized every received payload to compare lengths.

## Numbers

Barrier, 1M iterations, wall seconds on an M4 (four performance cores):

| | w=1 | w=2 | w=3 | w=4 |
|---|---|---|---|---|
| master, typed | 0.58 | 3.3 | 2.7 | 2.6 |
| this branch, typed | 0.58 | 0.80 | 1.07 | 1.31 |
| master, `--zerocopy` | | 2.15 | 1.40 | 1.74 |
| this branch, `--zerocopy` | | 0.97 | 1.24 | 1.53 |

`examples/pingpong.rs` with 200k rounds and four workers: 1.5 s to 0.54 s typed, 0.76 s to 0.56 s zero-copy.

Even a 1 µs poll budget captures nearly all of the barrier gain; the default of 10 µs is there to cover slightly longer waits elsewhere.

## Things worth a reviewer's eye

- The default `idle_spin` is a policy change for every user: at most 10 µs of a core per idle transition, which is negligible for busy or fully idle workers but is measurable for a worker woken every 100 µs, and it delays workers with real work in oversubscribed deployments. `Config::default()` is now written out to carry the default.
- With `--idle-spin 0` the `None` change makes three and four typed workers slower than master, because the redundant wakeups had been acting as an accidental spin. I kept it since it is strictly less work and the default covers it.
- `Config` loses `derive(Default)`; the manual impl is equivalent apart from the new field.

Not included, measured and shelved for now: `ChangeBatch` backed by `Vec` (−22% at one worker, but an API change and an allocation per message), a total-order fast path for `MutableAntichain`, and a sorted worklist in the reachability tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDsLC46QQW9aBrksaWad6T
