### PR TITLE
InputCapability::time() requires TotalOrder and returns Option

### DIFF
--- a/mdbook/src/chapter_1/chapter_1_2.md
+++ b/mdbook/src/chapter_1/chapter_1_2.md
@@ -26,7 +26,7 @@ Let's change the program to print out the timestamp with each record. This shoul
 # }
 ```
 
-with a slightly more complicated operator, `inspect_batch`.
+with a slightly more complicated operator, `inspect_core`.
 
 ```rust
 # extern crate timely;
@@ -36,9 +36,11 @@ with a slightly more complicated operator, `inspect_batch`.
 #     let index = scope.index();
 #     (0..10u64).to_stream(scope)
 #         .container::<Vec<_>>()
-.inspect_batch(move |t,xs| {
-    for x in xs.iter() {
-        println!("worker {}:\thello {} @ {:?}", index, x, t)
+.inspect_core(move |event| {
+    if let Ok((stamp, xs)) = event {
+        for x in xs.iter() {
+            println!("worker {}:\thello {} @ {:?}", index, x, stamp.elements())
+        }
     }
 })
 # ;
@@ -46,7 +48,7 @@ with a slightly more complicated operator, `inspect_batch`.
 # }
 ```
 
-The `inspect_batch` operator gets lower-level access to data in timely dataflow, in particular access to batches of records with the same timestamp. It is intended for diagnosing system-level details, but we can also use it to see what timestamps accompany the data.
+The `inspect_core` operator gets lower-level access to data in timely dataflow, in particular access to batches of records that travel together, along with the stamp of timestamps that accompanies them (usually just one timestamp). It also reports changes to the frontier, which we ignore here. It is intended for diagnosing system-level details, but we can also use it to see what timestamps accompany the data.
 
 The output we get with two workers is now:
 
@@ -54,16 +56,16 @@ The output we get with two workers is now:
     Echidnatron% cargo run --example hello -- -w2
         Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
         Running `target/debug/examples/hello -w2`
-    worker 1:	hello 1 @ 1
-    worker 1:	hello 3 @ 3
-    worker 1:	hello 5 @ 5
-    worker 0:	hello 0 @ 0
-    worker 0:	hello 2 @ 2
-    worker 0:	hello 4 @ 4
-    worker 0:	hello 6 @ 6
-    worker 0:	hello 8 @ 8
-    worker 1:	hello 7 @ 7
-    worker 1:	hello 9 @ 9
+    worker 1:	hello 1 @ [1]
+    worker 1:	hello 3 @ [3]
+    worker 1:	hello 5 @ [5]
+    worker 0:	hello 0 @ [0]
+    worker 0:	hello 2 @ [2]
+    worker 0:	hello 4 @ [4]
+    worker 0:	hello 6 @ [6]
+    worker 0:	hello 8 @ [8]
+    worker 1:	hello 7 @ [7]
+    worker 1:	hello 9 @ [9]
     Echidnatron%
 ```
 

--- a/mdbook/src/chapter_2/chapter_2_2.md
+++ b/mdbook/src/chapter_2/chapter_2_2.md
@@ -25,7 +25,7 @@ This simple example turns the sequence zero through nine into a stream and then 
 
 ## Inspecting Batches
 
-The `inspect` operator has a big sibling, `inspect_batch`, whose closure gets access to whole batches of records at a time, just like the underlying operator. More precisely, `inspect_batch` takes a closure of two parameters: first, the timestamp of a batch, and second a reference to the batch itself. The `inspect_batch` operator can be especially helpful if you want to process the outputs more efficiently.
+The `inspect` operator has a big sibling, `inspect_core`, whose closure gets access to whole batches of records at a time, just like the underlying operator. More precisely, `inspect_core` takes a closure of one parameter, a `Result` that is either `Ok` with the stamp of a batch (the timestamps it travels under, usually just one) and a reference to the batch itself, or `Err` with a new frontier. The `inspect_core` operator can be especially helpful if you want to process the outputs more efficiently.
 
 ```rust
 extern crate timely;
@@ -38,7 +38,7 @@ fn main() {
             (0 .. 10)
                 .to_stream(scope)
                 .container::<Vec<_>>()
-                .inspect_batch(|t, xs| println!("hello: {:?} @ {:?}", xs, t));
+                .inspect_core(|event| if let Ok((stamp, xs)) = event { println!("hello: {:?} @ {:?}", xs, stamp.elements()) });
         });
     }).unwrap();
 }

--- a/mdbook/src/chapter_2/chapter_2_4.md
+++ b/mdbook/src/chapter_2/chapter_2_4.md
@@ -19,8 +19,8 @@ fn main() {
             .container::<Vec<_>>()
             .unary(Pipeline, "increment", |capability, info| {
                 move |input, output| {
-                    input.for_each_time(|time, data| {
-                        let mut session = output.session(&time);
+                    input.for_each_stamp(|cap, data| {
+                        let mut session = output.session(&cap);
                         for datum in data.flat_map(|d| d.drain(..)) {
                             session.give(datum + 1);
                         }
@@ -38,7 +38,7 @@ Most of what is interesting lies in the closure, so let's first tidy up some loo
 
 The heart of the logic lies in the closure that binds `input` and `output`. These two are handles respectively to the operator's input (from which it can read records) and the operator's output (to which it can send records).
 
-The input handle `input` has one primary method, `for_each_time`, which is invoked for each distinct timestamp with a `CapabilityRef<Timestamp>` and a list of batches of data.
+The input handle `input` has one primary method, `for_each_stamp`, which is invoked for each distinct stamp (the set of timestamps under which a message travels, usually just one) with an `InputCapability<Timestamp>` and a list of batches of data.
 This method should be called each scheduling invocation, if nothing else to move the batches of data from the input to some operator-local storage.
 
 The output handle `output` has one primary method, `session`, which starts up an output session at the indicated time. The resulting session can be given data in various ways: (i) an element at a time with `give`, (ii) an iterator at a time with `give_iterator`, and (iii) a container at a time with `give_container`. Internally it is buffering up the output and flushing automatically when the session goes out of scope, which happens above when we go around the `while` loop.
@@ -145,8 +145,8 @@ fn main() {
                 let mut maximum = 0;    // define this here; use in the closure
 
                 move |input, output| {
-                    input.for_each_time(|time, data| {
-                        let mut session = output.session(&time);
+                    input.for_each_stamp(|cap, data| {
+                        let mut session = output.session(&cap);
                         for datum in data.flat_map(|d| d.drain(..)) {
                             if datum > maximum {
                                 session.give(datum + 1);
@@ -197,17 +197,21 @@ fn main() {
             let mut stash = HashMap::new();
 
             move |(input1, frontier1), (input2, frontier2), output| {
-                input1.for_each_time(|time, data| {
-                    stash.entry(time.time().clone())
-                         .or_insert(Vec::new())
-                         .extend(data.map(std::mem::take));
-                    notificator.notify_at(time.retain(output.output_index()));
+                input1.for_each_stamp(|cap, data| {
+                    if let Some(cap) = cap.retain_least(output.output_index()) {
+                        stash.entry(cap.time().clone())
+                             .or_insert(Vec::new())
+                             .extend(data.map(std::mem::take));
+                        notificator.notify_at(cap);
+                    }
                 });
-                input2.for_each_time(|time, data| {
-                    stash.entry(time.time().clone())
-                         .or_insert(Vec::new())
-                         .extend(data.map(std::mem::take));
-                    notificator.notify_at(time.retain(output.output_index()));
+                input2.for_each_stamp(|cap, data| {
+                    if let Some(cap) = cap.retain_least(output.output_index()) {
+                        stash.entry(cap.time().clone())
+                             .or_insert(Vec::new())
+                             .extend(data.map(std::mem::take));
+                        notificator.notify_at(cap);
+                    }
                 });
 
                 notificator.for_each(&[frontier1, frontier2], |time, notificator| {
@@ -248,15 +252,19 @@ fn main() {
 
             move |(input1, frontier1), (input2, frontier2), output| {
 
-                input1.for_each_time(|time, data| {
-                    stash.entry(time.retain(output.output_index()))
-                         .or_insert(Vec::new())
-                         .extend(data.map(std::mem::take));
+                input1.for_each_stamp(|cap, data| {
+                    if let Some(cap) = cap.retain_least(output.output_index()) {
+                        stash.entry(cap)
+                             .or_insert(Vec::new())
+                             .extend(data.map(std::mem::take));
+                    }
                 });
-                input2.for_each_time(|time, data| {
-                    stash.entry(time.retain(output.output_index()))
-                         .or_insert(Vec::new())
-                         .extend(data.map(std::mem::take));
+                input2.for_each_stamp(|cap, data| {
+                    if let Some(cap) = cap.retain_least(output.output_index()) {
+                        stash.entry(cap)
+                             .or_insert(Vec::new())
+                             .extend(data.map(std::mem::take));
+                    }
                 });
 
                 // consider sending everything in `stash`.

--- a/mdbook/src/chapter_2/chapter_2_5.md
+++ b/mdbook/src/chapter_2/chapter_2_5.md
@@ -236,10 +236,12 @@ As before, I'm just going to show you the new code, which now lives just after `
                     move |(input, frontier), output| {
 
                         // for each input batch, stash it at `time`.
-                        input.for_each_time(|time, data| {
-                            queues.entry(time.retain(output.output_index()))
-                                  .or_insert(Vec::new())
-                                  .extend(data.flat_map(|d| d.drain(..)));
+                        input.for_each_stamp(|cap, data| {
+                            if let Some(cap) = cap.retain_least(output.output_index()) {
+                                queues.entry(cap)
+                                      .or_insert(Vec::new())
+                                      .extend(data.flat_map(|d| d.drain(..)));
+                            }
                         });
 
                         // enable each stashed time if ready.
@@ -321,14 +323,16 @@ Inside the closure, we do two things: (i) read inputs and (ii) update counts and
 
 ```rust,ignore
         // for each input batch, stash it at `time`.
-        while let Some((time, data)) = input.next() {
-            queues.entry(time.retain(output.output_index()))
-                  .or_insert(Vec::new())
-                  .extend(std::mem::take(data));
-        }
+        input.for_each_stamp(|cap, data| {
+            if let Some(cap) = cap.retain_least(output.output_index()) {
+                queues.entry(cap)
+                      .or_insert(Vec::new())
+                      .extend(data.flat_map(|d| d.drain(..)));
+            }
+        });
 ```
 
-The `input` handle has a `next` method, and it optionally returns a pair of `time` and `data`, representing a timely dataflow timestamp and a hunk of data bearing that timestamp, respectively. Our plan is to iterate through all available input (the `next()` method doesn't block, it just returns `None` when it runs out of data), accepting it from the timely dataflow system and moving it into our `queue` hash map.
+The `input` handle has a `for_each_stamp` method, which calls our closure with a capability `cap` and the batches of `data` received under it, once for each distinct stamp (the set of timestamps under which a message travels, usually just one). Our plan is to accept all available input (the method doesn't block; it just stops when it runs out of data) and move it into our `queue` hash map, keyed by a capability for the least time of the stamp. A message sent under no capabilities has no such time, and we let it go.
 
 Why do we do this? Because this is a streaming system, we could be getting data out of order. Our goal is to update the counts in time order, and to do this we'll need to enqueue what we get until we also get word that the associated `time` is complete. That happens in the next few hunks of code
 

--- a/mdbook/src/chapter_4/chapter_4_1.md
+++ b/mdbook/src/chapter_4/chapter_4_1.md
@@ -58,7 +58,7 @@ fn main() {
         // Create a new scope with the same (u64) timestamp.
         let result = scope.scoped::<u64,_,_>("SubScope", |subscope| {
             stream.enter(subscope)
-                  .inspect_batch(|t, xs| println!("{:?}, {:?}", t, xs))
+                  .inspect_core(|event| if let Ok((stamp, xs)) = event { println!("{:?}, {:?}", stamp.elements(), xs) })
                   .leave(scope)
         });
 
@@ -90,7 +90,7 @@ fn main() {
         // Create a new scope with the same (u64) timestamp.
         let result = scope.region(|subscope| {
             stream.enter(subscope)
-                  .inspect_batch(|t, xs| println!("{:?}, {:?}", t, xs))
+                  .inspect_core(|event| if let Ok((stamp, xs)) = event { println!("{:?}, {:?}", stamp.elements(), xs) })
                   .leave(scope)
         });
 
@@ -122,7 +122,7 @@ fn main() {
         // Create a new scope with a (u64, u32) timestamp.
         let result = scope.iterative::<u32,_,_>(|subscope| {
             stream.enter(subscope)
-                  .inspect_batch(|t, xs| println!("{:?}, {:?}", t, xs))
+                  .inspect_core(|event| if let Ok((stamp, xs)) = event { println!("{:?}, {:?}", stamp.elements(), xs) })
                   .leave(scope)
         });
 

--- a/mdbook/src/chapter_4/chapter_4_3.md
+++ b/mdbook/src/chapter_4/chapter_4_3.md
@@ -82,10 +82,12 @@ fn main() {
                 move |(input1, frontier1), (input2, frontier2), output| {
 
                     // Stash received data.
-                    input1.for_each_time(|time, data| {
-                        stash.entry(time.retain(output.output_index()))
-                             .or_insert(Vec::new())
-                             .extend(data.flat_map(|d| d.drain(..)));
+                    input1.for_each_stamp(|cap, data| {
+                        if let Some(cap) = cap.retain_least(output.output_index()) {
+                            stash.entry(cap)
+                                 .or_insert(Vec::new())
+                                 .extend(data.flat_map(|d| d.drain(..)));
+                        }
                     });
 
                     // Consider sending stashed data.

--- a/timely/examples/bfs.rs
+++ b/timely/examples/bfs.rs
@@ -56,18 +56,22 @@ fn main() {
 
                     // receive edges, start to sort them
                     input1.for_each_time(|time, data| {
-                        notify.notify_at(time.retain(output.output_index()));
-                        edge_list.extend(data.map(std::mem::take));
+                        if let Some(cap) = time.retain(output.output_index()) {
+                            notify.notify_at(cap);
+                            edge_list.extend(data.map(std::mem::take));
+                        }
                     });
 
                     // receive (node, worker) pairs, note any new ones.
                     input2.for_each_time(|time, data| {
-                        node_lists.entry(*time.time())
-                                  .or_insert_with(|| {
-                                      notify.notify_at(time.retain(output.output_index()));
-                                      Vec::new()
-                                  })
-                                  .extend(data.map(std::mem::take));
+                        if let Some(cap) = time.retain(output.output_index()) {
+                            node_lists.entry(*cap.time())
+                                      .or_insert_with(|| {
+                                          notify.notify_at(cap);
+                                          Vec::new()
+                                      })
+                                      .extend(data.map(std::mem::take));
+                        }
                     });
 
                     notify.for_each(|time, _num, _notify| {

--- a/timely/examples/bfs.rs
+++ b/timely/examples/bfs.rs
@@ -55,16 +55,16 @@ fn main() {
                 move |input1, input2, output, notify| {
 
                     // receive edges, start to sort them
-                    input1.for_each_time(|time, data| {
-                        if let Some(cap) = time.retain(output.output_index()) {
+                    input1.for_each_stamp(|cap, data| {
+                        if let Some(cap) = cap.retain_least(output.output_index()) {
                             notify.notify_at(cap);
                             edge_list.extend(data.map(std::mem::take));
                         }
                     });
 
                     // receive (node, worker) pairs, note any new ones.
-                    input2.for_each_time(|time, data| {
-                        if let Some(cap) = time.retain(output.output_index()) {
+                    input2.for_each_stamp(|cap, data| {
+                        if let Some(cap) = cap.retain_least(output.output_index()) {
                             node_lists.entry(*cap.time())
                                       .or_insert_with(|| {
                                           notify.notify_at(cap);
@@ -74,10 +74,10 @@ fn main() {
                         }
                     });
 
-                    notify.for_each(|time, _num, _notify| {
+                    notify.for_each(|cap, _num, _notify| {
 
                         // maybe process the graph
-                        if *time == 0 {
+                        if *cap.time() == 0 {
 
                             // print some diagnostic timing information
                             if index == 0 { println!("{:?}:\tsorting", start.elapsed()); }
@@ -111,10 +111,10 @@ fn main() {
                         }
 
                         // print some diagnostic timing information
-                        if index == 0 { println!("{:?}:\ttime: {:?}", start.elapsed(), time.time()); }
+                        if index == 0 { println!("{:?}:\ttime: {:?}", start.elapsed(), cap.time()); }
 
-                        if let Some(mut todo) = node_lists.remove(&time) {
-                            let mut session = output.session(&time);
+                        if let Some(mut todo) = node_lists.remove(cap.time()) {
+                            let mut session = output.session(&cap);
 
                             // we could sort these, or not (previously: radix sorted).
                             // todo.sort();

--- a/timely/examples/columnar.rs
+++ b/timely/examples/columnar.rs
@@ -44,8 +44,8 @@ fn main() {
                     "Split",
                     |_cap, _info| {
                         move |input, output| {
-                            input.for_each_time(|time, data| {
-                                let mut session = output.session(&time);
+                            input.for_each_stamp(|cap, data| {
+                                let mut session = output.session(&cap);
                                 for data in data {
                                     for wordcount in data.borrow().into_index_iter().flat_map(|wordcount| {
                                         wordcount.text.split(|b| b.is_ascii_whitespace()).filter(|s| !s.is_empty()).map(move |text| WordCountReference { text, diff: wordcount.diff })
@@ -66,8 +66,8 @@ fn main() {
                         let mut counts = HashMap::new();
 
                         move |(input, frontier), output| {
-                            input.for_each_time(|time, data| {
-                                if let Some(cap) = time.retain(output.output_index()) {
+                            input.for_each_stamp(|cap, data| {
+                                if let Some(cap) = cap.retain_least(output.output_index()) {
                                     queues
                                         .entry(cap)
                                         .or_insert(Vec::new())

--- a/timely/examples/columnar.rs
+++ b/timely/examples/columnar.rs
@@ -7,7 +7,7 @@ use timely::Accountable;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::{ExchangeCore, Pipeline};
 use timely::dataflow::InputHandle;
-use timely::dataflow::operators::{InspectCore, Operator, Probe};
+use timely::dataflow::operators::{Inspect, Operator, Probe};
 use timely::dataflow::ProbeHandle;
 
 // Creates `WordCountContainer` and `WordCountReference` structs,
@@ -101,7 +101,7 @@ fn main() {
                     },
                 )
                 .container::<Container>()
-                .inspect_container(|x| {
+                .inspect_core(|x| {
                     match x {
                         Ok((time, data)) => {
                             println!("seen at: {:?}\t{:?} records", time, data.record_count());

--- a/timely/examples/columnar.rs
+++ b/timely/examples/columnar.rs
@@ -67,10 +67,12 @@ fn main() {
 
                         move |(input, frontier), output| {
                             input.for_each_time(|time, data| {
-                                queues
-                                    .entry(time.retain(output.output_index()))
-                                    .or_insert(Vec::new())
-                                    .extend(data.map(std::mem::take));
+                                if let Some(cap) = time.retain(output.output_index()) {
+                                    queues
+                                        .entry(cap)
+                                        .or_insert(Vec::new())
+                                        .extend(data.map(std::mem::take));
+                                }
 
                             });
 

--- a/timely/examples/distinct.rs
+++ b/timely/examples/distinct.rs
@@ -19,18 +19,20 @@ fn main() {
                 .unary(Exchange::new(|x| *x), "Distinct", move |_, _|
                     move |input, output| {
                         input.for_each_time(|time, data| {
-                            let counts =
-                            counts_by_time
-                                .entry(*time.time())
-                                .or_insert(HashMap::new());
-                            let mut session = output.session(&time);
-                            for data in data {
-                                for &datum in data.iter() {
-                                    let count = counts.entry(datum).or_insert(0);
-                                    if *count == 0 {
-                                        session.give(datum);
+                            if let Some(&t) = time.time() {
+                                let counts =
+                                counts_by_time
+                                    .entry(t)
+                                    .or_insert(HashMap::new());
+                                let mut session = output.session(&time);
+                                for data in data {
+                                    for &datum in data.iter() {
+                                        let count = counts.entry(datum).or_insert(0);
+                                        if *count == 0 {
+                                            session.give(datum);
+                                        }
+                                        *count += 1;
                                     }
-                                    *count += 1;
                                 }
                             }
                         })

--- a/timely/examples/distinct.rs
+++ b/timely/examples/distinct.rs
@@ -18,13 +18,13 @@ fn main() {
             scope.input_from(&mut input)
                 .unary(Exchange::new(|x| *x), "Distinct", move |_, _|
                     move |input, output| {
-                        input.for_each_time(|time, data| {
-                            if let Some(&t) = time.time() {
+                        input.for_each_stamp(|cap, data| {
+                            if let Some(&t) = cap.least() {
                                 let counts =
                                 counts_by_time
                                     .entry(t)
                                     .or_insert(HashMap::new());
-                                let mut session = output.session(&time);
+                                let mut session = output.session(&cap);
                                 for data in data {
                                     for &datum in data.iter() {
                                         let count = counts.entry(datum).or_insert(0);

--- a/timely/examples/flow_controlled.rs
+++ b/timely/examples/flow_controlled.rs
@@ -26,7 +26,7 @@ fn main() {
                     }
                 },
                 probe_handle_2)
-            .inspect_time(|t, d| eprintln!("@ {:?}: {:?}", t, d))
+            .inspect(|d| eprintln!("{:?}", d))
             .probe_with(&probe_handle);
         });
     }).unwrap();

--- a/timely/examples/hashjoin.rs
+++ b/timely/examples/hashjoin.rs
@@ -38,8 +38,8 @@ fn main() {
                     move |input1, input2, output| {
 
                         // Drain first input, check second map, update first map.
-                        input1.for_each_time(|time, data| {
-                            let mut session = output.session(&time);
+                        input1.for_each_stamp(|cap, data| {
+                            let mut session = output.session(&cap);
                             for (key, val1) in data.flat_map(|d| d.drain(..)) {
                                 if let Some(values) = map2.get(&key) {
                                     for val2 in values.iter() {
@@ -52,8 +52,8 @@ fn main() {
                         });
 
                         // Drain second input, check first map, update second map.
-                        input2.for_each_time(|time, data| {
-                            let mut session = output.session(&time);
+                        input2.for_each_stamp(|cap, data| {
+                            let mut session = output.session(&cap);
                             for (key, val2) in data.flat_map(|d| d.drain(..)) {
                                 if let Some(values) = map1.get(&key) {
                                     for val1 in values.iter() {

--- a/timely/examples/pagerank.rs
+++ b/timely/examples/pagerank.rs
@@ -43,16 +43,16 @@ fn main() {
                     move |(input1, frontier1), (input2, frontier2), output| {
 
                         // hold on to edge changes until it is time.
-                        input1.for_each_time(|time, data| {
-                            if let Some(cap) = time.retain(output.output_index()) {
+                        input1.for_each_stamp(|cap, data| {
+                            if let Some(cap) = cap.retain_least(output.output_index()) {
                                 let entry = edge_stash.entry(cap).or_default();
                                 data.for_each(|data| entry.append(data));
                             }
                         });
 
                         // hold on to rank changes until it is time.
-                        input2.for_each_time(|time, data| {
-                            if let Some(cap) = time.retain(output.output_index()) {
+                        input2.for_each_stamp(|cap, data| {
+                            if let Some(cap) = cap.retain_least(output.output_index()) {
                                 let entry = rank_stash.entry(cap).or_default();
                                 data.for_each(|data| entry.append(data));
                             }

--- a/timely/examples/pagerank.rs
+++ b/timely/examples/pagerank.rs
@@ -44,14 +44,18 @@ fn main() {
 
                         // hold on to edge changes until it is time.
                         input1.for_each_time(|time, data| {
-                            let entry = edge_stash.entry(time.retain(output.output_index())).or_default();
-                            data.for_each(|data| entry.append(data));
+                            if let Some(cap) = time.retain(output.output_index()) {
+                                let entry = edge_stash.entry(cap).or_default();
+                                data.for_each(|data| entry.append(data));
+                            }
                         });
 
                         // hold on to rank changes until it is time.
                         input2.for_each_time(|time, data| {
-                            let entry = rank_stash.entry(time.retain(output.output_index())).or_default();
-                            data.for_each(|data| entry.append(data));
+                            if let Some(cap) = time.retain(output.output_index()) {
+                                let entry = rank_stash.entry(cap).or_default();
+                                data.for_each(|data| entry.append(data));
+                            }
                         });
 
                         let frontiers = &[frontier1, frontier2];

--- a/timely/examples/unionfind.rs
+++ b/timely/examples/unionfind.rs
@@ -64,8 +64,8 @@ impl<'scope, T: Timestamp> UnionFind for StreamVec<'scope, T, (usize, usize)> {
 
             move |input, output| {
 
-                input.for_each_time(|time, data| {
-                    let mut session = output.session(&time);
+                input.for_each_stamp(|cap, data| {
+                    let mut session = output.session(&cap);
                     for &mut (mut x, mut y) in data.flatten() {
 
                         // grow arrays if required.

--- a/timely/examples/unordered_input.rs
+++ b/timely/examples/unordered_input.rs
@@ -5,7 +5,7 @@ fn main() {
     timely::execute(Config::thread(), |worker| {
         let (mut input, mut cap) = worker.dataflow::<usize,_,_>(|scope| {
             let (input, stream) = scope.new_unordered_input();
-            stream.container::<Vec<_>>().inspect_batch(|t, x| println!("{:?} -> {:?}", t, x));
+            stream.container::<Vec<_>>().inspect_core(|e| if let Ok((s, x)) = e { println!("{:?} -> {:?}", s, x) });
             input
         });
 

--- a/timely/examples/wordcount.rs
+++ b/timely/examples/wordcount.rs
@@ -29,8 +29,8 @@ fn main() {
                     let mut counts = HashMap::new();
 
                     move |(input, frontier), output| {
-                        input.for_each_time(|time, data| {
-                            if let Some(cap) = time.retain(output.output_index()) {
+                        input.for_each_stamp(|cap, data| {
+                            if let Some(cap) = cap.retain_least(output.output_index()) {
                                 queues.entry(cap)
                                       .or_insert(Vec::new())
                                       .extend(data.map(std::mem::take));

--- a/timely/examples/wordcount.rs
+++ b/timely/examples/wordcount.rs
@@ -30,9 +30,11 @@ fn main() {
 
                     move |(input, frontier), output| {
                         input.for_each_time(|time, data| {
-                            queues.entry(time.retain(output.output_index()))
-                                  .or_insert(Vec::new())
-                                  .extend(data.map(std::mem::take));
+                            if let Some(cap) = time.retain(output.output_index()) {
+                                queues.entry(cap)
+                                      .or_insert(Vec::new())
+                                      .extend(data.map(std::mem::take));
+                            }
                         });
 
                         for (key, val) in queues.iter_mut() {

--- a/timely/src/dataflow/operators/capability.rs
+++ b/timely/src/dataflow/operators/capability.rs
@@ -286,12 +286,12 @@ impl<T: Timestamp> InputCapability<T> {
     /// have no such element; operators over them must read the whole
     /// [`InputCapability::stamp`] and forward each of its elements.
     ///
-    /// Messages sent under no capabilities have an empty stamp and no time to report. An
-    /// operator that needs a time should `if let Some(time) = cap.time()` and drop such
+    /// Messages sent under no capabilities have an empty stamp and no least element. An
+    /// operator that needs a time should `if let Some(time) = cap.least()` and drop such
     /// messages otherwise; they make no progress claims, and may arrive after the frontier
     /// has passed every time in their contents.
     #[inline]
-    pub fn time(&self) -> Option<&T> where T: TotalOrder {
+    pub fn least(&self) -> Option<&T> where T: TotalOrder {
         self.stamp().least()
     }
 
@@ -328,8 +328,8 @@ impl<T: Timestamp> InputCapability<T> {
     ///
     /// This method panics if the timestamp summary to `output_port` strictly advances the time.
     #[inline]
-    pub fn retain(&self, output_port: usize) -> Option<Capability<T>> where T: TotalOrder {
-        self.time().map(|time| self.delayed(time, output_port))
+    pub fn retain_least(&self, output_port: usize) -> Option<Capability<T>> where T: TotalOrder {
+        self.least().map(|time| self.delayed(time, output_port))
     }
 
     /// Transforms to an owned capability set for a specific output port, with one
@@ -445,7 +445,7 @@ impl<T: Timestamp> CapabilitySet<T> {
     ///             let mut cap = CapabilitySet::from_elem(default_cap);
     ///             move |(input, frontier), output| {
     ///                 cap.downgrade(&frontier.frontier());
-    ///                 input.for_each_time(|time, data| {});
+    ///                 input.for_each_stamp(|cap, data| {});
     ///                 let a_cap = cap.first();
     ///                 if let Some(a_cap) = a_cap.as_ref() {
     ///                     output.session(a_cap).give(());

--- a/timely/src/dataflow/operators/capability.rs
+++ b/timely/src/dataflow/operators/capability.rs
@@ -26,7 +26,7 @@ use std::rc::Rc;
 use std::cell::{OnceCell, RefCell};
 use std::fmt::{self, Debug};
 
-use crate::order::PartialOrder;
+use crate::order::{PartialOrder, TotalOrder};
 use crate::progress::Timestamp;
 use crate::progress::{ChangeBatch, Stamp};
 use crate::progress::operate::PortConnectivity;
@@ -278,14 +278,21 @@ impl<T: Timestamp> InputCapability<T> {
         self.consumed_guard.stamp()
     }
 
-    /// The timestamp associated with this capability.
+    /// The least timestamp of the message's stamp, if the stamp is non-empty.
     ///
-    /// This method panics if the message's stamp is not a singleton, as is the case
-    /// when an upstream operator sends messages stamped by multiple timestamps, or by
-    /// none at all. Such messages must be accessed through [`InputCapability::stamp`].
+    /// This method exists only for totally ordered timestamps, where every non-empty stamp
+    /// has a least element: the time at which the message may first result in downstream
+    /// work, and the time at which to hold a capability for it. Partially ordered timestamps
+    /// have no such element; operators over them must read the whole
+    /// [`InputCapability::stamp`] and forward each of its elements.
+    ///
+    /// Messages sent under no capabilities have an empty stamp and no time to report. An
+    /// operator that needs a time should `if let Some(time) = cap.time()` and drop such
+    /// messages otherwise; they make no progress claims, and may arrive after the frontier
+    /// has passed every time in their contents.
     #[inline]
-    pub fn time(&self) -> &T {
-        self.stamp().expect_singleton()
+    pub fn time(&self) -> Option<&T> where T: TotalOrder {
+        self.stamp().least()
     }
 
     /// Delays capability for a specific output port.
@@ -314,12 +321,15 @@ impl<T: Timestamp> InputCapability<T> {
     /// capability. Users should take care that these capabilities are only stored for
     /// as long as they are required, as failing to drop them may result in livelock.
     ///
-    /// This method panics if the message's stamp is not a singleton, or if the timestamp
-    /// summary to `output_port` strictly advances the time. Stamps with zero or multiple
-    /// elements must be retained with [`InputCapability::retain_stamp`].
+    /// The capability is for the least element of the stamp, and so exists only for totally
+    /// ordered timestamps; partially ordered timestamps must be retained with
+    /// [`InputCapability::retain_stamp`], which holds a capability for each element. An
+    /// empty stamp yields no capability.
+    ///
+    /// This method panics if the timestamp summary to `output_port` strictly advances the time.
     #[inline]
-    pub fn retain(&self, output_port: usize) -> Capability<T> {
-        self.delayed(self.time(), output_port)
+    pub fn retain(&self, output_port: usize) -> Option<Capability<T>> where T: TotalOrder {
+        self.time().map(|time| self.delayed(time, output_port))
     }
 
     /// Transforms to an owned capability set for a specific output port, with one
@@ -336,18 +346,10 @@ impl<T: Timestamp> InputCapability<T> {
     }
 }
 
-impl<T: Timestamp> Deref for InputCapability<T> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        self.time()
-    }
-}
-
 impl<T: Timestamp> Debug for InputCapability<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("InputCapability")
-            .field("time", self.time())
+            .field("stamp", self.stamp())
             .field("internal", &"...")
             .finish()
     }

--- a/timely/src/dataflow/operators/core/concat.rs
+++ b/timely/src/dataflow/operators/core/concat.rs
@@ -78,8 +78,8 @@ impl<'scope, T: Timestamp> Concatenate<'scope, T> for Scope<'scope, T> {
             move |_frontier| {
                 let mut output = output.activate();
                 for handle in handles.iter_mut() {
-                    handle.for_each(|time, data| {
-                        output.give(&time, data);
+                    handle.for_each(|cap, data| {
+                        output.give(&cap, data);
                     })
                 }
             }

--- a/timely/src/dataflow/operators/core/exchange.rs
+++ b/timely/src/dataflow/operators/core/exchange.rs
@@ -45,8 +45,8 @@ where
     {
         self.unary(ExchangeCore::new(route), "Exchange", |_, _| {
             move |input, output| {
-                input.for_each_time(|time, data| {
-                    output.session(&time).give_containers(data);
+                input.for_each_stamp(|cap, data| {
+                    output.session(&cap).give_containers(data);
                 });
             }
         })

--- a/timely/src/dataflow/operators/core/feedback.rs
+++ b/timely/src/dataflow/operators/core/feedback.rs
@@ -50,17 +50,18 @@ pub trait LoopVariable<'scope, TOuter: Timestamp, TInner: Timestamp> {
     /// ```
     /// use timely::dataflow::Scope;
     /// use timely::dataflow::operators::{LoopVariable, ConnectLoop, ToStream, Concat, Inspect};
-    /// use timely::dataflow::operators::vec::BranchWhen;
+    /// use timely::dataflow::operators::vec::{Map, Filter};
     ///
     /// timely::example(|scope| {
-    ///     // circulate 0..10 for 100 iterations.
+    ///     // circulate 0..10, incrementing each, until each reaches 100.
     ///     scope.iterative::<usize,_,_>(|inner| {
     ///         let (handle, cycle) = inner.loop_variable(1);
     ///         (0..10).to_stream(inner)
     ///                .container::<Vec<_>>()
     ///                .concat(cycle)
     ///                .inspect(|x| println!("seen: {:?}", x))
-    ///                .branch_when(|t| t.inner < 100).1
+    ///                .map(|x| x + 1)
+    ///                .filter(|x| *x < 100)
     ///                .connect_loop(handle);
     ///     });
     /// });

--- a/timely/src/dataflow/operators/core/filter.rs
+++ b/timely/src/dataflow/operators/core/filter.rs
@@ -30,8 +30,8 @@ where
 {
     fn filter<P: FnMut(&C::Item<'_>)->bool+'static>(self, mut predicate: P) -> Self {
         self.unary(Pipeline, "Filter", move |_,_| move |input, output| {
-            input.for_each_time(|time, data| {
-                output.session(&time)
+            input.for_each_stamp(|cap, data| {
+                output.session(&cap)
                       .give_iterator(data.flat_map(|d| d.drain()).filter(&mut predicate));
             });
         })

--- a/timely/src/dataflow/operators/core/input.rs
+++ b/timely/src/dataflow/operators/core/input.rs
@@ -77,7 +77,7 @@ pub trait Input<'scope> {
     /// ```
     /// use std::rc::Rc;
     /// use timely::*;
-    /// use timely::dataflow::operators::{Input, InspectCore};
+    /// use timely::dataflow::operators::{Input, Inspect};
     /// use timely::container::CapacityContainerBuilder;
     ///
     /// // construct and execute a timely dataflow
@@ -86,7 +86,7 @@ pub trait Input<'scope> {
     ///     // add an input and base computation off of it
     ///     let mut input = worker.dataflow(|scope| {
     ///         let (input, stream) = scope.new_input_with_builder::<CapacityContainerBuilder<Rc<Vec<_>>>>();
-    ///         stream.inspect_container(|x| println!("hello {:?}", x));
+    ///         stream.inspect_core(|x| println!("hello {:?}", x));
     ///         input
     ///     });
     ///
@@ -422,7 +422,7 @@ impl<T: Timestamp, CB: ContainerBuilder<Container: Clone>> Handle<T, CB> {
     /// ```
     /// use timely::*;
     /// use timely::dataflow::InputHandle;
-    /// use timely::dataflow::operators::{Input, InspectCore};
+    /// use timely::dataflow::operators::{Input, Inspect};
     ///
     /// // construct and execute a timely dataflow
     /// timely::execute(Config::thread(), |worker| {
@@ -431,7 +431,7 @@ impl<T: Timestamp, CB: ContainerBuilder<Container: Clone>> Handle<T, CB> {
     ///     let mut input = InputHandle::new();
     ///     worker.dataflow(|scope| {
     ///         scope.input_from(&mut input)
-    ///              .inspect_container(|x| println!("hello {:?}", x));
+    ///              .inspect_core(|x| println!("hello {:?}", x));
     ///     });
     ///
     ///     // introduce input, advance computation

--- a/timely/src/dataflow/operators/core/inspect.rs
+++ b/timely/src/dataflow/operators/core/inspect.rs
@@ -1,7 +1,8 @@
 //! Extension trait and implementation for observing and action on streamed data.
 
 use crate::Container;
-use crate::progress::Timestamp;
+use crate::order::TotalOrder;
+use crate::progress::{Stamp, Timestamp};
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::Stream;
 use crate::dataflow::operators::generic::Operator;
@@ -27,10 +28,29 @@ where
     where
         F: for<'a> FnMut(<&'a C as IntoIterator>::Item) + 'static,
     {
-        self.inspect_batch(move |_, data| {
+        self.inspect_stamp(move |_, data| {
             for datum in data.into_iter() { func(datum); }
         })
     }
+
+    /// Runs a supplied closure on each observed container, with the stamp under which it travels.
+    ///
+    /// The stamp is the set of timestamps under which the container travels: a singleton unless
+    /// an upstream operator has stamped its messages with several times, or with none. This is
+    /// the batch-level inspection available for all timestamps; [`Inspect::inspect_batch`]
+    /// reveals a single time, and so exists only for totally ordered timestamps.
+    ///
+    /// # Examples
+    /// ```
+    /// use timely::dataflow::operators::{ToStream, Inspect};
+    ///
+    /// timely::example(|scope| {
+    ///     (0..10).to_stream(scope)
+    ///            .container::<Vec<_>>()
+    ///            .inspect_stamp(|stamp, xs| println!("seen under {:?}: {:?}", stamp, xs));
+    /// });
+    /// ```
+    fn inspect_stamp(self, func: impl FnMut(&Stamp<T>, &C)+'static) -> Self;
 
     /// Runs a supplied closure on each observed data element and associated time.
     ///
@@ -47,6 +67,7 @@ where
     fn inspect_time<F>(self, mut func: F) -> Self
     where
         F: for<'a> FnMut(&T, <&'a C as IntoIterator>::Item) + 'static,
+        T: TotalOrder,
     {
         self.inspect_batch(move |time, data| {
             for datum in data.into_iter() {
@@ -67,7 +88,7 @@ where
     ///            .inspect_batch(|t,xs| println!("seen at: {:?}\t{:?} records", t, xs.len()));
     /// });
     /// ```
-    fn inspect_batch(self, mut func: impl FnMut(&T, &C)+'static) -> Self {
+    fn inspect_batch(self, mut func: impl FnMut(&T, &C)+'static) -> Self where T: TotalOrder {
         self.inspect_core(move |event| {
             if let Ok((time, data)) = event {
                 func(time, data);
@@ -95,14 +116,26 @@ where
     ///             });
     /// });
     /// ```
-    fn inspect_core<F>(self, func: F) -> Self where F: FnMut(Result<(&T, &C), &[T]>)+'static;
+    fn inspect_core<F>(self, func: F) -> Self where F: FnMut(Result<(&T, &C), &[T]>)+'static, T: TotalOrder;
 }
 
 impl<T: Timestamp, C: Container> Inspect<T, C> for Stream<'_, T, C>
 where
     for<'a> &'a C: IntoIterator,
 {
-    fn inspect_core<F>(self, func: F) -> Self where F: FnMut(Result<(&T, &C), &[T]>) + 'static {
+    fn inspect_stamp(self, mut func: impl FnMut(&Stamp<T>, &C)+'static) -> Self {
+        self.unary(Pipeline, "Inspect", move |_,_| move |input, output| {
+            input.for_each_time(|time, data| {
+                let mut session = output.session(&time);
+                for data in data {
+                    func(time.stamp(), &*data);
+                    session.give_container(data);
+                }
+            });
+        })
+    }
+
+    fn inspect_core<F>(self, func: F) -> Self where F: FnMut(Result<(&T, &C), &[T]>) + 'static, T: TotalOrder {
         self.inspect_container(func)
     }
 }
@@ -129,13 +162,13 @@ pub trait InspectCore<T: Timestamp, C> {
     ///             });
     /// });
     /// ```
-    fn inspect_container<F>(self, func: F) -> Self where F: FnMut(Result<(&T, &C), &[T]>)+'static;
+    fn inspect_container<F>(self, func: F) -> Self where F: FnMut(Result<(&T, &C), &[T]>)+'static, T: TotalOrder;
 }
 
 impl<T: Timestamp, C: Container> InspectCore<T, C> for Stream<'_, T, C> {
 
     fn inspect_container<F>(self, mut func: F) -> Self
-        where F: FnMut(Result<(&T, &C), &[T]>)+'static
+        where F: FnMut(Result<(&T, &C), &[T]>)+'static, T: TotalOrder
     {
         let mut frontier = crate::progress::Antichain::from_elem(T::minimum());
         self.unary_frontier(Pipeline, "InspectBatch", move |_,_| move |(input, chain), output| {
@@ -147,7 +180,8 @@ impl<T: Timestamp, C: Container> InspectCore<T, C> for Stream<'_, T, C> {
             input.for_each_time(|time, data| {
                 let mut session = output.session(&time);
                 for data in data {
-                    func(Ok((&time, &*data)));
+                    // A message with no time is forwarded unobserved; there is no time to report.
+                    if let Some(t) = time.time() { func(Ok((t, &*data))); }
                     session.give_container(data);
                 }
             });

--- a/timely/src/dataflow/operators/core/inspect.rs
+++ b/timely/src/dataflow/operators/core/inspect.rs
@@ -1,18 +1,39 @@
 //! Extension trait and implementation for observing and action on streamed data.
 
 use crate::Container;
-use crate::order::TotalOrder;
 use crate::progress::{Stamp, Timestamp};
 use crate::dataflow::channels::pact::Pipeline;
 use crate::dataflow::Stream;
 use crate::dataflow::operators::generic::Operator;
 
-/// Methods to inspect records and batches of records on a stream.
-pub trait Inspect<T: Timestamp, C>: InspectCore<T, C> + Sized
-where
-    for<'a> &'a C: IntoIterator,
-{
-    /// Runs a supplied closure on each observed data element.
+/// Methods to inspect records and container and frontier events on a stream.
+pub trait Inspect<T: Timestamp, C>: Sized {
+    /// Runs a supplied closure on each observed container, and each frontier advancement.
+    ///
+    /// Rust's `Result` type is used to distinguish the events, with `Ok` for a container and
+    /// the stamp under which it travels, and `Err` for frontiers. Frontiers are only presented
+    /// when they change. The stamp is the set of timestamps under which the container travels:
+    /// a singleton unless an upstream operator has stamped its messages with several times, or
+    /// with none.
+    ///
+    /// # Examples
+    /// ```
+    /// use timely::dataflow::operators::{ToStream, Inspect};
+    ///
+    /// timely::example(|scope| {
+    ///     (0..10).to_stream(scope)
+    ///            .container::<Vec<_>>()
+    ///            .inspect_core(|event| {
+    ///                match event {
+    ///                    Ok((stamp, data)) => println!("seen under {:?}: {:?} records", stamp, data.len()),
+    ///                    Err(frontier) => println!("frontier advanced to {:?}", frontier),
+    ///                }
+    ///             });
+    /// });
+    /// ```
+    fn inspect_core<F>(self, func: F) -> Self where F: FnMut(Result<(&Stamp<T>, &C), &[T]>)+'static;
+
+    /// Runs a supplied closure on each observed record.
     ///
     /// # Examples
     /// ```
@@ -26,152 +47,21 @@ where
     /// ```
     fn inspect<F>(self, mut func: F) -> Self
     where
+        for<'a> &'a C: IntoIterator,
         F: for<'a> FnMut(<&'a C as IntoIterator>::Item) + 'static,
     {
-        self.inspect_stamp(move |_, data| {
-            for datum in data.into_iter() { func(datum); }
-        })
-    }
-
-    /// Runs a supplied closure on each observed container, with the stamp under which it travels.
-    ///
-    /// The stamp is the set of timestamps under which the container travels: a singleton unless
-    /// an upstream operator has stamped its messages with several times, or with none. This is
-    /// the batch-level inspection available for all timestamps; [`Inspect::inspect_batch`]
-    /// reveals a single time, and so exists only for totally ordered timestamps.
-    ///
-    /// # Examples
-    /// ```
-    /// use timely::dataflow::operators::{ToStream, Inspect};
-    ///
-    /// timely::example(|scope| {
-    ///     (0..10).to_stream(scope)
-    ///            .container::<Vec<_>>()
-    ///            .inspect_stamp(|stamp, xs| println!("seen under {:?}: {:?}", stamp, xs));
-    /// });
-    /// ```
-    fn inspect_stamp(self, func: impl FnMut(&Stamp<T>, &C)+'static) -> Self;
-
-    /// Runs a supplied closure on each observed data element and associated time.
-    ///
-    /// # Examples
-    /// ```
-    /// use timely::dataflow::operators::{ToStream, Inspect};
-    ///
-    /// timely::example(|scope| {
-    ///     (0..10).to_stream(scope)
-    ///            .container::<Vec<_>>()
-    ///            .inspect_time(|t, x| println!("seen at: {:?}\t{:?}", t, x));
-    /// });
-    /// ```
-    fn inspect_time<F>(self, mut func: F) -> Self
-    where
-        F: for<'a> FnMut(&T, <&'a C as IntoIterator>::Item) + 'static,
-        T: TotalOrder,
-    {
-        self.inspect_batch(move |time, data| {
-            for datum in data.into_iter() {
-                func(time, datum);
-            }
-        })
-    }
-
-    /// Runs a supplied closure on each observed data batch (time and data slice).
-    ///
-    /// # Examples
-    /// ```
-    /// use timely::dataflow::operators::{ToStream, Inspect};
-    ///
-    /// timely::example(|scope| {
-    ///     (0..10).to_stream(scope)
-    ///            .container::<Vec<_>>()
-    ///            .inspect_batch(|t,xs| println!("seen at: {:?}\t{:?} records", t, xs.len()));
-    /// });
-    /// ```
-    fn inspect_batch(self, mut func: impl FnMut(&T, &C)+'static) -> Self where T: TotalOrder {
         self.inspect_core(move |event| {
-            if let Ok((time, data)) = event {
-                func(time, data);
+            if let Ok((_, data)) = event {
+                for datum in data.into_iter() { func(datum); }
             }
         })
     }
-
-    /// Runs a supplied closure on each observed data batch, and each frontier advancement.
-    ///
-    /// Rust's `Result` type is used to distinguish the events, with `Ok` for time and data,
-    /// and `Err` for frontiers. Frontiers are only presented when they change.
-    ///
-    /// # Examples
-    /// ```
-    /// use timely::dataflow::operators::{ToStream, Inspect};
-    ///
-    /// timely::example(|scope| {
-    ///     (0..10).to_stream(scope)
-    ///            .container::<Vec<_>>()
-    ///            .inspect_core(|event| {
-    ///                match event {
-    ///                    Ok((time, data)) => println!("seen at: {:?}\t{:?} records", time, data.len()),
-    ///                    Err(frontier) => println!("frontier advanced to {:?}", frontier),
-    ///                }
-    ///             });
-    /// });
-    /// ```
-    fn inspect_core<F>(self, func: F) -> Self where F: FnMut(Result<(&T, &C), &[T]>)+'static, T: TotalOrder;
 }
 
-impl<T: Timestamp, C: Container> Inspect<T, C> for Stream<'_, T, C>
-where
-    for<'a> &'a C: IntoIterator,
-{
-    fn inspect_stamp(self, mut func: impl FnMut(&Stamp<T>, &C)+'static) -> Self {
-        self.unary(Pipeline, "Inspect", move |_,_| move |input, output| {
-            input.for_each_stamp(|cap, data| {
-                let mut session = output.session(&cap);
-                for data in data {
-                    func(cap.stamp(), &*data);
-                    session.give_container(data);
-                }
-            });
-        })
-    }
-
-    fn inspect_core<F>(self, func: F) -> Self where F: FnMut(Result<(&T, &C), &[T]>) + 'static, T: TotalOrder {
-        self.inspect_container(func)
-    }
-}
-
-/// Inspect containers
-pub trait InspectCore<T: Timestamp, C> {
-    /// Runs a supplied closure on each observed container, and each frontier advancement.
-    ///
-    /// Rust's `Result` type is used to distinguish the events, with `Ok` for time and data,
-    /// and `Err` for frontiers. Frontiers are only presented when they change.
-    ///
-    /// # Examples
-    /// ```
-    /// use timely::dataflow::operators::{ToStream, InspectCore};
-    ///
-    /// timely::example(|scope| {
-    ///     (0..10).to_stream(scope)
-    ///            .container::<Vec<_>>()
-    ///            .inspect_container(|event| {
-    ///                match event {
-    ///                    Ok((time, data)) => println!("seen at: {:?}\t{:?} records", time, data.len()),
-    ///                    Err(frontier) => println!("frontier advanced to {:?}", frontier),
-    ///                }
-    ///             });
-    /// });
-    /// ```
-    fn inspect_container<F>(self, func: F) -> Self where F: FnMut(Result<(&T, &C), &[T]>)+'static, T: TotalOrder;
-}
-
-impl<T: Timestamp, C: Container> InspectCore<T, C> for Stream<'_, T, C> {
-
-    fn inspect_container<F>(self, mut func: F) -> Self
-        where F: FnMut(Result<(&T, &C), &[T]>)+'static, T: TotalOrder
-    {
+impl<T: Timestamp, C: Container> Inspect<T, C> for Stream<'_, T, C> {
+    fn inspect_core<F>(self, mut func: F) -> Self where F: FnMut(Result<(&Stamp<T>, &C), &[T]>)+'static {
         let mut frontier = crate::progress::Antichain::from_elem(T::minimum());
-        self.unary_frontier(Pipeline, "InspectBatch", move |_,_| move |(input, chain), output| {
+        self.unary_frontier(Pipeline, "Inspect", move |_,_| move |(input, chain), output| {
             if chain.frontier() != frontier.borrow() {
                 frontier.clear();
                 frontier.extend(chain.frontier().iter().cloned());
@@ -180,8 +70,7 @@ impl<T: Timestamp, C: Container> InspectCore<T, C> for Stream<'_, T, C> {
             input.for_each_stamp(|cap, data| {
                 let mut session = output.session(&cap);
                 for data in data {
-                    // A message with no time is forwarded unobserved; there is no time to report.
-                    if let Some(t) = cap.least() { func(Ok((t, &*data))); }
+                    func(Ok((cap.stamp(), &*data)));
                     session.give_container(data);
                 }
             });

--- a/timely/src/dataflow/operators/core/inspect.rs
+++ b/timely/src/dataflow/operators/core/inspect.rs
@@ -125,10 +125,10 @@ where
 {
     fn inspect_stamp(self, mut func: impl FnMut(&Stamp<T>, &C)+'static) -> Self {
         self.unary(Pipeline, "Inspect", move |_,_| move |input, output| {
-            input.for_each_time(|time, data| {
-                let mut session = output.session(&time);
+            input.for_each_stamp(|cap, data| {
+                let mut session = output.session(&cap);
                 for data in data {
-                    func(time.stamp(), &*data);
+                    func(cap.stamp(), &*data);
                     session.give_container(data);
                 }
             });
@@ -177,11 +177,11 @@ impl<T: Timestamp, C: Container> InspectCore<T, C> for Stream<'_, T, C> {
                 frontier.extend(chain.frontier().iter().cloned());
                 func(Err(frontier.elements()));
             }
-            input.for_each_time(|time, data| {
-                let mut session = output.session(&time);
+            input.for_each_stamp(|cap, data| {
+                let mut session = output.session(&cap);
                 for data in data {
                     // A message with no time is forwarded unobserved; there is no time to report.
-                    if let Some(t) = time.time() { func(Ok((t, &*data))); }
+                    if let Some(t) = cap.least() { func(Ok((t, &*data))); }
                     session.give_container(data);
                 }
             });

--- a/timely/src/dataflow/operators/core/map.rs
+++ b/timely/src/dataflow/operators/core/map.rs
@@ -100,8 +100,8 @@ impl<'scope, T: Timestamp, C: Container + DrainContainer> Map<'scope, T, C> for 
         L: FnMut(C::Item<'_>)->I + 'static,
     {
         self.unary(Pipeline, "FlatMap", move |_,_| move |input, output| {
-            input.for_each_time(|time, data| {
-                output.session(&time)
+            input.for_each_stamp(|cap, data| {
+                output.session(&cap)
                       .give_iterator(data.flat_map(|d| d.drain()).flat_map(&mut logic));
             });
         })

--- a/timely/src/dataflow/operators/core/mod.rs
+++ b/timely/src/dataflow/operators/core/mod.rs
@@ -25,7 +25,7 @@ pub use exchange::Exchange;
 pub use feedback::{Feedback, LoopVariable, ConnectLoop};
 pub use filter::Filter;
 pub use input::Input;
-pub use inspect::{Inspect, InspectCore};
+pub use inspect::Inspect;
 pub use map::Map;
 pub use ok_err::OkErr;
 pub use partition::Partition;

--- a/timely/src/dataflow/operators/core/ok_err.rs
+++ b/timely/src/dataflow/operators/core/ok_err.rs
@@ -67,9 +67,9 @@ impl<'scope, T: Timestamp, C: Container + DrainContainer> OkErr<'scope, T, C> fo
                 let mut output1_handle = output1.activate();
                 let mut output2_handle = output2.activate();
 
-                input.for_each_time(|time, data| {
-                    let mut out1 = output1_handle.session(&time);
-                    let mut out2 = output2_handle.session(&time);
+                input.for_each_stamp(|cap, data| {
+                    let mut out1 = output1_handle.session(&cap);
+                    let mut out2 = output2_handle.session(&cap);
                     for datum in data.flat_map(|d| d.drain()) {
                         match logic(datum) {
                             Ok(datum) => out1.give(datum),

--- a/timely/src/dataflow/operators/core/partition.rs
+++ b/timely/src/dataflow/operators/core/partition.rs
@@ -60,7 +60,7 @@ impl<'scope, T: Timestamp, C: Container + DrainContainer> Partition<'scope, T, C
             move |_frontiers| {
                 let mut handles = outputs.iter_mut().map(|o| o.activate()).collect::<Vec<_>>();
                 let mut targets = BTreeMap::<u64,Vec<_>>::default();
-                input.for_each_time(|time, data| {
+                input.for_each_stamp(|cap, data| {
                     // Sort data by intended output.
                     for datum in data.flat_map(|d| d.drain()) {
                         let (part, datum) = route(datum);
@@ -71,11 +71,11 @@ impl<'scope, T: Timestamp, C: Container + DrainContainer> Partition<'scope, T, C
                         for datum in data.into_iter() {
                             c_build.push_into(datum);
                             while let Some(container) = c_build.extract() {
-                                handles[part as usize].give(&time, container);
+                                handles[part as usize].give(&cap, container);
                             }
                         }
                         while let Some(container) = c_build.finish() {
-                            handles[part as usize].give(&time, container);
+                            handles[part as usize].give(&cap, container);
                         }
                     }
                 });

--- a/timely/src/dataflow/operators/core/rc.rs
+++ b/timely/src/dataflow/operators/core/rc.rs
@@ -30,8 +30,8 @@ impl<'scope, T: Timestamp, C: Container> SharedStream<'scope, T, C> for Stream<'
     fn shared(self) -> Stream<'scope, T, Rc<C>> {
         self.unary(Pipeline, "Shared", move |_, _| {
             move |input, output| {
-                input.for_each_time(|time, data| {
-                    let mut session = output.session(&time);
+                input.for_each_stamp(|cap, data| {
+                    let mut session = output.session(&cap);
                     for data in data {
                         session.give_container(&mut Rc::new(std::mem::take(data)));
                     }
@@ -56,15 +56,15 @@ mod test {
                 .concatenate([
                     shared.clone().unary(Pipeline, "read shared 1", |_, _| {
                         move |input, output| {
-                            input.for_each_time(|time, data| {
-                                output.session(&time).give_iterator(data.map(|d| d.as_ptr() as usize));
+                            input.for_each_stamp(|cap, data| {
+                                output.session(&cap).give_iterator(data.map(|d| d.as_ptr() as usize));
                             });
                         }
                     }),
                     shared.unary(Pipeline, "read shared 2", |_, _| {
                         move |input, output| {
-                            input.for_each_time(|time, data| {
-                                output.session(&time).give_iterator(data.map(|d| d.as_ptr() as usize));
+                            input.for_each_stamp(|cap, data| {
+                                output.session(&cap).give_iterator(data.map(|d| d.as_ptr() as usize));
                             });
                         }
                     }),

--- a/timely/src/dataflow/operators/core/rc.rs
+++ b/timely/src/dataflow/operators/core/rc.rs
@@ -13,14 +13,14 @@ pub trait SharedStream<'scope, T: Timestamp, C> {
     ///
     /// # Examples
     /// ```
-    /// use timely::dataflow::operators::{ToStream, InspectCore};
+    /// use timely::dataflow::operators::{ToStream, Inspect};
     /// use timely::dataflow::operators::rc::SharedStream;
     ///
     /// timely::example(|scope| {
     ///     (0..10).to_stream(scope)
     ///            .container::<Vec<_>>()
     ///            .shared()
-    ///            .inspect_container(|x| println!("seen: {:?}", x));
+    ///            .inspect_core(|x| println!("seen: {:?}", x));
     /// });
     /// ```
     fn shared(self) -> Stream<'scope, T, Rc<C>>;

--- a/timely/src/dataflow/operators/core/reclock.rs
+++ b/timely/src/dataflow/operators/core/reclock.rs
@@ -56,10 +56,13 @@ impl<'scope, T: Timestamp, C: Container> Reclock<'scope, T> for Stream<'scope, T
 
         self.binary_notify(clock, Pipeline, Pipeline, "Reclock", vec![], move |input1, input2, output, notificator| {
 
-            // stash each data input with its stamp.
+            // stash each data input with its stamp; a message with no capabilities
+            // could never be released, and is discarded.
             input1.for_each_stamp(|cap, data| {
-                for data in data {
-                    stash.push((cap.stamp().clone(), std::mem::take(data)));
+                if !cap.stamp().is_empty() {
+                    for data in data {
+                        stash.push((cap.stamp().clone(), std::mem::take(data)));
+                    }
                 }
             });
 

--- a/timely/src/dataflow/operators/core/reclock.rs
+++ b/timely/src/dataflow/operators/core/reclock.rs
@@ -57,15 +57,15 @@ impl<'scope, T: Timestamp, C: Container> Reclock<'scope, T> for Stream<'scope, T
         self.binary_notify(clock, Pipeline, Pipeline, "Reclock", vec![], move |input1, input2, output, notificator| {
 
             // stash each data input with its stamp.
-            input1.for_each_time(|cap, data| {
+            input1.for_each_stamp(|cap, data| {
                 for data in data {
                     stash.push((cap.stamp().clone(), std::mem::take(data)));
                 }
             });
 
             // request notification at each clock time, to flush stash.
-            input2.for_each_time(|time, _data| {
-                for cap in time.retain_stamp(output.output_index()).iter() {
+            input2.for_each_stamp(|cap, _data| {
+                for cap in cap.retain_stamp(output.output_index()).iter() {
                     notificator.notify_at(cap.clone());
                 }
             });

--- a/timely/src/dataflow/operators/core/reclock.rs
+++ b/timely/src/dataflow/operators/core/reclock.rs
@@ -56,23 +56,26 @@ impl<'scope, T: Timestamp, C: Container> Reclock<'scope, T> for Stream<'scope, T
 
         self.binary_notify(clock, Pipeline, Pipeline, "Reclock", vec![], move |input1, input2, output, notificator| {
 
-            // stash each data input with its timestamp.
+            // stash each data input with its stamp.
             input1.for_each_time(|cap, data| {
                 for data in data {
-                    stash.push((cap.time().clone(), std::mem::take(data)));
+                    stash.push((cap.stamp().clone(), std::mem::take(data)));
                 }
             });
 
-            // request notification at time, to flush stash.
+            // request notification at each clock time, to flush stash.
             input2.for_each_time(|time, _data| {
-                notificator.notify_at(time.retain(output.output_index()));
+                for cap in time.retain_stamp(output.output_index()).iter() {
+                    notificator.notify_at(cap.clone());
+                }
             });
 
-            // each time with complete stash can be flushed.
+            // each time with complete stash can be flushed: data whose stamp has an
+            // element less or equal to the clock time may be sent at the clock time.
             notificator.for_each(|cap,_,_| {
                 let mut session = output.session(&cap);
-                for &mut (ref t, ref mut data) in &mut stash {
-                    if t.less_equal(cap.time()) {
+                for &mut (ref stamp, ref mut data) in &mut stash {
+                    if stamp.less_equal(cap.time()) {
                         session.give_container(data);
                     }
                 }

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -35,7 +35,8 @@ pub struct InputHandleCore<T: Timestamp, C, P: Pull<Message<T, C>>> {
 
 impl<T: Timestamp, C: Accountable, P: Pull<Message<T, C>>> InputHandleCore<T, C, P> {
     /// Reads the next input buffer (at some timestamp `t`) and a corresponding capability for `t`.
-    /// The timestamp `t` of the input buffer can be retrieved by invoking `.time()` on the capability.
+    /// The stamp of the input buffer can be retrieved by invoking `.stamp()` on the capability, and
+    /// for totally ordered timestamps its least time by `.time()`.
     /// Returns `None` when there's no more data available.
     #[inline]
     fn next(&mut self) -> Option<(InputCapability<T>, &mut C)> {

--- a/timely/src/dataflow/operators/generic/handles.rs
+++ b/timely/src/dataflow/operators/generic/handles.rs
@@ -36,7 +36,7 @@ pub struct InputHandleCore<T: Timestamp, C, P: Pull<Message<T, C>>> {
 impl<T: Timestamp, C: Accountable, P: Pull<Message<T, C>>> InputHandleCore<T, C, P> {
     /// Reads the next input buffer (at some timestamp `t`) and a corresponding capability for `t`.
     /// The stamp of the input buffer can be retrieved by invoking `.stamp()` on the capability, and
-    /// for totally ordered timestamps its least time by `.time()`.
+    /// for totally ordered timestamps its least time by `.least()`.
     /// Returns `None` when there's no more data available.
     #[inline]
     fn next(&mut self) -> Option<(InputCapability<T>, &mut C)> {
@@ -48,13 +48,16 @@ impl<T: Timestamp, C: Accountable, P: Pull<Message<T, C>>> InputHandleCore<T, C,
     }
     /// Iterates through pairs of capability and container.
     ///
-    /// The `for_each_time` method is equivalent, but groups containers by capability and is preferred,
-    /// in that it often leads to grouping work by capability, including the creation of output sessions.
+    /// The `for_each_stamp` method is equivalent, but groups containers by stamp and is preferred,
+    /// in that it often leads to grouping work by stamp, including the creation of output sessions.
     pub fn for_each<F>(&mut self, mut logic: F) where F: FnMut(InputCapability<T>, &mut C) {
         while let Some((cap, data)) = self.next() { logic(cap, data); }
     }
-    /// Iterates through distinct capabilities and the lists of containers associated with each.
-    pub fn for_each_time<F>(&mut self, mut logic: F) where F: FnMut(InputCapability<T>, std::slice::IterMut::<C>), C: Default {
+    /// Iterates through distinct stamps, each with a capability and the containers received under it.
+    ///
+    /// Containers are grouped by the stamp of their message, the set of timestamps under which
+    /// it travels; the capability covers exactly that stamp.
+    pub fn for_each_stamp<F>(&mut self, mut logic: F) where F: FnMut(InputCapability<T>, std::slice::IterMut::<C>), C: Default {
         while let Some((cap, data)) = self.next() {
             let data = std::mem::take(data);
             self.staging.push_back((cap, data));
@@ -69,6 +72,11 @@ impl<T: Timestamp, C: Accountable, P: Pull<Message<T, C>>> InputHandleCore<T, C,
             // Could return these back to the input ..
             self.staged.clear();
         }
+    }
+    /// Iterates through distinct stamps; renamed to [`for_each_stamp`](Self::for_each_stamp).
+    #[deprecated(note = "renamed to `for_each_stamp`: containers are grouped by stamp, not by a time")]
+    pub fn for_each_time<F>(&mut self, logic: F) where F: FnMut(InputCapability<T>, std::slice::IterMut::<C>), C: Default {
+        self.for_each_stamp(logic)
     }
 }
 

--- a/timely/src/dataflow/operators/generic/notificator.rs
+++ b/timely/src/dataflow/operators/generic/notificator.rs
@@ -58,8 +58,9 @@ impl<'a, T: Timestamp> Notificator<'a, T> {
     ///            .unary_notify(Pipeline, "example", Some(0), |input, output, notificator| {
     ///                input.for_each_time(|cap, data| {
     ///                    output.session(&cap).give_containers(data);
-    ///                    let time = cap.time().clone() + 1;
-    ///                    notificator.notify_at(cap.delayed(&time, output.output_index()));
+    ///                    if let Some(time) = cap.time().map(|t| t + 1) {
+    ///                        notificator.notify_at(cap.delayed(&time, output.output_index()));
+    ///                    }
     ///                });
     ///                notificator.for_each(|cap, count, _| {
     ///                    println!("done with time: {:?}, requested {} times", cap.time(), count);
@@ -194,12 +195,16 @@ fn notificator_delivers_notifications_in_topo_order() {
 ///             let mut stash = HashMap::new();
 ///             move |(input1, frontier1), (input2, frontier2), output| {
 ///                 input1.for_each_time(|time, data| {
-///                     stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.flat_map(|d| d.drain(..)));
-///                     notificator.notify_at(time.retain(output.output_index()));
+///                     if let Some(cap) = time.retain(output.output_index()) {
+///                         stash.entry(cap.time().clone()).or_insert(Vec::new()).extend(data.flat_map(|d| d.drain(..)));
+///                         notificator.notify_at(cap);
+///                     }
 ///                 });
 ///                 input2.for_each_time(|time, data| {
-///                     stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.flat_map(|d| d.drain(..)));
-///                     notificator.notify_at(time.retain(output.output_index()));
+///                     if let Some(cap) = time.retain(output.output_index()) {
+///                         stash.entry(cap.time().clone()).or_insert(Vec::new()).extend(data.flat_map(|d| d.drain(..)));
+///                         notificator.notify_at(cap);
+///                     }
 ///                 });
 ///                 notificator.for_each(&[frontier1, frontier2], |time, _| {
 ///                     if let Some(mut vec) = stash.remove(time.time()) {
@@ -268,8 +273,9 @@ impl<T: Timestamp> FrontierNotificator<T> {
     ///                move |(input, frontier), output| {
     ///                    input.for_each_time(|cap, data| {
     ///                        output.session(&cap).give_containers(data);
-    ///                        let time = cap.time().clone() + 1;
-    ///                        notificator.notify_at(cap.delayed(&time, output.output_index()));
+    ///                        if let Some(time) = cap.time().map(|t| t + 1) {
+    ///                            notificator.notify_at(cap.delayed(&time, output.output_index()));
+    ///                        }
     ///                    });
     ///                    notificator.for_each(&[frontier], |cap, _| {
     ///                        println!("done with time: {:?}", cap.time());
@@ -404,9 +410,10 @@ impl<T: Timestamp> FrontierNotificator<T> {
     ///                move |(input, frontier), output| {
     ///                    input.for_each_time(|cap, data| {
     ///                        output.session(&cap).give_containers(data);
-    ///                        let time = cap.time().clone() + 1;
-    ///                        notificator.notify_at(cap.delayed(&time, output.output_index()));
-    ///                        assert_eq!(notificator.pending().filter(|t| t.0.time() == &time).count(), 1);
+    ///                        if let Some(time) = cap.time().map(|t| t + 1) {
+    ///                            notificator.notify_at(cap.delayed(&time, output.output_index()));
+    ///                            assert_eq!(notificator.pending().filter(|t| t.0.time() == &time).count(), 1);
+    ///                        }
     ///                    });
     ///                    notificator.for_each(&[frontier], |cap, _| {
     ///                        println!("done with time: {:?}", cap.time());

--- a/timely/src/dataflow/operators/generic/notificator.rs
+++ b/timely/src/dataflow/operators/generic/notificator.rs
@@ -214,7 +214,7 @@ fn notificator_delivers_notifications_in_topo_order() {
 ///             }
 ///         })
 ///         .container::<Vec<_>>()
-///         .inspect_batch(|t, x| println!("{:?} -> {:?}", t, x));
+///         .inspect_core(|e| if let Ok((s, x)) = e { println!("{:?} -> {:?}", s, x) });
 ///
 ///         (in1_handle, in2_handle)
 ///     });

--- a/timely/src/dataflow/operators/generic/notificator.rs
+++ b/timely/src/dataflow/operators/generic/notificator.rs
@@ -56,14 +56,14 @@ impl<'a, T: Timestamp> Notificator<'a, T> {
     ///     (0..10).to_stream(scope)
     ///            .container::<Vec<_>>()
     ///            .unary_notify(Pipeline, "example", Some(0), |input, output, notificator| {
-    ///                input.for_each_time(|cap, data| {
+    ///                input.for_each_stamp(|cap, data| {
     ///                    output.session(&cap).give_containers(data);
-    ///                    if let Some(time) = cap.time().map(|t| t + 1) {
+    ///                    if let Some(time) = cap.least().map(|t| t + 1) {
     ///                        notificator.notify_at(cap.delayed(&time, output.output_index()));
     ///                    }
     ///                });
     ///                notificator.for_each(|cap, count, _| {
-    ///                    println!("done with time: {:?}, requested {} times", cap.time(), count);
+    ///                    println!("done with cap: {:?}, requested {} times", cap.time(), count);
     ///                    assert!(*cap.time() == 0 && count == 2 || count == 1);
     ///                });
     ///            });
@@ -194,21 +194,21 @@ fn notificator_delivers_notifications_in_topo_order() {
 ///             let mut notificator = FrontierNotificator::default();
 ///             let mut stash = HashMap::new();
 ///             move |(input1, frontier1), (input2, frontier2), output| {
-///                 input1.for_each_time(|time, data| {
-///                     if let Some(cap) = time.retain(output.output_index()) {
+///                 input1.for_each_stamp(|cap, data| {
+///                     if let Some(cap) = cap.retain_least(output.output_index()) {
 ///                         stash.entry(cap.time().clone()).or_insert(Vec::new()).extend(data.flat_map(|d| d.drain(..)));
 ///                         notificator.notify_at(cap);
 ///                     }
 ///                 });
-///                 input2.for_each_time(|time, data| {
-///                     if let Some(cap) = time.retain(output.output_index()) {
+///                 input2.for_each_stamp(|cap, data| {
+///                     if let Some(cap) = cap.retain_least(output.output_index()) {
 ///                         stash.entry(cap.time().clone()).or_insert(Vec::new()).extend(data.flat_map(|d| d.drain(..)));
 ///                         notificator.notify_at(cap);
 ///                     }
 ///                 });
-///                 notificator.for_each(&[frontier1, frontier2], |time, _| {
-///                     if let Some(mut vec) = stash.remove(time.time()) {
-///                         output.session(&time).give_iterator(vec.drain(..));
+///                 notificator.for_each(&[frontier1, frontier2], |cap, _| {
+///                     if let Some(mut vec) = stash.remove(cap.time()) {
+///                         output.session(&cap).give_iterator(vec.drain(..));
 ///                     }
 ///                 });
 ///             }
@@ -271,14 +271,14 @@ impl<T: Timestamp> FrontierNotificator<T> {
     ///            .unary_frontier(Pipeline, "example", |_, _| {
     ///                let mut notificator = FrontierNotificator::default();
     ///                move |(input, frontier), output| {
-    ///                    input.for_each_time(|cap, data| {
+    ///                    input.for_each_stamp(|cap, data| {
     ///                        output.session(&cap).give_containers(data);
-    ///                        if let Some(time) = cap.time().map(|t| t + 1) {
+    ///                        if let Some(time) = cap.least().map(|t| t + 1) {
     ///                            notificator.notify_at(cap.delayed(&time, output.output_index()));
     ///                        }
     ///                    });
     ///                    notificator.for_each(&[frontier], |cap, _| {
-    ///                        println!("done with time: {:?}", cap.time());
+    ///                        println!("done with cap: {:?}", cap.time());
     ///                    });
     ///                }
     ///            });
@@ -408,15 +408,15 @@ impl<T: Timestamp> FrontierNotificator<T> {
     ///            .unary_frontier(Pipeline, "example", |_, _| {
     ///                let mut notificator = FrontierNotificator::default();
     ///                move |(input, frontier), output| {
-    ///                    input.for_each_time(|cap, data| {
+    ///                    input.for_each_stamp(|cap, data| {
     ///                        output.session(&cap).give_containers(data);
-    ///                        if let Some(time) = cap.time().map(|t| t + 1) {
+    ///                        if let Some(time) = cap.least().map(|t| t + 1) {
     ///                            notificator.notify_at(cap.delayed(&time, output.output_index()));
     ///                            assert_eq!(notificator.pending().filter(|t| t.0.time() == &time).count(), 1);
     ///                        }
     ///                    });
     ///                    notificator.for_each(&[frontier], |cap, _| {
-    ///                        println!("done with time: {:?}", cap.time());
+    ///                        println!("done with cap: {:?}", cap.time());
     ///                    });
     ///                }
     ///            });

--- a/timely/src/dataflow/operators/generic/operator.rs
+++ b/timely/src/dataflow/operators/generic/operator.rs
@@ -42,9 +42,11 @@ pub trait Operator<'scope, T: Timestamp, C1> {
     ///                     output.session(&c).give(12);
     ///                 }
     ///                 input.for_each_time(|time, data| {
-    ///                     stash.entry(time.time().clone())
-    ///                          .or_insert(Vec::new())
-    ///                          .extend(data.flat_map(|d| d.drain(..)));
+    ///                     if let Some(t) = time.time() {
+    ///                         stash.entry(t.clone())
+    ///                              .or_insert(Vec::new())
+    ///                              .extend(data.flat_map(|d| d.drain(..)));
+    ///                     }
     ///                 });
     ///                 notificator.for_each(&[frontier], |time, _not| {
     ///                     if let Some(mut vec) = stash.remove(time.time()) {
@@ -82,7 +84,9 @@ pub trait Operator<'scope, T: Timestamp, C1> {
     ///         .unary_notify(Pipeline, "example", None, move |input, output, notificator| {
     ///             input.for_each_time(|time, data| {
     ///                 output.session(&time).give_containers(data);
-    ///                 notificator.notify_at(time.retain(output.output_index()));
+    ///                 if let Some(cap) = time.retain(output.output_index()) {
+    ///                     notificator.notify_at(cap);
+    ///                 }
     ///             });
     ///             notificator.for_each(|time, _cnt, _not| {
     ///                 println!("notified at {:?}", time);
@@ -153,12 +157,16 @@ pub trait Operator<'scope, T: Timestamp, C1> {
     ///            let mut stash = HashMap::new();
     ///            move |(input1, frontier1), (input2, frontier2), output| {
     ///                input1.for_each_time(|time, data| {
-    ///                    stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.flat_map(|d| d.drain(..)));
-    ///                    notificator.notify_at(time.retain(output.output_index()));
+    ///                    if let Some(cap) = time.retain(output.output_index()) {
+    ///                        stash.entry(cap.time().clone()).or_insert(Vec::new()).extend(data.flat_map(|d| d.drain(..)));
+    ///                        notificator.notify_at(cap);
+    ///                    }
     ///                });
     ///                input2.for_each_time(|time, data| {
-    ///                    stash.entry(time.time().clone()).or_insert(Vec::new()).extend(data.flat_map(|d| d.drain(..)));
-    ///                    notificator.notify_at(time.retain(output.output_index()));
+    ///                    if let Some(cap) = time.retain(output.output_index()) {
+    ///                        stash.entry(cap.time().clone()).or_insert(Vec::new()).extend(data.flat_map(|d| d.drain(..)));
+    ///                        notificator.notify_at(cap);
+    ///                    }
     ///                });
     ///                notificator.for_each(&[frontier1, frontier2], |time, _not| {
     ///                    if let Some(mut vec) = stash.remove(time.time()) {
@@ -211,11 +219,15 @@ pub trait Operator<'scope, T: Timestamp, C1> {
     ///        in1.binary_notify(in2, Pipeline, Pipeline, "example", None, move |input1, input2, output, notificator| {
     ///            input1.for_each_time(|time, data| {
     ///                output.session(&time).give_containers(data);
-    ///                notificator.notify_at(time.retain(output.output_index()));
+    ///                if let Some(cap) = time.retain(output.output_index()) {
+    ///                    notificator.notify_at(cap);
+    ///                }
     ///            });
     ///            input2.for_each_time(|time, data| {
     ///                output.session(&time).give_containers(data);
-    ///                notificator.notify_at(time.retain(output.output_index()));
+    ///                if let Some(cap) = time.retain(output.output_index()) {
+    ///                    notificator.notify_at(cap);
+    ///                }
     ///            });
     ///            notificator.for_each(|time, _cnt, _not| {
     ///                println!("notified at {:?}", time);

--- a/timely/src/dataflow/operators/generic/operator.rs
+++ b/timely/src/dataflow/operators/generic/operator.rs
@@ -176,7 +176,7 @@ pub trait Operator<'scope, T: Timestamp, C1> {
     ///            }
     ///        })
     ///        .container::<Vec<_>>()
-    ///        .inspect_batch(|t, x| println!("{:?} -> {:?}", t, x));
+    ///        .inspect_core(|e| if let Ok((s, x)) = e { println!("{:?} -> {:?}", s, x) });
     ///
     ///        (in1_handle, in2_handle)
     ///    });

--- a/timely/src/dataflow/operators/generic/operator.rs
+++ b/timely/src/dataflow/operators/generic/operator.rs
@@ -41,16 +41,16 @@ pub trait Operator<'scope, T: Timestamp, C1> {
     ///                 if let Some(ref c) = cap.take() {
     ///                     output.session(&c).give(12);
     ///                 }
-    ///                 input.for_each_time(|time, data| {
-    ///                     if let Some(t) = time.time() {
+    ///                 input.for_each_stamp(|cap, data| {
+    ///                     if let Some(t) = cap.least() {
     ///                         stash.entry(t.clone())
     ///                              .or_insert(Vec::new())
     ///                              .extend(data.flat_map(|d| d.drain(..)));
     ///                     }
     ///                 });
-    ///                 notificator.for_each(&[frontier], |time, _not| {
-    ///                     if let Some(mut vec) = stash.remove(time.time()) {
-    ///                         output.session(&time).give_iterator(vec.drain(..));
+    ///                 notificator.for_each(&[frontier], |cap, _not| {
+    ///                     if let Some(mut vec) = stash.remove(cap.time()) {
+    ///                         output.session(&cap).give_iterator(vec.drain(..));
     ///                     }
     ///                 });
     ///             }
@@ -82,14 +82,14 @@ pub trait Operator<'scope, T: Timestamp, C1> {
     ///         .to_stream(scope)
     ///         .container::<Vec<_>>()
     ///         .unary_notify(Pipeline, "example", None, move |input, output, notificator| {
-    ///             input.for_each_time(|time, data| {
-    ///                 output.session(&time).give_containers(data);
-    ///                 if let Some(cap) = time.retain(output.output_index()) {
+    ///             input.for_each_stamp(|cap, data| {
+    ///                 output.session(&cap).give_containers(data);
+    ///                 if let Some(cap) = cap.retain_least(output.output_index()) {
     ///                     notificator.notify_at(cap);
     ///                 }
     ///             });
-    ///             notificator.for_each(|time, _cnt, _not| {
-    ///                 println!("notified at {:?}", time);
+    ///             notificator.for_each(|cap, _cnt, _not| {
+    ///                 println!("notified at {:?}", cap);
     ///             });
     ///         });
     /// });
@@ -122,8 +122,8 @@ pub trait Operator<'scope, T: Timestamp, C1> {
     ///                 if let Some(ref c) = cap.take() {
     ///                     output.session(&c).give(100);
     ///                 }
-    ///                 input.for_each_time(|time, data| {
-    ///                     output.session(&time).give_containers(data);
+    ///                 input.for_each_stamp(|cap, data| {
+    ///                     output.session(&cap).give_containers(data);
     ///                 });
     ///             }
     ///         });
@@ -156,21 +156,21 @@ pub trait Operator<'scope, T: Timestamp, C1> {
     ///            let mut notificator = FrontierNotificator::default();
     ///            let mut stash = HashMap::new();
     ///            move |(input1, frontier1), (input2, frontier2), output| {
-    ///                input1.for_each_time(|time, data| {
-    ///                    if let Some(cap) = time.retain(output.output_index()) {
+    ///                input1.for_each_stamp(|cap, data| {
+    ///                    if let Some(cap) = cap.retain_least(output.output_index()) {
     ///                        stash.entry(cap.time().clone()).or_insert(Vec::new()).extend(data.flat_map(|d| d.drain(..)));
     ///                        notificator.notify_at(cap);
     ///                    }
     ///                });
-    ///                input2.for_each_time(|time, data| {
-    ///                    if let Some(cap) = time.retain(output.output_index()) {
+    ///                input2.for_each_stamp(|cap, data| {
+    ///                    if let Some(cap) = cap.retain_least(output.output_index()) {
     ///                        stash.entry(cap.time().clone()).or_insert(Vec::new()).extend(data.flat_map(|d| d.drain(..)));
     ///                        notificator.notify_at(cap);
     ///                    }
     ///                });
-    ///                notificator.for_each(&[frontier1, frontier2], |time, _not| {
-    ///                    if let Some(mut vec) = stash.remove(time.time()) {
-    ///                        output.session(&time).give_iterator(vec.drain(..));
+    ///                notificator.for_each(&[frontier1, frontier2], |cap, _not| {
+    ///                    if let Some(mut vec) = stash.remove(cap.time()) {
+    ///                        output.session(&cap).give_iterator(vec.drain(..));
     ///                    }
     ///                });
     ///            }
@@ -217,20 +217,20 @@ pub trait Operator<'scope, T: Timestamp, C1> {
     ///        let (in2_handle, in2) = scope.new_input::<Vec<_>>();
     ///
     ///        in1.binary_notify(in2, Pipeline, Pipeline, "example", None, move |input1, input2, output, notificator| {
-    ///            input1.for_each_time(|time, data| {
-    ///                output.session(&time).give_containers(data);
-    ///                if let Some(cap) = time.retain(output.output_index()) {
+    ///            input1.for_each_stamp(|cap, data| {
+    ///                output.session(&cap).give_containers(data);
+    ///                if let Some(cap) = cap.retain_least(output.output_index()) {
     ///                    notificator.notify_at(cap);
     ///                }
     ///            });
-    ///            input2.for_each_time(|time, data| {
-    ///                output.session(&time).give_containers(data);
-    ///                if let Some(cap) = time.retain(output.output_index()) {
+    ///            input2.for_each_stamp(|cap, data| {
+    ///                output.session(&cap).give_containers(data);
+    ///                if let Some(cap) = cap.retain_least(output.output_index()) {
     ///                    notificator.notify_at(cap);
     ///                }
     ///            });
-    ///            notificator.for_each(|time, _cnt, _not| {
-    ///                println!("notified at {:?}", time);
+    ///            notificator.for_each(|cap, _cnt, _not| {
+    ///                println!("notified at {:?}", cap);
     ///            });
     ///        });
     ///
@@ -276,8 +276,8 @@ pub trait Operator<'scope, T: Timestamp, C1> {
     ///                 if let Some(ref c) = cap.take() {
     ///                     output.session(&c).give(100);
     ///                 }
-    ///                 input1.for_each_time(|time, data| output.session(&time).give_containers(data));
-    ///                 input2.for_each_time(|time, data| output.session(&time).give_containers(data));
+    ///                 input1.for_each_stamp(|cap, data| output.session(&cap).give_containers(data));
+    ///                 input2.for_each_stamp(|cap, data| output.session(&cap).give_containers(data));
     ///             }
     ///         }).inspect(|x| println!("{:?}", x));
     /// });
@@ -309,9 +309,9 @@ pub trait Operator<'scope, T: Timestamp, C1> {
     ///         .to_stream(scope)
     ///         .container::<Vec<_>>()
     ///         .sink(Pipeline, "example", |(input, frontier)| {
-    ///             input.for_each_time(|time, data| {
+    ///             input.for_each_stamp(|cap, data| {
     ///                 for datum in data.flatten() {
-    ///                     println!("{:?}:\t{:?}", time, datum);
+    ///                     println!("{:?}:\t{:?}", cap, datum);
     ///                 }
     ///             });
     ///         });

--- a/timely/src/dataflow/operators/mod.rs
+++ b/timely/src/dataflow/operators/mod.rs
@@ -11,7 +11,7 @@
 //! operators whose behavior can be supplied using closures accepting input and output handles.
 //! Most of the operators in this module are defined using these two general operators.
 
-pub use self::inspect::{Inspect, InspectCore};
+pub use self::inspect::Inspect;
 pub use self::exchange::Exchange;
 
 pub use self::generic::Operator;

--- a/timely/src/dataflow/operators/vec/aggregation/aggregate.rs
+++ b/timely/src/dataflow/operators/vec/aggregation/aggregate.rs
@@ -3,6 +3,7 @@ use std::hash::Hash;
 use std::collections::HashMap;
 
 use crate::ExchangeData;
+use crate::order::TotalOrder;
 use crate::progress::Timestamp;
 use crate::dataflow::StreamVec;
 use crate::dataflow::operators::generic::operator::Operator;
@@ -69,7 +70,7 @@ pub trait Aggregate<'scope, T: Timestamp, K: ExchangeData+Hash, V: ExchangeData>
         hash: H) -> StreamVec<'scope, T, R> where T: Eq;
 }
 
-impl<'scope, T: Timestamp + Hash, K: ExchangeData+Clone+Hash+Eq, V: ExchangeData> Aggregate<'scope, T, K, V> for StreamVec<'scope, T, (K, V)> {
+impl<'scope, T: Timestamp + TotalOrder + Hash, K: ExchangeData+Clone+Hash+Eq, V: ExchangeData> Aggregate<'scope, T, K, V> for StreamVec<'scope, T, (K, V)> {
 
     fn aggregate<R: 'static, D: Default+'static, F: Fn(&K, V, &mut D)+'static, E: Fn(K, D)->R+'static, H: Fn(&K)->u64+'static>(
         self,
@@ -82,12 +83,15 @@ impl<'scope, T: Timestamp + Hash, K: ExchangeData+Clone+Hash+Eq, V: ExchangeData
 
             // read each input, fold into aggregates
             input.for_each_time(|time, data| {
-                let agg_time = aggregates.entry(time.time().clone()).or_insert_with(HashMap::new);
-                for (key, val) in data.flat_map(|d| d.drain(..)) {
-                    let agg = agg_time.entry(key.clone()).or_insert_with(Default::default);
-                    fold(&key, val, agg);
+                // A message with no time makes no progress claims, and has no time to aggregate at.
+                if let Some(cap) = time.retain(output.output_index()) {
+                    let agg_time = aggregates.entry(cap.time().clone()).or_insert_with(HashMap::new);
+                    for (key, val) in data.flat_map(|d| d.drain(..)) {
+                        let agg = agg_time.entry(key.clone()).or_insert_with(Default::default);
+                        fold(&key, val, agg);
+                    }
+                    notificator.notify_at(cap);
                 }
-                notificator.notify_at(time.retain(output.output_index()));
             });
 
             // pop completed aggregates, send along whatever

--- a/timely/src/dataflow/operators/vec/aggregation/aggregate.rs
+++ b/timely/src/dataflow/operators/vec/aggregation/aggregate.rs
@@ -82,9 +82,9 @@ impl<'scope, T: Timestamp + TotalOrder + Hash, K: ExchangeData+Clone+Hash+Eq, V:
         self.unary_notify(Exchange::new(move |(k, _)| hash(k)), "Aggregate", vec![], move |input, output, notificator| {
 
             // read each input, fold into aggregates
-            input.for_each_time(|time, data| {
+            input.for_each_stamp(|cap, data| {
                 // A message with no time makes no progress claims, and has no time to aggregate at.
-                if let Some(cap) = time.retain(output.output_index()) {
+                if let Some(cap) = cap.retain_least(output.output_index()) {
                     let agg_time = aggregates.entry(cap.time().clone()).or_insert_with(HashMap::new);
                     for (key, val) in data.flat_map(|d| d.drain(..)) {
                         let agg = agg_time.entry(key.clone()).or_insert_with(Default::default);
@@ -95,9 +95,9 @@ impl<'scope, T: Timestamp + TotalOrder + Hash, K: ExchangeData+Clone+Hash+Eq, V:
             });
 
             // pop completed aggregates, send along whatever
-            notificator.for_each(|time,_,_| {
-                if let Some(aggs) = aggregates.remove(time.time()) {
-                    let mut session = output.session(&time);
+            notificator.for_each(|cap,_,_| {
+                if let Some(aggs) = aggregates.remove(cap.time()) {
+                    let mut session = output.session(&cap);
                     for (key, agg) in aggs {
                         session.give(emit(key, agg));
                     }

--- a/timely/src/dataflow/operators/vec/aggregation/state_machine.rs
+++ b/timely/src/dataflow/operators/vec/aggregation/state_machine.rs
@@ -71,9 +71,9 @@ impl<'scope, T: Timestamp + TotalOrder, K: ExchangeData+Hash+Eq+Clone, V: Exchan
         self.unary_notify(Exchange::new(move |(k, _)| hash(k)), "StateMachine", vec![], move |input, output, notificator| {
 
             // go through each time with data, process each (key, val) pair.
-            notificator.for_each(|time,_,_| {
-                if let Some(pend) = pending.remove(time.time()) {
-                    let mut session = output.session(&time);
+            notificator.for_each(|cap,_,_| {
+                if let Some(pend) = pending.remove(cap.time()) {
+                    let mut session = output.session(&cap);
                     for (key, val) in pend {
                         let (remove, output) = {
                             let state = states.entry(key.clone()).or_insert_with(Default::default);
@@ -86,9 +86,9 @@ impl<'scope, T: Timestamp + TotalOrder, K: ExchangeData+Hash+Eq+Clone, V: Exchan
             });
 
             // stash each input and request a notification when ready
-            input.for_each_time(|time, data| {
+            input.for_each_stamp(|cap, data| {
                 // A message with no time makes no progress claims, and has no place in time order.
-                if let Some(cap) = time.retain(output.output_index()) {
+                if let Some(cap) = cap.retain_least(output.output_index()) {
                     // stash if not time yet
                     if notificator.frontier(0).less_than(cap.time()) {
                         for data in data { pending.entry(cap.time().clone()).or_insert_with(Vec::new).append(data); }

--- a/timely/src/dataflow/operators/vec/aggregation/state_machine.rs
+++ b/timely/src/dataflow/operators/vec/aggregation/state_machine.rs
@@ -3,6 +3,7 @@ use std::hash::Hash;
 use std::collections::HashMap;
 
 use crate::ExchangeData;
+use crate::order::TotalOrder;
 use crate::progress::Timestamp;
 use crate::dataflow::StreamVec;
 use crate::dataflow::operators::generic::operator::Operator;
@@ -55,7 +56,7 @@ pub trait StateMachine<'scope, T: Timestamp, K: ExchangeData+Hash+Eq, V: Exchang
     >(self, fold: F, hash: H) -> StreamVec<'scope, T, R> where T : Hash+Eq ;
 }
 
-impl<'scope, T: Timestamp, K: ExchangeData+Hash+Eq+Clone, V: ExchangeData> StateMachine<'scope, T, K, V> for StreamVec<'scope, T, (K, V)> {
+impl<'scope, T: Timestamp + TotalOrder, K: ExchangeData+Hash+Eq+Clone, V: ExchangeData> StateMachine<'scope, T, K, V> for StreamVec<'scope, T, (K, V)> {
     fn state_machine<
             R: 'static,                                 // output type
             D: Default+'static,                         // per-key state (data)
@@ -86,22 +87,24 @@ impl<'scope, T: Timestamp, K: ExchangeData+Hash+Eq+Clone, V: ExchangeData> State
 
             // stash each input and request a notification when ready
             input.for_each_time(|time, data| {
-
-                // stash if not time yet
-                if notificator.frontier(0).less_than(time.time()) {
-                    for data in data { pending.entry(time.time().clone()).or_insert_with(Vec::new).append(data); }
-                    notificator.notify_at(time.retain(output.output_index()));
-                }
-                else {
-                    // else we can process immediately
-                    let mut session = output.session(&time);
-                    for (key, val) in data.flat_map(|d| d.drain(..)) {
-                        let (remove, output) = {
-                            let state = states.entry(key.clone()).or_insert_with(Default::default);
-                            fold(&key, val, state)
-                        };
-                        if remove { states.remove(&key); }
-                        session.give_iterator(output.into_iter());
+                // A message with no time makes no progress claims, and has no place in time order.
+                if let Some(cap) = time.retain(output.output_index()) {
+                    // stash if not time yet
+                    if notificator.frontier(0).less_than(cap.time()) {
+                        for data in data { pending.entry(cap.time().clone()).or_insert_with(Vec::new).append(data); }
+                        notificator.notify_at(cap);
+                    }
+                    else {
+                        // else we can process immediately
+                        let mut session = output.session(&cap);
+                        for (key, val) in data.flat_map(|d| d.drain(..)) {
+                            let (remove, output) = {
+                                let state = states.entry(key.clone()).or_insert_with(Default::default);
+                                fold(&key, val, state)
+                            };
+                            if remove { states.remove(&key); }
+                            session.give_iterator(output.into_iter());
+                        }
                     }
                 }
             });

--- a/timely/src/dataflow/operators/vec/branch.rs
+++ b/timely/src/dataflow/operators/vec/branch.rs
@@ -51,11 +51,11 @@ impl<'scope, T: Timestamp + TotalOrder, D: 'static> Branch<T, D> for StreamVec<'
                 let mut output1_handle = output1.activate();
                 let mut output2_handle = output2.activate();
 
-                input.for_each_time(|time, data| {
+                input.for_each_stamp(|cap, data| {
                     // A message with no time makes no progress claims, and cannot be routed by time.
-                    if let Some(t) = time.time() {
-                        let mut out1 = output1_handle.session(&time);
-                        let mut out2 = output2_handle.session(&time);
+                    if let Some(t) = cap.least() {
+                        let mut out1 = output1_handle.session(&cap);
+                        let mut out2 = output2_handle.session(&cap);
                         for datum in data.flat_map(|d| d.drain(..)) {
                             if condition(t, &datum) {
                                 out2.give(datum);
@@ -120,12 +120,12 @@ impl<'scope, T: Timestamp + TotalOrder, C: Container> BranchWhen<T> for Stream<'
                 let mut output1_handle = output1.activate();
                 let mut output2_handle = output2.activate();
 
-                input.for_each_time(|time, data| {
-                    if let Some(t) = time.time() {
+                input.for_each_stamp(|cap, data| {
+                    if let Some(t) = cap.least() {
                         let mut out = if condition(t) {
-                            output2_handle.session(&time)
+                            output2_handle.session(&cap)
                         } else {
-                            output1_handle.session(&time)
+                            output1_handle.session(&cap)
                         };
                         out.give_containers(data);
                     }

--- a/timely/src/dataflow/operators/vec/branch.rs
+++ b/timely/src/dataflow/operators/vec/branch.rs
@@ -1,6 +1,7 @@
 //! Operators that separate one stream into two streams based on some condition
 
 use crate::dataflow::channels::pact::Pipeline;
+use crate::order::TotalOrder;
 use crate::progress::Timestamp;
 use crate::dataflow::operators::generic::OutputBuilder;
 use crate::dataflow::operators::generic::builder_rc::OperatorBuilder;
@@ -33,7 +34,7 @@ pub trait Branch<T: Timestamp, D> : Sized {
     fn branch(self, condition: impl Fn(&T, &D) -> bool + 'static) -> (Self, Self);
 }
 
-impl<'scope, T: Timestamp, D: 'static> Branch<T, D> for StreamVec<'scope, T, D> {
+impl<'scope, T: Timestamp + TotalOrder, D: 'static> Branch<T, D> for StreamVec<'scope, T, D> {
     fn branch(self, condition: impl Fn(&T, &D) -> bool + 'static) -> (Self, Self) {
         let mut builder = OperatorBuilder::new("Branch".to_owned(), self.scope());
 
@@ -51,13 +52,16 @@ impl<'scope, T: Timestamp, D: 'static> Branch<T, D> for StreamVec<'scope, T, D> 
                 let mut output2_handle = output2.activate();
 
                 input.for_each_time(|time, data| {
-                    let mut out1 = output1_handle.session(&time);
-                    let mut out2 = output2_handle.session(&time);
-                    for datum in data.flat_map(|d| d.drain(..)) {
-                        if condition(time.time(), &datum) {
-                            out2.give(datum);
-                        } else {
-                            out1.give(datum);
+                    // A message with no time makes no progress claims, and cannot be routed by time.
+                    if let Some(t) = time.time() {
+                        let mut out1 = output1_handle.session(&time);
+                        let mut out2 = output2_handle.session(&time);
+                        for datum in data.flat_map(|d| d.drain(..)) {
+                            if condition(t, &datum) {
+                                out2.give(datum);
+                            } else {
+                                out1.give(datum);
+                            }
                         }
                     }
                 });
@@ -74,6 +78,10 @@ pub trait BranchWhen<T>: Sized {
     /// For each time, the supplied closure is called. If it returns `true`,
     /// the records for that will be sent to the second returned stream, otherwise
     /// they will be sent to the first.
+    ///
+    /// The closure sees the least time of each message's stamp, and so this operator
+    /// exists only for totally ordered timestamps; deciding routing by the value of a
+    /// timestamp has no meaning for a message stamped by several incomparable times.
     ///
     /// # Examples
     /// ```
@@ -94,7 +102,7 @@ pub trait BranchWhen<T>: Sized {
     fn branch_when(self, condition: impl Fn(&T) -> bool + 'static) -> (Self, Self);
 }
 
-impl<'scope, T: Timestamp, C: Container> BranchWhen<T> for Stream<'scope, T, C> {
+impl<'scope, T: Timestamp + TotalOrder, C: Container> BranchWhen<T> for Stream<'scope, T, C> {
     fn branch_when(self, condition: impl Fn(&T) -> bool + 'static) -> (Self, Self) {
         let mut builder = OperatorBuilder::new("Branch".to_owned(), self.scope());
 
@@ -113,12 +121,14 @@ impl<'scope, T: Timestamp, C: Container> BranchWhen<T> for Stream<'scope, T, C> 
                 let mut output2_handle = output2.activate();
 
                 input.for_each_time(|time, data| {
-                    let mut out = if condition(time.time()) {
-                        output2_handle.session(&time)
-                    } else {
-                        output1_handle.session(&time)
-                    };
-                    out.give_containers(data);
+                    if let Some(t) = time.time() {
+                        let mut out = if condition(t) {
+                            output2_handle.session(&time)
+                        } else {
+                            output1_handle.session(&time)
+                        };
+                        out.give_containers(data);
+                    }
                 });
             }
         });

--- a/timely/src/dataflow/operators/vec/count.rs
+++ b/timely/src/dataflow/operators/vec/count.rs
@@ -54,9 +54,9 @@ impl<'scope, T: Timestamp + TotalOrder + ::std::hash::Hash, D: 'static> Accumula
 
         let mut accums = HashMap::new();
         self.unary_notify(Pipeline, "Accumulate", vec![], move |input, output, notificator| {
-            input.for_each_time(|time, data| {
+            input.for_each_stamp(|cap, data| {
                 // A message with no time makes no progress claims, and has no time to accumulate at.
-                if let Some(cap) = time.retain(output.output_index()) {
+                if let Some(cap) = cap.retain_least(output.output_index()) {
                     for data in data {
                         logic(accums.entry(cap.time().clone()).or_insert_with(|| default.clone()), data);
                     }
@@ -64,9 +64,9 @@ impl<'scope, T: Timestamp + TotalOrder + ::std::hash::Hash, D: 'static> Accumula
                 }
             });
 
-            notificator.for_each(|time,_,_| {
-                if let Some(accum) = accums.remove(&time) {
-                    output.session(&time).give(accum);
+            notificator.for_each(|cap,_,_| {
+                if let Some(accum) = accums.remove(cap.time()) {
+                    output.session(&cap).give(accum);
                 }
             });
         })

--- a/timely/src/dataflow/operators/vec/count.rs
+++ b/timely/src/dataflow/operators/vec/count.rs
@@ -2,6 +2,7 @@
 use std::collections::HashMap;
 
 use crate::dataflow::channels::pact::Pipeline;
+use crate::order::TotalOrder;
 use crate::progress::Timestamp;
 use crate::dataflow::StreamVec;
 use crate::dataflow::operators::generic::operator::Operator;
@@ -48,16 +49,19 @@ pub trait Accumulate<'scope, T: Timestamp, D: 'static> : Sized {
     fn count(self) -> StreamVec<'scope, T, usize> { self.accumulate(0, |sum, data| *sum += data.len()) }
 }
 
-impl<'scope, T: Timestamp + ::std::hash::Hash, D: 'static> Accumulate<'scope, T, D> for StreamVec<'scope, T, D> {
+impl<'scope, T: Timestamp + TotalOrder + ::std::hash::Hash, D: 'static> Accumulate<'scope, T, D> for StreamVec<'scope, T, D> {
     fn accumulate<A: Clone+'static>(self, default: A, logic: impl Fn(&mut A, &mut Vec<D>)+'static) -> StreamVec<'scope, T, A> {
 
         let mut accums = HashMap::new();
         self.unary_notify(Pipeline, "Accumulate", vec![], move |input, output, notificator| {
             input.for_each_time(|time, data| {
-                for data in data {
-                    logic(accums.entry(time.time().clone()).or_insert_with(|| default.clone()), data);
+                // A message with no time makes no progress claims, and has no time to accumulate at.
+                if let Some(cap) = time.retain(output.output_index()) {
+                    for data in data {
+                        logic(accums.entry(cap.time().clone()).or_insert_with(|| default.clone()), data);
+                    }
+                    notificator.notify_at(cap);
                 }
-                notificator.notify_at(time.retain(output.output_index()));
             });
 
             notificator.for_each(|time,_,_| {

--- a/timely/src/dataflow/operators/vec/delay.rs
+++ b/timely/src/dataflow/operators/vec/delay.rs
@@ -31,8 +31,8 @@ pub trait Delay<T: Timestamp, D: 'static> {
     ///     (0..10).to_stream(scope)
     ///            .delay(|data, time| *data)
     ///            .sink(Pipeline, "example", |(input, frontier)| {
-    ///                input.for_each_time(|time, data| {
-    ///                    println!("data at time: {:?}", time);
+    ///                input.for_each_stamp(|cap, data| {
+    ///                    println!("data at time: {:?}", cap);
     ///                });
     ///            });
     /// });
@@ -59,8 +59,8 @@ pub trait Delay<T: Timestamp, D: 'static> {
     ///     (0..10).to_stream(scope)
     ///            .delay(|data, time| *data)
     ///            .sink(Pipeline, "example", |(input, frontier)| {
-    ///                input.for_each_time(|time, data| {
-    ///                    println!("data at time: {:?}", time);
+    ///                input.for_each_stamp(|cap, data| {
+    ///                    println!("data at time: {:?}", cap);
     ///                });
     ///            });
     /// });
@@ -88,8 +88,8 @@ pub trait Delay<T: Timestamp, D: 'static> {
     ///     (0..10).to_stream(scope)
     ///            .delay_batch(|time| time + 1)
     ///            .sink(Pipeline, "example", |(input, frontier)| {
-    ///                input.for_each_time(|time, data| {
-    ///                    println!("data at time: {:?}", time);
+    ///                input.for_each_stamp(|cap, data| {
+    ///                    println!("data at time: {:?}", cap);
     ///                });
     ///            });
     /// });
@@ -101,23 +101,23 @@ impl<T: Timestamp + TotalOrder + ::std::hash::Hash, D: 'static> Delay<T, D> for 
     fn delay<L: FnMut(&D, &T)->T+'static>(self, mut func: L) -> Self {
         let mut elements = HashMap::new();
         self.unary_notify(Pipeline, "Delay", vec![], move |input, output, notificator| {
-            input.for_each_time(|time, data| {
+            input.for_each_stamp(|cap, data| {
                 // A message with no time makes no progress claims, and has no time to delay from.
-                if let Some(old_time) = time.time() {
+                if let Some(old_time) = cap.least() {
                     for datum in data.flat_map(|d| d.drain(..)) {
                         let new_time = func(&datum, old_time);
                         assert!(old_time.less_equal(&new_time));
                         elements.entry(new_time.clone())
-                                .or_insert_with(|| { notificator.notify_at(time.delayed(&new_time, output.output_index())); Vec::new() })
+                                .or_insert_with(|| { notificator.notify_at(cap.delayed(&new_time, output.output_index())); Vec::new() })
                                 .push(datum);
                     }
                 }
             });
 
             // for each available notification, send corresponding set
-            notificator.for_each(|time,_,_| {
-                if let Some(mut data) = elements.remove(&time) {
-                    output.session(&time).give_iterator(data.drain(..));
+            notificator.for_each(|cap,_,_| {
+                if let Some(mut data) = elements.remove(cap.time()) {
+                    output.session(&cap).give_iterator(data.drain(..));
                 }
             });
         })
@@ -132,21 +132,21 @@ impl<T: Timestamp + TotalOrder + ::std::hash::Hash, D: 'static> Delay<T, D> for 
     fn delay_batch<L: FnMut(&T)->T+'static>(self, mut func: L) -> Self {
         let mut elements = HashMap::new();
         self.unary_notify(Pipeline, "Delay", vec![], move |input, output, notificator| {
-            input.for_each_time(|time, data| {
-                if let Some(old_time) = time.time() {
+            input.for_each_stamp(|cap, data| {
+                if let Some(old_time) = cap.least() {
                     let new_time = func(old_time);
                     assert!(old_time.less_equal(&new_time));
                     elements.entry(new_time.clone())
-                            .or_insert_with(|| { notificator.notify_at(time.delayed(&new_time, output.output_index())); Vec::new() })
+                            .or_insert_with(|| { notificator.notify_at(cap.delayed(&new_time, output.output_index())); Vec::new() })
                             .extend(data.map(std::mem::take));
                 }
             });
 
             // for each available notification, send corresponding set
-            notificator.for_each(|time,_,_| {
-                if let Some(mut datas) = elements.remove(&time) {
+            notificator.for_each(|cap,_,_| {
+                if let Some(mut datas) = elements.remove(cap.time()) {
                     for mut data in datas.drain(..) {
-                        output.session(&time).give_container(&mut data);
+                        output.session(&cap).give_container(&mut data);
                     }
                 }
             });

--- a/timely/src/dataflow/operators/vec/delay.rs
+++ b/timely/src/dataflow/operators/vec/delay.rs
@@ -97,17 +97,20 @@ pub trait Delay<T: Timestamp, D: 'static> {
     fn delay_batch<L: FnMut(&T)->T+'static>(self, func: L) -> Self;
 }
 
-impl<T: Timestamp + ::std::hash::Hash, D: 'static> Delay<T, D> for StreamVec<'_, T, D> {
+impl<T: Timestamp + TotalOrder + ::std::hash::Hash, D: 'static> Delay<T, D> for StreamVec<'_, T, D> {
     fn delay<L: FnMut(&D, &T)->T+'static>(self, mut func: L) -> Self {
         let mut elements = HashMap::new();
         self.unary_notify(Pipeline, "Delay", vec![], move |input, output, notificator| {
             input.for_each_time(|time, data| {
-                for datum in data.flat_map(|d| d.drain(..)) {
-                    let new_time = func(&datum, &time);
-                    assert!(time.time().less_equal(&new_time));
-                    elements.entry(new_time.clone())
-                            .or_insert_with(|| { notificator.notify_at(time.delayed(&new_time, output.output_index())); Vec::new() })
-                            .push(datum);
+                // A message with no time makes no progress claims, and has no time to delay from.
+                if let Some(old_time) = time.time() {
+                    for datum in data.flat_map(|d| d.drain(..)) {
+                        let new_time = func(&datum, old_time);
+                        assert!(old_time.less_equal(&new_time));
+                        elements.entry(new_time.clone())
+                                .or_insert_with(|| { notificator.notify_at(time.delayed(&new_time, output.output_index())); Vec::new() })
+                                .push(datum);
+                    }
                 }
             });
 
@@ -130,11 +133,13 @@ impl<T: Timestamp + ::std::hash::Hash, D: 'static> Delay<T, D> for StreamVec<'_,
         let mut elements = HashMap::new();
         self.unary_notify(Pipeline, "Delay", vec![], move |input, output, notificator| {
             input.for_each_time(|time, data| {
-                let new_time = func(&time);
-                assert!(time.time().less_equal(&new_time));
-                elements.entry(new_time.clone())
-                        .or_insert_with(|| { notificator.notify_at(time.delayed(&new_time, output.output_index())); Vec::new() })
-                        .extend(data.map(std::mem::take));
+                if let Some(old_time) = time.time() {
+                    let new_time = func(old_time);
+                    assert!(old_time.less_equal(&new_time));
+                    elements.entry(new_time.clone())
+                            .or_insert_with(|| { notificator.notify_at(time.delayed(&new_time, output.output_index())); Vec::new() })
+                            .extend(data.map(std::mem::take));
+                }
             });
 
             // for each available notification, send corresponding set

--- a/timely/src/dataflow/operators/vec/filter.rs
+++ b/timely/src/dataflow/operators/vec/filter.rs
@@ -26,8 +26,8 @@ pub trait Filter<D> {
 impl<T: Timestamp, D: 'static> Filter<D> for StreamVec<'_, T, D> {
     fn filter<P: FnMut(&D)->bool+'static>(self, mut predicate: P) -> Self {
         self.unary(Pipeline, "Filter", move |_,_| move |input, output| {
-            input.for_each_time(|time, data| {
-                let mut session = output.session(&time);
+            input.for_each_stamp(|cap, data| {
+                let mut session = output.session(&cap);
                 for data in data {
                     data.retain(&mut predicate);
                     session.give_container(data);

--- a/timely/src/dataflow/operators/vec/flow_controlled.rs
+++ b/timely/src/dataflow/operators/vec/flow_controlled.rs
@@ -63,7 +63,7 @@ pub struct IteratorSourceInput<T: Clone, D: 'static, DI: IntoIterator<Item=D>, I
 ///                 }
 ///             },
 ///             probe_handle_2)
-///         .inspect_time(|t, d| eprintln!("@ {:?}: {:?}", t, d))
+///         .inspect(|d| eprintln!("{:?}", d))
 ///         .probe_with(&mut probe_handle);
 ///     });
 /// }).unwrap();

--- a/timely/src/dataflow/operators/vec/map.rs
+++ b/timely/src/dataflow/operators/vec/map.rs
@@ -54,8 +54,8 @@ pub trait Map<'scope, T: Timestamp, D: 'static> : Sized {
 impl<'scope, T: Timestamp, D: 'static> Map<'scope, T, D> for StreamVec<'scope, T, D> {
     fn map_in_place<L: FnMut(&mut D)+'static>(self, mut logic: L) -> StreamVec<'scope, T, D> {
         self.unary(Pipeline, "MapInPlace", move |_,_| move |input, output| {
-            input.for_each_time(|time, data| {
-                let mut session = output.session(&time);
+            input.for_each_stamp(|cap, data| {
+                let mut session = output.session(&cap);
                 for data in data {
                     for datum in data.iter_mut() { logic(datum); }
                     session.give_container(data);

--- a/timely/src/progress/stamp.rs
+++ b/timely/src/progress/stamp.rs
@@ -23,7 +23,7 @@
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-use crate::order::PartialOrder;
+use crate::order::{PartialOrder, TotalOrder};
 
 /// A multiset of timestamps affixed to a message, stored sorted.
 ///
@@ -96,6 +96,18 @@ impl<T> Stamp<T> {
         self.as_singleton().unwrap_or_else(|| {
             panic!("expected a singleton stamp; found {:?} elements: {:?}", self.elements.len(), self.elements())
         })
+    }
+}
+
+impl<T: TotalOrder> Stamp<T> {
+    /// The least element of the stamp, if the stamp is non-empty.
+    ///
+    /// Only totally ordered stamps have a least element. A non-empty stamp over a
+    /// total order has one however many elements it contains, and it is the time
+    /// at which the message may first result in downstream work.
+    #[inline]
+    pub fn least(&self) -> Option<&T> {
+        self.elements.iter().reduce(|a, b| if b.less_equal(a) { b } else { a })
     }
 }
 

--- a/timely/src/progress/stamp.rs
+++ b/timely/src/progress/stamp.rs
@@ -105,6 +105,9 @@ impl<T: TotalOrder> Stamp<T> {
     /// Only totally ordered stamps have a least element. A non-empty stamp over a
     /// total order has one however many elements it contains, and it is the time
     /// at which the message may first result in downstream work.
+    ///
+    /// Elements are stored in `Ord` order, but `TotalOrder` speaks only of `PartialOrder`
+    /// and need not agree with `Ord`, so this is a reduction rather than `first()`.
     #[inline]
     pub fn least(&self) -> Option<&T> {
         self.elements.iter().reduce(|a, b| if b.less_equal(a) { b } else { a })

--- a/timely/src/synchronization/sequence.rs
+++ b/timely/src/synchronization/sequence.rs
@@ -174,9 +174,9 @@ impl<T: ExchangeData+Clone> Sequencer<T> {
                 move |(input, frontier)| {
 
                     // grab each command and queue it up
-                    input.for_each_time(|time, data| {
+                    input.for_each_stamp(|cap, data| {
                         // A message with no time makes no progress claims, and has no place in the sequence.
-                        if let Some(&time) = time.time() {
+                        if let Some(&time) = cap.least() {
                             for (worker, counter, element) in data.flat_map(|d| d.drain(..)) {
                                 recvd.push(((time, worker, counter), element));
                             }

--- a/timely/src/synchronization/sequence.rs
+++ b/timely/src/synchronization/sequence.rs
@@ -175,8 +175,11 @@ impl<T: ExchangeData+Clone> Sequencer<T> {
 
                     // grab each command and queue it up
                     input.for_each_time(|time, data| {
-                        for (worker, counter, element) in data.flat_map(|d| d.drain(..)) {
-                            recvd.push(((*time.time(), worker, counter), element));
+                        // A message with no time makes no progress claims, and has no place in the sequence.
+                        if let Some(&time) = time.time() {
+                            for (worker, counter, element) in data.flat_map(|d| d.drain(..)) {
+                                recvd.push(((time, worker, counter), element));
+                            }
                         }
                     });
 

--- a/timely/tests/gh_523.rs
+++ b/timely/tests/gh_523.rs
@@ -13,7 +13,7 @@ fn gh_523() {
                 .container::<Vec<_>>()
                 .unary(Pipeline, "Test", move |_, _| {
                     move |input, output| {
-                        input.for_each_time(|cap, data| {
+                        input.for_each_stamp(|cap, data| {
                             let mut session = output.session(&cap);
                             for data in data {
                                 session.give_container(&mut Vec::new());

--- a/timely/tests/shape_scaling.rs
+++ b/timely/tests/shape_scaling.rs
@@ -36,8 +36,8 @@ fn operator_scaling(scale: u64) {
                 move |_frontiers| {
                     for (input, output) in handles.iter_mut() {
                         let mut output = output.activate();
-                        input.for_each(|time, data| {
-                            output.give(&time, data);
+                        input.for_each(|cap, data| {
+                            output.give(&cap, data);
                         });
                     }
                 }


### PR DESCRIPTION
Since #813 a message's stamp is a multiset of timestamps, and `InputCapability::time()` panicked unless the stamp was a singleton. This turns that runtime failure into a compile-time one.

**The change.** `InputCapability::time()` is replaced by `least()`, which exists only for `T: TotalOrder`, where every non-empty stamp has a least element, and returns `Option<&T>`: the least element, or `None` exactly when the message was stamped by no capabilities (it makes no progress claims). `retain(port)` is replaced by `retain_least(port)`, returning `Option<Capability<T>>` likewise, and the `Deref` to `T` is gone. Partially ordered timestamps must read `stamp()` and forward its elements with `retain_stamp()`, which is unchanged. `Stamp::least()` is the underlying accessor. The names say what is computed, and no existing `time()` or `retain()` call site silently inherits new behavior: each one fails to compile and is pointed at `least`, `retain_least`, or `retain_stamp`.

An operator that needs a time asks for it with an `if let`, and a message with no capabilities is dropped. That is a decision, not an accident: such a message makes no progress claims and may arrive after the frontier has passed every time in its contents, so an operator whose work is keyed by time has nothing to do with it.

```rust
input.for_each_stamp(|cap, data| {
    if let Some(cap) = cap.retain_least(output.output_index()) {
        stash.entry(cap.time().clone()).or_default().extend(...);
        notificator.notify_at(cap);
    }
});
```

**Operators.** Those whose logic reads one time from the capability are bounded by `TotalOrder` and use the idiom: `count`/`accumulate`, `aggregate`, `state_machine`, `delay`, `delay_batch`, `branch`, and `branch_when`. For total orders they behave exactly as before; for partial orders they no longer compile, which is deliberate: they use the capability as a stand-in for a time the records do not carry, and there is no correct generalization of that to a message stamped by several times. (An earlier draft keyed their stashes by stamp and flushed once every element completed; that stalls in a loop whenever a pointwise boundary map produces comparable elements, so it was dropped.) The bound is the static property "at most one meaningful time"; it makes holding capabilities sound, and does not give these operators meaning for a multi-element stamp. They have no users in differential-dataflow or Materialize and will be removed in a follow-up PR.

**Inspect** is one trait with two methods, neither bounded: `inspect_core` observes every container with its stamp and every frontier change, and `inspect` observes records. `inspect_batch`, `inspect_time`, `inspect_container`, and the `InspectCore` trait are removed; each revealed one time, and each is a map inside `inspect_core`. `reclock` is rewritten to stash by stamp and notify at each clock element, releasing data once some element of its stamp is at or before the clock time; a message with no capabilities could never be released and is discarded. It needs no bound. The book is updated to the new names.

**Rename.** `for_each_time` is now `for_each_stamp`: containers are grouped by the stamp of their message, not by a time, and the closure receives a capability for that stamp. Closure arguments named `time` are renamed `cap` throughout the docs and examples; they were never a time. `for_each_time` remains as a deprecated alias.

**Breaking changes.** `InputCapability::time()` and `retain()` are removed in favour of `least()` and `retain_least()`, with a `TotalOrder` bound and `Option` results; `Deref for InputCapability` is removed, so implicit uses (`*cap`, `cap.less_equal(..)`) become explicit; the operators above gain a `TotalOrder` bound; `Debug for InputCapability` prints the stamp. Examples and doctests are adapted; the `loop_variable` doctest terminates by data rather than by `branch_when`, which now needs a total order.

**Verification.** All unit, integration, and 155 doctests pass. A differential-dataflow adaptation (eight files: capture, upsert, half_join, `Collection::delay` reimplemented without `delay_batch`, diagnostics, two tests) builds and passes its workspace tests against this branch and will follow as its own PR once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012k2GSwxmvD2LvckkoXi6GK




